### PR TITLE
issue-146: add reusable KirbyAM fixture datasets

### DIFF
--- a/worlds/kirbyam/test/conftest.py
+++ b/worlds/kirbyam/test/conftest.py
@@ -1,7 +1,22 @@
 """Pytest fixtures for Kirby AM client and world testing."""
+import json
 import pytest
-from typing import Dict, Generator
+from pathlib import Path
+from typing import Any, Dict, Generator
 from unittest.mock import AsyncMock, Mock
+
+from ..data import data
+
+
+FIXTURE_DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def _load_fixture_json(filename: str) -> dict[str, Any]:
+    with (FIXTURE_DATA_DIR / filename).open("r", encoding="utf-8") as fixture_file:
+        loaded = json.load(fixture_file)
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Fixture file {filename} must contain a JSON object")
+    return loaded
 
 
 @pytest.fixture
@@ -48,17 +63,16 @@ def mock_ram_read_write() -> Generator[Dict[str, bytes], None, None]:
     Returns dict mapping address (int) -> bytes value.
     """
     ram_state: Dict[int, bytes] = {}
-    
-    # AP Mailbox region (0x0202C000-0x0202C028)
-    ram_state[0x0202C000] = (0).to_bytes(4, 'little')  # shard_bitfield
-    ram_state[0x0202C004] = (0).to_bytes(4, 'little')  # incoming_item_flag
-    ram_state[0x0202C008] = (0).to_bytes(4, 'little')  # incoming_item_id
-    ram_state[0x0202C00C] = (0).to_bytes(4, 'little')  # incoming_item_player
-    ram_state[0x0202C010] = (0).to_bytes(4, 'little')  # debug_item_counter
-    ram_state[0x0202C014] = (0).to_bytes(4, 'little')  # debug_last_item_id
-    ram_state[0x0202C018] = (0).to_bytes(4, 'little')  # debug_last_from
-    ram_state[0x0202C01C] = (0).to_bytes(4, 'little')  # frame_counter
-    ram_state[0x0202C020] = (0).to_bytes(4, 'little')  # delivered_item_index
+    baseline = _load_fixture_json("ram_mailbox_baseline.json")
+    baseline_u32 = baseline.get("ram_u32", {})
+    if not isinstance(baseline_u32, dict):
+        raise TypeError("ram_mailbox_baseline.json ram_u32 must be an object")
+    for addr_text, value in baseline_u32.items():
+        if not isinstance(addr_text, str):
+            continue
+        if not isinstance(value, int):
+            continue
+        ram_state[int(addr_text, 16)] = int(value).to_bytes(4, "little", signed=False)
     
     yield ram_state
 
@@ -111,18 +125,22 @@ def shard_bitfield_fixtures() -> Dict[str, int]:
     - shard_2_3: shards 1 and 2 (0x03)
     - all_8_shards: all 8 mirror shards (0xFF)
     """
-    return {
-        "empty": 0x00,
-        "shard_1": 0x01,
-        "shard_1_2": 0x03,
-        "shard_1_2_3": 0x07,
-        "shard_1_to_4": 0x0F,
-        "all_8_shards": 0xFF,
-    }
+    payload = _load_fixture_json("shard_bitfields.json")
+    scenarios = payload.get("scenarios", {})
+    if not isinstance(scenarios, dict):
+        raise TypeError("shard_bitfields.json scenarios must be an object")
+    result: Dict[str, int] = {}
+    for scenario_name, scenario_data in scenarios.items():
+        if not isinstance(scenario_name, str) or not isinstance(scenario_data, dict):
+            continue
+        bitfield = scenario_data.get("bitfield")
+        if isinstance(bitfield, int):
+            result[scenario_name] = bitfield
+    return result
 
 
 @pytest.fixture
-def item_delivery_fixtures() -> Dict[str, Dict[str, int]]:
+def item_delivery_fixtures() -> Dict[str, Dict[str, Any]]:
     """
     Pre-generated item delivery sequences for testing item handling.
     
@@ -131,24 +149,23 @@ def item_delivery_fixtures() -> Dict[str, Dict[str, int]]:
     - player_id: slot ID to credit
     - expected_state_change: what should happen in client
     """
