### PR TITLE
issue-137: Refactor KirbyAM address schema into transport/native RAM maps

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -122,9 +122,13 @@ class KirbyAmClient(BizHawkClient):
     def _u32_le(b: bytes) -> int:
         return int.from_bytes(b, "little")
 
+    @staticmethod
+    def _transport_addr(key: str) -> Optional[int]:
+        return data.transport_ram_addresses.get(key) or data.ram_addresses.get(key)
+
     async def _persist_u32(self, ctx: "BizHawkClientContext", key: str, value: int) -> None:
         """Persist a 32-bit value to RAM by address key."""
-        addr = data.ram_addresses.get(key)
+        addr = self._transport_addr(key)
         if addr is None:
             return
         await bizhawk.write(ctx.bizhawk_ctx, [(addr, int(value & 0xFFFFFFFF).to_bytes(4, "little"), "System Bus")])
@@ -142,7 +146,7 @@ class KirbyAmClient(BizHawkClient):
         # - sim_last_frame
         # - sim_next_index  (we will treat this as "simulated next location index cursor")
         for key in ("delivered_item_index", "sim_last_frame", "sim_next_index"):
-            addr = data.ram_addresses.get(key)
+            addr = self._transport_addr(key)
             if addr is not None:
                 reads.append((addr, 4, "System Bus"))
                 keys_in_order.append(key)
@@ -184,7 +188,7 @@ class KirbyAmClient(BizHawkClient):
         if not self._all_location_ids_sorted:
             return
 
-        frame_addr = data.ram_addresses.get("frame_counter")
+        frame_addr = self._transport_addr("frame_counter")
         if frame_addr is None:
             current_frame = (self._last_simulated_frame + 1) & 0xFFFFFFFF
         else:
@@ -227,7 +231,9 @@ class KirbyAmClient(BizHawkClient):
         - New bits tracked in _checked_location_bits
         - Sends LocationChecks for all newly set bits
         """
-        shard_addr = data.ram_addresses["shard_bitfield"]
+        shard_addr = self._transport_addr("shard_bitfield")
+        if shard_addr is None:
+            return
         raw = (await bizhawk.read(ctx.bizhawk_ctx, [(shard_addr, 4, "System Bus")]))[0]
         shard_bits = self._u32_le(raw)
 
@@ -262,9 +268,11 @@ class KirbyAmClient(BizHawkClient):
         - If flag=0 and items available: write next item (set flag -> 1)
         - Otherwise: wait
         """
