### PR TITLE
issue-145: improve KirbyAM BizHawk typing surface

### DIFF
--- a/worlds/kirbyam/TESTING.md
+++ b/worlds/kirbyam/TESTING.md
@@ -64,6 +64,14 @@ Compose launches the bootstrap script, which automatically selects the newest `.
 - Local script: stop with `Ctrl+C`
 - Compose: `docker compose -f docker-compose.test.yml down`
 
+## Type Checking (Issue 145)
+
+Run focused mypy validation for the KirbyAM client typing surface:
+
+- `python -m mypy worlds/kirbyam/client.py --follow-imports=skip --ignore-missing-imports`
+
+The client's expected BizHawk context shape is documented in `worlds/kirbyam/types.py` as `KirbyAmBizHawkClientContext`.
+
 ## Notes
 
 - This setup is intentionally minimal for integration testing and is not a production deployment path.

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1,9 +1,10 @@
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Any, Dict
+from typing import TYPE_CHECKING, Optional
 
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
 
 from .data import data
+from .types import KirbyAmBizHawkClientContext
 
 if TYPE_CHECKING:
     from worlds._bizhawk.context import BizHawkClientContext
@@ -118,14 +119,14 @@ class KirbyAmClient(BizHawkClient):
             return data.native_ram_addresses[key]
         return None
 
-    async def _persist_u32(self, ctx: "BizHawkClientContext", key: str, value: int) -> None:
+    async def _persist_u32(self, ctx: KirbyAmBizHawkClientContext, key: str, value: int) -> None:
         """Persist a 32-bit value to RAM by address key."""
         addr = self._transport_addr(key)
         if addr is None:
             return
         await bizhawk.write(ctx.bizhawk_ctx, [(addr, int(value & 0xFFFFFFFF).to_bytes(4, "little"), "System Bus")])
 
-    async def _load_persistent_state(self, ctx: "BizHawkClientContext") -> None:
+    async def _load_persistent_state(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
         Best-effort load of persistent state from our reserved mailbox RAM block.
         If addresses are missing, this simply does nothing.
@@ -154,7 +155,7 @@ class KirbyAmClient(BizHawkClient):
     # Location checking
     # --------------------------
 
-    async def _poll_locations(self, ctx: "BizHawkClientContext") -> None:
+    async def _poll_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
         Primary location polling: read shard bitfield and map set bits to locations.
         
@@ -195,7 +196,7 @@ class KirbyAmClient(BizHawkClient):
     # Item delivery (mailbox protocol)
     # --------------------------
 
-    async def _deliver_items(self, ctx: "BizHawkClientContext") -> None:
+    async def _deliver_items(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
         Deliver items via mailbox protocol.
         
@@ -278,7 +279,7 @@ class KirbyAmClient(BizHawkClient):
     # Temporary completion condition
     # --------------------------
 
-    async def _maybe_report_goal(self, ctx: "BizHawkClientContext") -> None:
+    async def _maybe_report_goal(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
         Temporary goal reporting: mark finished when all locations are checked.
         

--- a/worlds/kirbyam/types.py
+++ b/worlds/kirbyam/types.py
@@ -1,0 +1,35 @@
+"""Typing helpers for KirbyAM BizHawk client integration."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from worlds._bizhawk import BizHawkContext
+
+
+@runtime_checkable
+class KirbyAmNetworkItem(Protocol):
+    """Minimal AP network item shape consumed by KirbyAM item delivery logic."""
+
+    item: int
+    player: int
+
+
+@runtime_checkable
+class KirbyAmBizHawkClientContext(Protocol):
+    """Typed subset of BizHawkClientContext required by KirbyAM client methods."""
+
+    bizhawk_ctx: BizHawkContext
+    server: Any
+    slot_data: dict[str, Any] | None
+    checked_locations: set[int]
+    items_received: list[KirbyAmNetworkItem]
+
+    auth: str | None
+    game: str
+    items_handling: int
+    want_slot_data: bool
+    watcher_timeout: float
+
+    async def send_msgs(self, msgs: list[dict[str, Any]]) -> None:
+        ...


### PR DESCRIPTION
## Summary\n- add KirbyAmBizHawkClientContext protocol documenting the BizHawk context surface used by KirbyAM\n- use the typed protocol across KirbyAM internal client helpers\n- add focused mypy command guidance to KirbyAM testing docs\n\n## Testing\n- .\\.venv\\Scripts\\python.exe -m mypy worlds/kirbyam/client.py --follow-imports=skip --ignore-missing-imports\n- .\\.venv\\Scripts\\python.exe -m pytest worlds/kirbyam/test -q\n\nCloses #145