-    base_offset = 3860000
-    return {
-        "1_up": {
-            "item_id": base_offset + 1,
-            "player_id": 1,
-            "description": "1-Up item",
-        },
-        "shard_1": {
-            "item_id": base_offset + 2,
-            "player_id": 1,
-            "description": "Mirror Shard 1",
-        },
-        "shard_8": {
-            "item_id": base_offset + 9,
-            "player_id": 1,
-            "description": "Mirror Shard 8",
-        },
-    }
+    payload = _load_fixture_json("item_delivery_sequences.json")
+    scenarios = payload.get("scenarios", {})
+    if not isinstance(scenarios, dict):
+        raise TypeError("item_delivery_sequences.json scenarios must be an object")
+    result: Dict[str, Dict[str, int]] = {}
+    for scenario_name, scenario_data in scenarios.items():
+        if not isinstance(scenario_name, str) or not isinstance(scenario_data, dict):
+            continue
+        item_id = scenario_data.get("item_id")
+        player_id = scenario_data.get("player_id")
+        if isinstance(item_id, int) and isinstance(player_id, int):
+            result[scenario_name] = {
+                "item_id": item_id,
+                "player_id": player_id,
+                "description": str(scenario_data.get("description", scenario_name)),
+            }
+    return result
 
 
 @pytest.fixture
