### PR TITLE
issue-135: Lock USA baseline and native address policy

### DIFF
--- a/worlds/kirbyam/ADDRESS_VERIFICATION_MATRIX.md
+++ b/worlds/kirbyam/ADDRESS_VERIFICATION_MATRIX.md
@@ -163,7 +163,7 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 ### From Workbook (KirbyAM Data.xlsx)
 | Signal | Workbook Address | Status | Notes |
 |--------|------------------|--------|-------|
-| Mirror Shards Bitfield | `0x02038970` | Verified for current POC path | Tracked in `addresses.json` as `shard_bitfield_native` |
+| Mirror Shards Bitfield | `0x02038970` | Integrated (pending live verification) | Tracked in `addresses.json` as `shard_bitfield_native` |
 | Chest/Switch Blocks | `0x02038960`–`0x0203896A` | TBD | Supporting data |
 | Boss/Mirror table region | `0x02028C14+` | Candidate | Candidate source from protocol reverse-engineering; needs live confirmation |
 | Dark Mind signal | `0x02028C14+` (offset TBD) | Candidate | Needs live mapping and confirmation |
@@ -175,7 +175,7 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 
 ## 5. VERIFICATION CHECKLIST
 
-- [x] At least one shard progression address is integrated as verified for current POC path (`0x02038970`)
+- [x] At least one shard progression address is integrated for current POC path (`0x02038970`)
 - [x] At least one dungeon boss signal candidate is documented (`0x02028C14+` region)
 - [x] At least one final boss signal candidate is documented (`0x02028C14+` region, offset TBD)
 - [ ] Live verification complete for dungeon boss candidate(s)

