### PR TITLE
issue-127: Auto-resync item delivery after save-loss/reconnect

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -227,6 +227,12 @@ class KirbyAmClient(BizHawkClient):
         # Auto-resync delivery cursor if ROM item state moved backward (save-loss)
         # or forward (reconnect after stale client state).
         if rom_received_count is not None:
+            if rom_received_count > len(ctx.items_received):
+                if self._delivered_item_index != len(ctx.items_received):
+                    self._delivered_item_index = len(ctx.items_received)
+                    await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
+                self._delivery_pending = False
+                return
             if rom_received_count < self._delivered_item_index:
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -204,3 +204,33 @@ async def test_deliver_items_resyncs_forward_after_reconnect(mock_bizhawk_contex
         assert client._delivery_pending is True
         written = mock_write.await_args.args[1]
         assert written[0][1] == int(3860003).to_bytes(4, 'little')
+
+
+@pytest.mark.asyncio
+async def test_deliver_items_waits_when_rom_counter_ahead_but_items_partial(mock_bizhawk_context):
+    """Do not write items while ReceivedItems list is still behind ROM counter."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._delivered_item_index = 0
+    client._delivery_pending = False
+
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860001, player=1),
+    ]
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (2).to_bytes(4, 'little'),
+        ]
+
+        await client._deliver_items(mock_bizhawk_context)
+
+        assert client._delivered_item_index == len(mock_bizhawk_context.items_received)
+        assert client._delivery_pending is False
+        mock_write.assert_awaited_once()
+        persisted = mock_write.await_args.args[1]
+        assert persisted == [
+            (data.transport_ram_addresses["delivered_item_index"], (1).to_bytes(4, 'little'), "System Bus")
+        ]


### PR DESCRIPTION
## Summary
Implements #127 by automatically resynchronizing item delivery cursor with ROM-acknowledged item count, allowing items to be pushed again after save-loss or stale reconnect state.

## Changes
- Read `debug_item_counter` alongside mailbox flag in `_deliver_items`.
- If ROM count regresses, rewind `_delivered_item_index` and resume redelivery.
- If ROM count is ahead (and within received list), fast-forward cursor to avoid duplicate pushes.
- Keep `delivered_item_index` persisted in transport RAM after resync adjustments.
- Add tests for save-loss rewind and reconnect fast-forward scenarios.

## Validation
- `python -m pytest worlds/kirbyam/test/test_client.py -q`
- `python worlds/kirbyam/tools/validate_addresses.py --strict-native-usage`

Closes #127