@@ -158,14 +175,16 @@ def location_check_fixtures() -> Dict[str, int]:
     
     Maps friendly names to location IDs used in LocationChecks commands.
     """
-    base_offset = 3860100  # Base offset for Kirby AM locations
-    return {
-        "shard_1": base_offset + 1,
-        "shard_2": base_offset + 2,
-        "shard_3": base_offset + 3,
-        "shard_4": base_offset + 4,
-        "shard_5": base_offset + 5,
-        "shard_6": base_offset + 6,
-        "shard_7": base_offset + 7,
-        "shard_8": base_offset + 8,
-    }
+    payload = _load_fixture_json("location_check_transitions.json")
+    location_keys = payload.get("location_keys", [])
+    if not isinstance(location_keys, list):
+        raise TypeError("location_check_transitions.json location_keys must be a list")
+    result: Dict[str, int] = {}
+    for loc_key in location_keys:
+        if not isinstance(loc_key, str):
+            continue
+        loc_data = data.locations.get(loc_key)
+        if loc_data is None:
+            continue
+        result[loc_key.lower()] = loc_data.location_id
+    return result

--- a/worlds/kirbyam/test/data/README.md
+++ b/worlds/kirbyam/test/data/README.md
@@ -1,0 +1,40 @@
+# KirbyAM Test Fixture Data
+
+This directory contains reusable, pre-generated fixture datasets for unit and integration tests in `worlds/kirbyam/test/`.
+
+## Files
+
+- `ram_mailbox_baseline.json`
+  - Baseline transport RAM snapshot for AP mailbox fields and shard fallback polling.
+- `shard_bitfields.json`
+  - Bitfield scenario vectors for shard polling and location-check transitions.
+- `item_delivery_sequences.json`
+  - Item delivery examples and mailbox ack transitions.
+- `location_check_transitions.json`
+  - Expected location-check behavior for shard progression and resend scenarios.
+
+## Address Ranges
+
+- `0x0202C000-0x0202C020`
+  - AP transport mailbox / debug region used by client protocol fields.
+- `0x02038970`
+  - Native shard flag byte used by current POC polling path.
+
+## Expected State Transitions
+
+- Mailbox write flow:
+  1. `incoming_item_flag == 0`
+  2. client writes `incoming_item_id` + `incoming_item_player`
+  3. client sets `incoming_item_flag = 1`
+  4. ROM applies item and clears `incoming_item_flag = 0`
+- Location checks:
+  1. shard bit flips from `0` to `1`
+  2. client maps bit index to AP location IDs
+  3. client sends missing checks relative to server `checked_locations`
+
+## Timing Assumptions
+
+- Watcher cadence is approximately one tick every `0.125s`.
+- Bitfield and mailbox reads are treated as atomic per watcher tick.
+- Server acknowledgment of location checks can lag by one or more ticks, requiring resend behavior.
+- Mailbox ack (`incoming_item_flag` reset to `0`) is observed on subsequent ticks.

--- a/worlds/kirbyam/test/data/item_delivery_sequences.json
+++ b/worlds/kirbyam/test/data/item_delivery_sequences.json
@@ -1,0 +1,62 @@
+{
+  "description": "Reusable item-delivery vectors for mailbox protocol tests.",
+  "address_ranges": [
+    {
+      "name": "mailbox_write_window",
+      "start": "0x0202C008",
+      "end": "0x0202C010",
+      "bus": "System Bus",
+      "notes": "Client writes item_id/player_id and then toggles incoming_item_flag."
+    },
+    {
+      "name": "delivery_progress_counter",
+      "start": "0x0202C010",
+      "end": "0x0202C020",
+      "bus": "System Bus",
+      "notes": "ROM ack/debug state used for delivery cursor resync."
+    }
+  ],
+  "timing_assumptions": {
+    "ack_semantics": "ROM clears incoming_item_flag to 0 after item apply",
+    "resync_semantics": "debug_item_counter is authoritative when present"
+  },
+  "scenarios": {
+    "1_up": {
+      "item_id": 3860001,
+      "player_id": 1,
+      "description": "1-Up item"
+    },
+    "shard_1": {
+      "item_id": 3860002,
+      "player_id": 1,
+      "description": "Mirror Shard 1"
+    },
+    "shard_8": {
+      "item_id": 3860009,
+      "player_id": 1,
+      "description": "Mirror Shard 8"
+    }
+  },
+  "transitions": [
+    {
+      "name": "mailbox_write",
+      "pre": {
+        "incoming_item_flag": 0,
+        "delivered_item_index": 0
+      },
+      "post": {
+        "incoming_item_flag": 1
+      }
+    },
+    {
+      "name": "rom_ack",
+      "pre": {
+        "incoming_item_flag": 1
+      },
+      "post": {
+        "incoming_item_flag": 0,
+        "delivered_item_index_increment": 1
+      }
+    }
+  ]
+}

--- a/worlds/kirbyam/test/data/location_check_transitions.json
+++ b/worlds/kirbyam/test/data/location_check_transitions.json
@@ -1,0 +1,30 @@
+{
+  "description": "Scenario mapping for expected location checks from shard bitfield transitions.",
+  "location_keys": [
+    "SHARD_1",
+    "SHARD_2",
+    "SHARD_3",
+    "SHARD_4",
+    "SHARD_5",
+    "SHARD_6",
+    "SHARD_7",
+    "SHARD_8"
+  ],
+  "timing_assumptions": {
+    "server_ack_lag": "LocationChecks may require resend until server checked_locations catches up",
+    "notes": "Transitions model client-side resend behavior under reconnect lag."
+  },
+  "transitions": [
+    {
+      "name": "first_shard_collected",
+      "bitfield": "shard_1",
+      "expected_location_keys": ["SHARD_1"]
+    },
+    {
+      "name": "second_shard_missing_on_server",
+      "bitfield": "shard_1_2",
+      "server_checked_location_keys": ["SHARD_1"],
+      "expected_location_keys": ["SHARD_2"]
+    }
+  ]
+}

--- a/worlds/kirbyam/test/data/ram_mailbox_baseline.json
+++ b/worlds/kirbyam/test/data/ram_mailbox_baseline.json
@@ -1,0 +1,39 @@
+{
+  "description": "Baseline AP mailbox and transport RAM image used by client tests.",
+  "address_ranges": [
+    {
+      "name": "ap_mailbox_transport",
+      "start": "0x0202C000",
+      "end": "0x0202C020",
+      "bus": "System Bus",
+      "notes": "Transport mirror block used by client mailbox protocol and shard fallback polling."
+    }
+  ],
+  "timing_assumptions": {
+    "watcher_timeout_seconds": 0.125,
+    "mailbox_poll_interval": "Each watcher tick",
+    "notes": "RAM snapshot models a single watcher tick before writes."
+  },
+  "ram_u32": {
+    "0x0202C000": 0,
+    "0x0202C004": 0,
+    "0x0202C008": 0,
+    "0x0202C00C": 0,
+    "0x0202C010": 0,
+    "0x0202C014": 0,
+    "0x0202C018": 0,
+    "0x0202C01C": 0,
+    "0x0202C020": 0
+  },
+  "fields": {
+    "0x0202C000": "shard_bitfield_transport",
+    "0x0202C004": "incoming_item_flag",
+    "0x0202C008": "incoming_item_id",
+    "0x0202C00C": "incoming_item_player",
+    "0x0202C010": "debug_item_counter",
+    "0x0202C014": "debug_last_item_id",
+    "0x0202C018": "debug_last_from",
+    "0x0202C01C": "frame_counter",
+    "0x0202C020": "delivered_item_index"
+  }
+}

--- a/worlds/kirbyam/test/data/shard_bitfields.json
+++ b/worlds/kirbyam/test/data/shard_bitfields.json
@@ -1,0 +1,71 @@
+{
+  "description": "Pre-generated bitfield patterns for location-check polling tests.",
+  "address_ranges": [
+    {
+      "name": "native_shard_flags",
+      "start": "0x02038970",
+      "end": "0x02038970",
+      "bus": "System Bus",
+      "notes": "Native candidate/integrated shard progression source for POC polling."
+    },
+    {
+      "name": "transport_shard_bitfield",
+      "start": "0x0202C000",
+      "end": "0x0202C003",
+      "bus": "System Bus",
+      "notes": "Fallback transport mirror bitfield."
+    }
+  ],
+  "timing_assumptions": {
+    "bit_flip_visibility": "Within one watcher tick",
+    "notes": "Test vectors represent stable bitfields read atomically by bizhawk.read."
+  },
+  "scenarios": {
+    "empty": {
+      "bitfield": 0,
+      "set_bits": []
+    },
+    "shard_1": {
+      "bitfield": 1,
+      "set_bits": [0]
+    },
+    "shard_1_2": {
+      "bitfield": 3,
+      "set_bits": [0, 1]
+    },
+    "shard_1_2_3": {
+      "bitfield": 7,
+      "set_bits": [0, 1, 2]
+    },
+    "shard_1_to_4": {
+      "bitfield": 15,
+      "set_bits": [0, 1, 2, 3]
+    },
+    "all_8_shards": {
+      "bitfield": 255,
+      "set_bits": [0, 1, 2, 3, 4, 5, 6, 7]
+    },
+    "reserved_high_bit": {
+      "bitfield": 2147483649,
+      "set_bits": [0, 31],
+      "notes": "Bit 31 is intentionally reserved/unmapped for validation."
+    }
+  },
+  "transitions": [
+    {
+      "from": "empty",
+      "to": "shard_1",
+      "expected_new_bits": [0]
+    },
+    {
+      "from": "shard_1",
+      "to": "shard_1_2",
+      "expected_new_bits": [1]
+    },
+    {
+      "from": "shard_1_2",
+      "to": "shard_1_2_3",
+      "expected_new_bits": [2]
+    }
+  ]
+}

--- a/worlds/kirbyam/test/test_fixture_data.py
+++ b/worlds/kirbyam/test/test_fixture_data.py
@@ -1,0 +1,48 @@
+"""Tests for reusable KirbyAM fixture data files."""
+
+from pathlib import Path
+import json
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fixture_file:
+        data = json.load(fixture_file)
+    assert isinstance(data, dict)
+    return data
+
+
+def test_fixture_data_files_exist() -> None:
+    data_dir = Path(__file__).resolve().parent / "data"
+    expected_files = {
+        "ram_mailbox_baseline.json",
+        "shard_bitfields.json",
+        "item_delivery_sequences.json",
+        "location_check_transitions.json",
+        "README.md",
+    }
+    existing = {p.name for p in data_dir.iterdir()}
+    assert expected_files.issubset(existing)
+
+
+def test_fixture_documents_core_address_ranges() -> None:
+    data_dir = Path(__file__).resolve().parent / "data"
+    ram_fixture = _load_json(data_dir / "ram_mailbox_baseline.json")
+    shard_fixture = _load_json(data_dir / "shard_bitfields.json")
+
+    ram_ranges = ram_fixture.get("address_ranges", [])
+    shard_ranges = shard_fixture.get("address_ranges", [])
+
+    assert any(r.get("start") == "0x0202C000" for r in ram_ranges)
+    assert any(r.get("start") == "0x02038970" for r in shard_ranges)
+
+
+def test_location_transition_fixture_has_reconnect_case() -> None:
+    data_dir = Path(__file__).resolve().parent / "data"
+    transition_fixture = _load_json(data_dir / "location_check_transitions.json")
+    transitions = transition_fixture.get("transitions", [])
+
+    reconnect_cases = [
+        t for t in transitions
+        if "server_checked_location_keys" in t and "expected_location_keys" in t
+    ]
+    assert reconnect_cases, "Expected at least one reconnect/resend transition case"


### PR DESCRIPTION
## Summary\n- add reusable fixture datasets under worlds/kirbyam/test/data for RAM, shard bitfields, item delivery, and location-check transitions\n- load fixture datasets from JSON in conftest.py so tests use pre-generated scenario data\n- add fixture data integrity tests in 	est_fixture_data.py\n- include fixture documentation covering address ranges, state transitions, and timing assumptions\n\n## Testing\n- .\\.venv\\Scripts\\python.exe -m pytest worlds/kirbyam/test -q\n\nCloses #146