### PR TITLE
issue-148: set up local KirbyAM integration test server

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,17 @@
+services:
+  kirbyam-test-server:
+    build:
+      context: .
+    image: archipelago-test
+    pull_policy: never
+    working_dir: /app
+    environment:
+      - PYTHONUNBUFFERED=1
+      - KIRBYAM_TEST_SERVER_HOST=0.0.0.0
+      - KIRBYAM_TEST_SERVER_PORT=38281
+    volumes:
+      - ./output:/app/output
+    entrypoint: python worlds/kirbyam/test/server/start_test_server.py
+    command: --output-dir /app/output
+    ports:
+      - "38281:38281"

--- a/worlds/kirbyam/TESTING.md
+++ b/worlds/kirbyam/TESTING.md
@@ -1,0 +1,70 @@
+# KirbyAM Local Integration Testing
+
+This guide provides a local Archipelago test-server setup for Kirby & The Amazing Mirror integration testing.
+
+## What This Provides
+
+- Local MultiServer bootstrap for KirbyAM test sessions
+- Example KirbyAM player yaml for deterministic test generation
+- Docker Compose wrapper for hosting a generated test archive
+
+## Files
+
+- `worlds/kirbyam/test/server/kirbyam_test_player.yaml`
+- `worlds/kirbyam/test/server/start_test_server.py`
+- `docker-compose.test.yml`
+
+## Addressed Test Requirements
+
+- Accept client connections: MultiServer exposed on `0.0.0.0:38281`
+- Host test ROM/slot data: generated multiworld archive includes slot data
+- Accept `LocationChecks`: standard AP server protocol via MultiServer
+- Deliver test items: standard AP `ReceivedItems` flow via MultiServer
+
+## Step 1: Generate Test Slot Data
+
+1. Place or copy your test player yaml into `Players/`.
+2. Recommended starter file:
+   - `worlds/kirbyam/test/server/kirbyam_test_player.yaml`
+3. Generate a test archive:
+
+   - Windows PowerShell example:
+     - `Copy-Item worlds/kirbyam/test/server/kirbyam_test_player.yaml Players/kirbyam_test.yaml`
+     - `python Generate.py`
+
+The generated multiworld archive is usually written under `output/` with `.zip` or `.archipelago` extension.
+
+## Step 2A: Start Server Locally (Python)
+
+Use the bootstrap script directly:
+
+- `python worlds/kirbyam/test/server/start_test_server.py --archive output/<your-archive>.zip`
+
+If `--archive` is omitted, the script automatically picks the newest `.zip` or `.archipelago` file under `output/`.
+
+## Step 2B: Start Server via Docker Compose
+
+1. Ensure your generated archive is available under `output/`.
+2. Start compose:
+   - `docker compose -f docker-compose.test.yml up --build`
+
+Compose launches the bootstrap script, which automatically selects the newest `.zip` or `.archipelago` archive in `output/`.
+
+## Step 3: Connect KirbyAM Client and Validate
+
+1. Launch BizHawk and the KirbyAM client flow.
+2. Connect to local AP server at `localhost:38281`.
+3. Validate:
+   - `LocationChecks` are accepted by server
+   - test items are delivered to client
+   - server-client logs can be correlated with `test-output/kirbyam/` logs
+
+## Shutdown
+
+- Local script: stop with `Ctrl+C`
+- Compose: `docker compose -f docker-compose.test.yml down`
+
+## Notes
+
+- This setup is intentionally minimal for integration testing and is not a production deployment path.
+- For broader deployment containers, refer to `deploy/docker-compose.yml`.

--- a/worlds/kirbyam/test/server/kirbyam_test_player.yaml
+++ b/worlds/kirbyam/test/server/kirbyam_test_player.yaml
@@ -1,0 +1,7 @@
+name: KirbyAM Test
+
+game: Kirby & The Amazing Mirror
+
+Kirby & The Amazing Mirror:
+  goal: defeat_dark_mind
+  shards: shuffle

--- a/worlds/kirbyam/test/server/start_test_server.py
+++ b/worlds/kirbyam/test/server/start_test_server.py
@@ -1,0 +1,81 @@
+"""Bootstrap a local Archipelago MultiServer for KirbyAM integration testing."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+def _find_latest_archive(output_dir: Path) -> Path:
+    candidates = sorted(
+        [
+            p for p in output_dir.glob("**/*")
+            if p.is_file() and p.suffix.lower() in {".zip", ".archipelago"}
+        ],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        raise FileNotFoundError(
+            f"No generated multiworld archive found in {output_dir}. "
+            "Run Generate.py first."
+        )
+    return candidates[0]
+
+
+def _run(cmd: Sequence[str], cwd: Path) -> int:
+    process = subprocess.run(cmd, cwd=str(cwd))
+    return process.returncode
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[4]
+
+    parser = argparse.ArgumentParser(
+        description="Start local MultiServer for KirbyAM test archive.",
+    )
+    parser.add_argument(
+        "--archive",
+        help="Path to generated archive (.zip/.archipelago). If omitted, newest file in --output-dir is used.",
+        default=None,
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(repo_root / "output"),
+        help="Directory to scan for generated archive when --archive is not provided.",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("KIRBYAM_TEST_SERVER_HOST", "0.0.0.0"),
+        help="Host interface for MultiServer.",
+    )
+    parser.add_argument(
+        "--port",
+        default=os.getenv("KIRBYAM_TEST_SERVER_PORT", "38281"),
+        help="Port for MultiServer.",
+    )
+    args = parser.parse_args()
+
+    archive_path = Path(args.archive).resolve() if args.archive else _find_latest_archive(Path(args.output_dir))
+    if not archive_path.exists():
+        raise FileNotFoundError(f"Archive not found: {archive_path}")
+
+    cmd = [
+        sys.executable,
+        "MultiServer.py",
+        "--host",
+        str(args.host),
+        "--port",
+        str(args.port),
+        str(archive_path),
+    ]
+    print(f"Starting MultiServer with archive: {archive_path}")
+    return _run(cmd, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worlds/kirbyam/test/test_local_test_server.py
+++ b/worlds/kirbyam/test/test_local_test_server.py
@@ -1,0 +1,22 @@
+"""Tests for KirbyAM local test server bootstrap helpers."""
+
+from pathlib import Path
+
+from .server.start_test_server import _find_latest_archive
+
+
+def test_find_latest_archive_selects_newest_zip(tmp_path: Path) -> None:
+    older = tmp_path / "older.archipelago"
+    newest = tmp_path / "newest.zip"
+    older.write_bytes(b"old")
+    newest.write_bytes(b"new")
+
+    assert _find_latest_archive(tmp_path) == newest
+
+
+def test_find_latest_archive_raises_when_missing(tmp_path: Path) -> None:
+    try:
+        _find_latest_archive(tmp_path)
+        raise AssertionError("Expected FileNotFoundError")
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
## Summary\n- add docker-based local test server orchestration via docker-compose.test.yml\n- add KirbyAM integration test server bootstrap script to host generated slot-data archives\n- add sample KirbyAM player yaml for reproducible test generation\n- document startup/shutdown and validation flow in worlds/kirbyam/TESTING.md\n- add tests for local test-server archive discovery helper\n\n## Testing\n- .\\.venv\\Scripts\\python.exe worlds/kirbyam/test/server/start_test_server.py --help\n- .\\.venv\\Scripts\\python.exe -m pytest worlds/kirbyam/test -q\n\nCloses #148