--- a/worlds/kirbyam/data/native_address_policy.json
+++ b/worlds/kirbyam/data/native_address_policy.json
@@ -17,14 +17,14 @@
   },
   "signals": {
     "shard_progression": {
-      "status": "verified",
+      "status": "integrated",
       "entries": [
         {
           "name": "shard_bitfield_native",
           "address": "0x02038970",
           "width": "u8",
           "source": "Workbook + cheat cross-reference + ROM payload integration",
-          "verification": "Integrated and used by polling path; continue live confirmation in matrix"
+          "verification": "Integrated and used by polling path; pending repeatable BizHawk confirmation per promotion_criteria"
         }
       ]
     },
@@ -33,7 +33,8 @@
       "entries": [
         {
           "name": "boss_mirror_table_region",
-          "address": "0x02028C14+",
+          "base_address": "0x02028C14",
+          "offset": "TBD",
           "width": "TBD",
           "source": "Protocol reverse-engineering candidate",
           "verification": "Needs live memory observation before production use"
@@ -45,7 +46,8 @@
       "entries": [
         {
           "name": "dark_mind_defeat_flag",
-          "address": "0x02028C14+ (offset TBD)",
+          "base_address": "0x02028C14",
+          "offset": "TBD",
           "width": "TBD",
           "source": "Protocol reverse-engineering candidate",
           "verification": "Needs live memory observation before production use"

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -6,6 +6,10 @@ Policy references:
 - `worlds/kirbyam/docs/notes.md`
 - `worlds/kirbyam/data/native_address_policy.json`
 
+Note: Address statuses (`candidate`, `integrated`, `verified`) and expected widths
+in this guide are intended to match `native_address_policy.json`. If there is a
+mismatch, treat the registry as authoritative and update this guide.
+
 From `KirbyAM Data.xlsx` and cheat codes:
 
 ```

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -1,118 +1,10 @@
-\# Kirby \& The Amazing Mirror (GBA) — Archipelago Setup (Work-in-Progress)
-
-
-
-This integration is currently implemented as a \*\*BizHawk client + ROM patch memory contract\*\*.
-
-
-
-\- The \*\*Python world\*\* is stable for seed generation.
-
-\- The \*\*ROM patch\*\* is responsible for implementing the RAM protocol described below.
-
-\- No seed-specific ROM patching is required yet; all randomization is mediated via RAM.
-
-
-
-This document describes the \*\*minimum contract required for a playable game\*\*.
-
-
-
----
-
-
-
-\## BizHawk requirements
-
-
-
-\- BizHawk 2.x
-
-\- `connector\_bizhawk\_generic.lua` (standard Archipelago BizHawk connector)
-
-
-
-All memory access uses the \*\*System Bus\*\* domain.
-
-
-
----
-
-
-
-\## Memory contract (EWRAM, System Bus)
-
-
-
-All Archipelago-related RAM is located in \*\*EWRAM starting at `0x0202C000`\*\*.
-
-
-
-Addresses are defined in: `worlds/kirbyam/data/addresses.json`
-
-
-
-The ROM patch must treat this region as \*\*reserved and owned by Archipelago\*\*.
-
-
-
-\### AP EWRAM layout
-
-
-
-Base address: \*\*`0x0202C000`\*\*
-
-
-
-| Address | Size | Name | Description |
-
-|------|------|------|-------------|
-
-| `0x0202C000` | u32 | `shard\_bitfield` | Location check bitfield |
-
-| `0x0202C004` | u32 | `incoming\_item\_flag` | Incoming item mailbox flag |
-
-| `0x0202C008` | u32 | `incoming\_item\_id` | Incoming AP item id |
-
-| `0x0202C00C` | u32 | `incoming\_item\_player` | Sender slot id |
-
-
-
-All values are \*\*little-endian 32-bit integers\*\*.
-
-
-
----
-
-
-
-\## Location checks
-
-
-
-\### `shard\_bitfield` (u32)
-
-
-
-\- Each bit represents whether a location has been checked.
-
-\- Bits are \*\*monotonic\*\* (once set, never cleared).
-
-
-
-Current proof-of-concept mapping:
-
-
-
-\- bit 0 → `SHARD\_1` location checked
-
 # Kirby & The Amazing Mirror (GBA) - Address Policy Notes
 
 ## POC baseline
 
 - Baseline ROM for the POC is `Kirby & The Amazing Mirror (USA).gba` only.
 - Multi-ROM parity (EU/JP/VC) is out of scope for this phase.
-- Non-USA testing issues remain tracked separately (`#99`, `#100`, `#101`, `#102`).
+- Non-USA testing remains tracked separately (`#99`, `#100`, `#101`, `#102`).
 
 ## Address domain separation (locked policy)
 
@@ -124,48 +16,56 @@ Do not mix these two domains:
 - Examples: `incoming_item_flag`, `incoming_item_id`, `delivered_item_index`.
 
 2. Native game-state addresses
-- Purpose: actual in-game progression/check/goal state.
-- Source of truth: `worlds/kirbyam/data/native_address_policy.json` and `ram.native` entries in `worlds/kirbyam/data/addresses.json`.
-- Current verified native signal: `shard_bitfield_native` at `0x02038970`.
+- Purpose: in-game progression/check/goal state.
+- Source of truth: `worlds/kirbyam/data/native_address_policy.json` and `ram.native` in `worlds/kirbyam/data/addresses.json`.
+- Current integrated native signal: `shard_bitfield_native` at `0x02038970`.
 
 Rule: AP transport fields must never be treated as native gameplay truth.
 
-## Candidate vs verified statuses
+## Status taxonomy
 
-- `candidate`: Derived from workbook/cheat/reverse-engineering source and needs live confirmation in BizHawk.
+- `candidate`: Derived from workbook/cheat/reverse-engineering source; requires live confirmation.
+- `integrated`: Used by current client/ROM path but not yet promoted to fully live-verified policy status.
 - `verified`: Confirmed by repeatable live memory observation on USA ROM.
 
 Current high-level status:
 
-| Signal type | Candidate exists | Verified exists |
-| --- | --- | --- |
-| Shard progression | Yes | Yes |
-| Dungeon boss defeat | Yes | Not yet |
-| Final boss defeat | Yes | Not yet |
+| Signal type | Candidate | Integrated | Verified |
+| --- | --- | --- | --- |
+| Shard progression | Yes | Yes | Not yet policy-promoted |
+| Dungeon boss defeat | Yes | No | No |
+| Final boss defeat | Yes | No | No |
 
-Detailed signal registry lives in `worlds/kirbyam/data/native_address_policy.json`.
+Detailed signal registry: `worlds/kirbyam/data/native_address_policy.json`
 
-## Promotion criteria: candidate -> verified
+## Promotion criteria (candidate/integrated -> verified)
 
-All criteria below must be met before a signal can be marked `verified`:
+All criteria below must be met:
 
-1. Observed on USA ROM in BizHawk memory viewer during real gameplay action.
-2. Before/after transition recorded with exact address, width, and expected semantic meaning.
+1. Observed on USA ROM in BizHawk during real gameplay action.
+2. Before/after transition recorded with exact address, width, and expected semantics.
 3. Reproduced in at least 3 independent attempts with consistent transition behavior.
 4. Persistence checked across room transitions and save/reload as applicable.
-5. Cross-domain sanity check confirms no AP mailbox field is being used as native source.
+5. Cross-domain sanity check confirms no AP mailbox field is used as native source.
 6. Registry and matrix updated together:
 - `worlds/kirbyam/data/native_address_policy.json`
 - `worlds/kirbyam/ADDRESS_VERIFICATION_MATRIX.md`
 
+## POC shard mapping reference
+
+Current proof-of-concept shard bit mapping:
+
+- bit 0 -> `SHARD_1`
+- bit 1 -> `SHARD_2`
+- bit 2 -> `SHARD_3`
+- bit 3 -> `SHARD_4`
+- bit 4 -> `SHARD_5`
+- bit 5 -> `SHARD_6`
+- bit 6 -> `SHARD_7`
+- bit 7 -> `SHARD_8`
+
 ## Implementation notes
 
-- Transport contract details remain documented in `worlds/kirbyam/PROTOCOL.md`.
-- Verification workflow remains documented in `worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md`.
-\### Client behavior
-
-
-
-
-
-
+- Transport contract details: `worlds/kirbyam/PROTOCOL.md`
+- Verification workflow: `worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md`
+- Native signal status registry: `worlds/kirbyam/data/native_address_policy.json`


### PR DESCRIPTION
## Summary
Implements issue #135 policy lock deliverables for USA-ROM POC memory mapping.

## Changes
- Adds `worlds/kirbyam/data/native_address_policy.json` as the native signal registry (candidate vs verified status, source, and promotion criteria).
- Rewrites `worlds/kirbyam/docs/notes.md` with explicit domain separation policy:
  - AP transport/mailbox vs native game-state
  - USA-ROM-only baseline
  - candidate -> verified promotion requirements
- Updates `worlds/kirbyam/ADDRESS_VERIFICATION_MATRIX.md` to align with policy references and status model.
- Updates `worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md` with policy registry references.

## Validation
- `python worlds/kirbyam/tools/validate_addresses.py --strict-native-usage`

## Notes
- This PR locks policy and signal status taxonomy without fabricating unverified boss/final mappings.
- Boss/final candidates remain explicitly marked candidate until live BizHawk confirmation.

Closes #135