-        flag_addr = data.ram_addresses["incoming_item_flag"]
-        id_addr = data.ram_addresses["incoming_item_id"]
-        player_addr = data.ram_addresses["incoming_item_player"]
+        flag_addr = self._transport_addr("incoming_item_flag")
+        id_addr = self._transport_addr("incoming_item_id")
+        player_addr = self._transport_addr("incoming_item_player")
+        if flag_addr is None or id_addr is None or player_addr is None:
+            return
 
         raw_flag = (await bizhawk.read(ctx.bizhawk_ctx, [(flag_addr, 4, "System Bus")]))[0]
         flag = self._u32_le(raw_flag)

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -180,6 +180,8 @@ class KirbyAmData:
     Central loaded data container.
     """
     ram_addresses: dict[str, int]
+    transport_ram_addresses: dict[str, int]
+    native_ram_addresses: dict[str, int]
     rom_addresses: dict[str, int]
 
     regions: dict[str, RegionData]
@@ -191,6 +193,8 @@ class KirbyAmData:
 
     def __init__(self) -> None:
         self.ram_addresses = {}
+        self.transport_ram_addresses = {}
+        self.native_ram_addresses = {}
         self.rom_addresses = {}
         self.regions = {}
         self.locations = {}
@@ -213,14 +217,36 @@ def _classification_from_string(s: str) -> ItemClassification:
 
 
 def _init() -> None:
-    # Optional addresses.json (recommended; this is where your shard bitfield belongs)
+    # Optional addresses.json.
+    # Supports both old flat schema:
+    #   {"ram": {"key": "0x..."}, "rom": {...}}
+    # and new grouped schema:
+    #   {"ram": {"transport": {...}, "native": {...}}, "rom": {...}}
     addresses_json = _maybe_load_json_data("addresses.json")
     if isinstance(addresses_json, dict):
         ram = addresses_json.get("ram", {})
         rom = addresses_json.get("rom", {})
+
+        def _load_addr_map(src: dict[str, Any], dst: dict[str, int]) -> None:
+            for k, v in src.items():
+                dst[k] = _parse_int(v)
+
         if isinstance(ram, dict):
-            for k, v in ram.items():
-                data.ram_addresses[k] = _parse_int(v)
+            transport = ram.get("transport")
+            native = ram.get("native")
+            if isinstance(transport, dict) or isinstance(native, dict):
+                if isinstance(transport, dict):
+                    _load_addr_map(transport, data.transport_ram_addresses)
+                if isinstance(native, dict):
+                    _load_addr_map(native, data.native_ram_addresses)
+            else:
+                # Backward compatibility with flat ram schema.
+                _load_addr_map(ram, data.transport_ram_addresses)
+
+            # Preserve legacy access path while introducing grouped maps.
+            data.ram_addresses.update(data.transport_ram_addresses)
+            data.ram_addresses.update(data.native_ram_addresses)
+
         if isinstance(rom, dict):
             for k, v in rom.items():
                 data.rom_addresses[k] = _parse_int(v)

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -1,16 +1,21 @@
 {
   "ram": {
-    "shard_bitfield": "0x0202C000",
-    "incoming_item_flag": "0x0202C004",
-    "incoming_item_id": "0x0202C008",
-    "incoming_item_player": "0x0202C00C",
-    "debug_item_counter": "0x0202C010",
-    "debug_last_item_id": "0x0202C014",
-    "debug_last_from": "0x0202C018",
-    "frame_counter": "0x0202C01C",
-    "delivered_item_index": "0x0202C020",
-    "sim_last_frame": "0x0202C024",
-    "sim_next_index": "0x0202C028"
+    "transport": {
+      "shard_bitfield": "0x0202C000",
+      "incoming_item_flag": "0x0202C004",
+      "incoming_item_id": "0x0202C008",
+      "incoming_item_player": "0x0202C00C",
+      "debug_item_counter": "0x0202C010",
+      "debug_last_item_id": "0x0202C014",
+      "debug_last_from": "0x0202C018",
+      "frame_counter": "0x0202C01C",
+      "delivered_item_index": "0x0202C020",
+      "sim_last_frame": "0x0202C024",
+      "sim_next_index": "0x0202C028"
+    },
+    "native": {
+      "shard_bitfield_native": "0x02038970"
+    }
   },
   "rom": {
     "gArchipelagoInfo": "0x08F00000"

--- a/worlds/kirbyam/tools/validate_addresses.py
+++ b/worlds/kirbyam/tools/validate_addresses.py
@@ -31,6 +31,7 @@ class AddressValidator:
         self.addresses_file = repo_root / "data" / "addresses.json"
         self.client_file = repo_root / "client.py"
         self.addresses: Dict[str, Dict[str, str]] = {}
+        self.grouped_ram_sections: Dict[str, Dict[str, str]] = {}
         self.client_code: str = ""
         
     def load_addresses(self) -> bool:
@@ -39,7 +40,26 @@ class AddressValidator:
             with open(self.addresses_file) as f:
                 data = json.load(f)
                 self.addresses = data
-                print(f"✓ Loaded {sum(len(v) for v in self.addresses.values())} addresses")
+                ram = self.addresses.get("ram", {}) if isinstance(self.addresses, dict) else {}
+                if isinstance(ram, dict):
+                    transport = ram.get("transport")
+                    native = ram.get("native")
+                    if isinstance(transport, dict) or isinstance(native, dict):
+                        self.grouped_ram_sections = {
+                            "ram.transport": transport if isinstance(transport, dict) else {},
+                            "ram.native": native if isinstance(native, dict) else {},
+                        }
+                    else:
+                        self.grouped_ram_sections = {"ram": ram}
+
+                total = 0
+                for section in self.grouped_ram_sections.values():
+                    total += len(section)
+                rom = self.addresses.get("rom", {}) if isinstance(self.addresses, dict) else {}
+                if isinstance(rom, dict):
+                    total += len(rom)
+
+                print(f"✓ Loaded {total} addresses")
                 return True
         except Exception as e:
             print(f"✗ Failed to load addresses: {e}")
@@ -59,19 +79,33 @@ class AddressValidator:
     def validate_usage(self) -> List[str]:
         """Check that addresses are used in client code."""
         issues = []
+        informational_unused = {
+            "debug_item_counter",
+            "debug_last_item_id",
+            "debug_last_from",
+        }
         
         print("\n--- Address Usage Validation ---")
         
-        for section, addrs in self.addresses.items():
+        sections: Dict[str, Dict[str, str]] = {}
+        sections.update(self.grouped_ram_sections)
+        rom = self.addresses.get("rom", {}) if isinstance(self.addresses, dict) else {}
+        if isinstance(rom, dict):
+            sections["rom"] = rom
+
+        for section, addrs in sections.items():
             print(f"\n{section}:")
             for name, addr in addrs.items():
                 # Search for address key usage in client
                 if f'"{name}"' in self.client_code or f"'{name}'" in self.client_code:
                     print(f"  ✓ {name:30s} = {addr}")
                 else:
-                    issue = f"Address '{name}' ({section}) not used in client.py"
-                    issues.append(issue)
-                    print(f"  ⚠ {name:30s} = {addr} (NOT USED)")
+                    if section == "ram.native" or name in informational_unused:
+                        print(f"  • {name:30s} = {addr} (unused by current client path)")
+                    else:
+                        issue = f"Address '{name}' ({section}) not used in client.py"
+                        issues.append(issue)
+                        print(f"  ⚠ {name:30s} = {addr} (NOT USED)")
         
         return issues
     
@@ -84,7 +118,13 @@ class AddressValidator:
         # Extract numeric values and check for overlap
         ranges: List[Tuple[str, int, int]] = []
         
-        for section, addrs in self.addresses.items():
+        sections: Dict[str, Dict[str, str]] = {}
+        sections.update(self.grouped_ram_sections)
+        rom = self.addresses.get("rom", {}) if isinstance(self.addresses, dict) else {}
+        if isinstance(rom, dict):
+            sections["rom"] = rom
+
+        for section, addrs in sections.items():
             for name, addr_str in addrs.items():
                 try:
                     addr = int(addr_str, 16)


### PR DESCRIPTION
Implements #137 by splitting KirbyAM RAM addresses into transport and native sections while preserving all existing numeric values and backward compatibility.

- addresses.json: ram.transport + ram.native
- data loader: supports new and old schema
- client wiring: transport map for mailbox accesses
- validator: nested schema support

No address values changed.

Closes #137