### PR TITLE
issue-117: get location checks working

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -161,9 +161,9 @@ class KirbyAmClient(BizHawkClient):
         Behavior:
         - Reads shard_bitfield_native from native RAM when available
         - Falls back to shard_bitfield transport mirror for compatibility
-        - Each bit (0-31) represents one location/shard
-        - New bits tracked in _checked_location_bits
-        - Sends LocationChecks for all newly set bits
+        - Each mapped bit can correspond to one or more AP location ids
+        - RAM state is authoritative for local checks
+        - Sends LocationChecks for any RAM-derived checks missing from server checked state
         """
         read_size = 1
         shard_addr = self._native_addr("shard_bitfield_native")
@@ -178,15 +178,18 @@ class KirbyAmClient(BizHawkClient):
         # Track only mapped bits so reserved bits do not pollute checked state.
         mapped_bits = sorted(self._location_ids_by_bit.keys())
 
-        newly_checked = []
+        mapped_checked_locations: set[int] = set()
         for bit in mapped_bits:
             if (shard_bits >> bit) & 1:
-                if bit not in self._checked_location_bits:
-                    self._checked_location_bits.add(bit)
-                    newly_checked.extend(self._location_ids_by_bit.get(bit, []))
+                self._checked_location_bits.add(bit)
+                mapped_checked_locations.update(self._location_ids_by_bit.get(bit, []))
 
-        if newly_checked:
-            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": newly_checked}])
+        # Reconnect-safe behavior: if server state is missing RAM-derived checks,
+        # resend them until the server acknowledges and reflects them.
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+
+        if missing_on_server:
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
 
     # --------------------------
     # Item delivery (mailbox protocol)

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -134,6 +134,29 @@ async def test_location_check_sent_on_new_shard(mock_bizhawk_context):
         ])
 
 
+@pytest.mark.asyncio
+async def test_location_check_resent_when_server_missing_location(mock_bizhawk_context):
+    """RAM-derived checks should be resent if server checked_locations is missing them."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    first_loc = data.locations["SHARD_1"].location_id
+    second_loc = data.locations["SHARD_2"].location_id
+    # Simulate server knowing only shard 1 while RAM reports shards 1+2.
+    mock_bizhawk_context.checked_locations = {first_loc}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+
+        mock_read.return_value = [(0x03).to_bytes(4, 'little')]
+
+        await client._poll_locations(mock_bizhawk_context)
+
+        mock_send.assert_awaited_once_with([
+            {"cmd": "LocationChecks", "locations": [second_loc]}
+        ])
+
+
 def test_client_initialization():
     """Test client state is properly initialized."""
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary\n- make RAM-derived location checks authoritative and reconnect-safe\n- resend location checks when RAM indicates checked but server state is missing them\n- add coverage for resend behavior in KirbyAM client tests\n\n## Testing\n- .\\.venv\\Scripts\\python.exe -m pytest worlds/kirbyam/test/test_client.py -q\n\nCloses #117