### PR TITLE
Issue #150: Add protocol fuzzing and malformed packet hardening

### DIFF
--- a/worlds/kirbyam/TESTING.md
+++ b/worlds/kirbyam/TESTING.md
@@ -72,6 +72,19 @@ Run focused mypy validation for the KirbyAM client typing surface:
 
 The client's expected BizHawk context shape is documented in `worlds/kirbyam/types.py` as `KirbyAmBizHawkClientContext`.
 
+## Protocol Fuzzing (Issue 150)
+
+Run targeted protocol-fuzzing coverage for malformed `ReceivedItems` payloads and unexpected command sequences:
+
+- `python -m pytest worlds/kirbyam/test/test_fuzzer.py worlds/kirbyam/test/test_client.py`
+
+The fuzz suite is implemented in `worlds/kirbyam/test/fuzzer.py` and reports scenario coverage as:
+
+- `passed_cases / total_cases`
+- `coverage_percent`
+
+The suite includes malformed and out-of-range item payload cases and verifies graceful handling (warnings + skip) without client crashes.
+
 ## Notes
 
 - This setup is intentionally minimal for integration testing and is not a production deployment path.

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -119,6 +119,24 @@ class KirbyAmClient(BizHawkClient):
             return data.native_ram_addresses[key]
         return None
 
+    @staticmethod
+    def _coerce_u32(value: object) -> int | None:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        if 0 <= parsed <= 0xFFFFFFFF:
+            return parsed
+        return None
+
+    @classmethod
+    def _extract_delivery_item_fields(cls, network_item: object) -> tuple[int, int] | None:
+        item_value = cls._coerce_u32(getattr(network_item, "item", None))
+        player_value = cls._coerce_u32(getattr(network_item, "player", None))
+        if item_value is None or player_value is None:
+            return None
+        return item_value, player_value
+
     async def _persist_u32(self, ctx: KirbyAmBizHawkClientContext, key: str, value: int) -> None:
         """Persist a 32-bit value to RAM by address key."""
         addr = self._transport_addr(key)
@@ -265,15 +283,32 @@ class KirbyAmClient(BizHawkClient):
         if self._delivered_item_index >= len(ctx.items_received):
             return
 
-        itm = ctx.items_received[self._delivered_item_index]
+        from CommonClient import logger
 
-        # Write item and mark mailbox full
-        await bizhawk.write(ctx.bizhawk_ctx, [
-            (id_addr, int(itm.item).to_bytes(4, "little"), "System Bus"),
-            (player_addr, int(itm.player).to_bytes(4, "little"), "System Bus"),
-            (flag_addr, (1).to_bytes(4, "little"), "System Bus"),
-        ])
-        self._delivery_pending = True
+        while self._delivered_item_index < len(ctx.items_received):
+            itm = ctx.items_received[self._delivered_item_index]
+            item_fields = self._extract_delivery_item_fields(itm)
+            if item_fields is None:
+                logger.warning(
+                    "KirbyAM: Skipping malformed ReceivedItems entry at index %s: %r",
+                    self._delivered_item_index,
+                    itm,
+                )
+                self._delivered_item_index += 1
+                self._delivery_pending = False
+                await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
+                continue
+
+            item_id, player_id = item_fields
+
+            # Write item and mark mailbox full
+            await bizhawk.write(ctx.bizhawk_ctx, [
+                (id_addr, item_id.to_bytes(4, "little"), "System Bus"),
+                (player_addr, player_id.to_bytes(4, "little"), "System Bus"),
+                (flag_addr, (1).to_bytes(4, "little"), "System Bus"),
+            ])
+            self._delivery_pending = True
+            return
 
     # --------------------------
     # Temporary completion condition

--- a/worlds/kirbyam/test/fuzzer.py
+++ b/worlds/kirbyam/test/fuzzer.py
@@ -1,0 +1,140 @@
+"""Protocol fuzz helpers for Kirby AM client behavior tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Awaitable, Callable
+
+from ..client import KirbyAmClient
+
+if False:
+    from ..types import KirbyAmBizHawkClientContext
+
+
+@dataclass(frozen=True)
+class ProtocolFuzzCase:
+    name: str
+    execute: Callable[[KirbyAmClient, "KirbyAmBizHawkClientContext"], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ProtocolFuzzFinding:
+    case_name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class ProtocolFuzzSummary:
+    findings: list[ProtocolFuzzFinding]
+
+    @property
+    def total_cases(self) -> int:
+        return len(self.findings)
+
+    @property
+    def passed_cases(self) -> int:
+        return sum(1 for finding in self.findings if finding.passed)
+
+    @property
+    def failed_cases(self) -> int:
+        return self.total_cases - self.passed_cases
+
+    @property
+    def coverage_percent(self) -> float:
+        if self.total_cases == 0:
+            return 0.0
+        return (self.passed_cases / self.total_cases) * 100.0
+
+
+def build_protocol_fuzz_cases() -> list[ProtocolFuzzCase]:
+    async def malformed_item_string(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        ctx.items_received = [SimpleNamespace(item="bad", player=1)]
+        client._delivery_pending = False
+        client._delivered_item_index = 0
+        await client._deliver_items(ctx)
+
+    async def malformed_item_negative(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        ctx.items_received = [SimpleNamespace(item=-1, player=1)]
+        client._delivery_pending = False
+        client._delivered_item_index = 0
+        await client._deliver_items(ctx)
+
+    async def malformed_player_overflow(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        ctx.items_received = [SimpleNamespace(item=3860001, player=0x100000000)]
+        client._delivery_pending = False
+        client._delivered_item_index = 0
+        await client._deliver_items(ctx)
+
+    async def malformed_item_missing_fields(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        ctx.items_received = [object()]
+        client._delivery_pending = False
+        client._delivered_item_index = 0
+        await client._deliver_items(ctx)
+
+    async def malformed_then_valid_item(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        ctx.items_received = [
+            SimpleNamespace(item="corrupt", player=1),
+            SimpleNamespace(item=3860001, player=1),
+        ]
+        client._delivery_pending = False
+        client._delivered_item_index = 0
+        await client._deliver_items(ctx)
+
+    async def duplicate_replay_cursor(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        ctx.items_received = [SimpleNamespace(item=3860001, player=1)]
+        client._delivery_pending = False
+        client._delivered_item_index = 5
+        await client._deliver_items(ctx)
+
+    async def unexpected_command_sequence(client: KirbyAmClient, ctx: "KirbyAmBizHawkClientContext") -> None:
+        client.on_package(ctx, "UnknownCommand", {"data": "x"})
+        client.on_package(ctx, "ReceivedItems", {"items": "invalid", "index": "bad"})
+
+    return [
+        ProtocolFuzzCase("malformed_item_string", malformed_item_string),
+        ProtocolFuzzCase("malformed_item_negative", malformed_item_negative),
+        ProtocolFuzzCase("malformed_player_overflow", malformed_player_overflow),
+        ProtocolFuzzCase("malformed_item_missing_fields", malformed_item_missing_fields),
+        ProtocolFuzzCase("malformed_then_valid_item", malformed_then_valid_item),
+        ProtocolFuzzCase("duplicate_replay_cursor", duplicate_replay_cursor),
+        ProtocolFuzzCase("unexpected_command_sequence", unexpected_command_sequence),
+    ]
+
+
+async def run_protocol_fuzz_suite(
+    client: KirbyAmClient,
+    ctx: "KirbyAmBizHawkClientContext",
+) -> ProtocolFuzzSummary:
+    findings: list[ProtocolFuzzFinding] = []
+    for case in build_protocol_fuzz_cases():
+        client.initialize_client()
+        try:
+            await case.execute(client, ctx)
+            findings.append(ProtocolFuzzFinding(case.name, True, "ok"))
+        except Exception as exc:  # pragma: no cover - expected only on regressions
+            findings.append(ProtocolFuzzFinding(case.name, False, f"{type(exc).__name__}: {exc}"))
+    return ProtocolFuzzSummary(findings)
+
+
+def render_markdown_report(summary: ProtocolFuzzSummary) -> str:
+    lines = [
+        "# KirbyAM Protocol Fuzz Report",
+        "",
+        f"Coverage: {summary.passed_cases}/{summary.total_cases} ({summary.coverage_percent:.1f}%)",
+        "",
+        "| Case | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for finding in summary.findings:
+        status = "PASS" if finding.passed else "FAIL"
+        lines.append(f"| {finding.case_name} | {status} | {finding.detail} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_markdown_report(summary: ProtocolFuzzSummary, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_markdown_report(summary), encoding="utf-8")

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1,5 +1,6 @@
 """Integration tests for client polling and delivery logic."""
 import pytest
+import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 from ..data import data
@@ -257,3 +258,33 @@ async def test_deliver_items_waits_when_rom_counter_ahead_but_items_partial(mock
         assert persisted == [
             (data.transport_ram_addresses["delivered_item_index"], (1).to_bytes(4, 'little'), "System Bus")
         ]
+
+
+@pytest.mark.asyncio
+async def test_deliver_items_skips_malformed_entries_and_logs_warning(mock_bizhawk_context, caplog):
+    """Malformed ReceivedItems entries should be skipped, logged, and not crash delivery."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.items_received = [
+        Mock(item="bad", player=1),
+        Mock(item=3860001, player=1),
+    ]
+
+    caplog.set_level(logging.WARNING, logger="Archipelago")
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (0).to_bytes(4, 'little'),
+        ]
+
+        await client._deliver_items(mock_bizhawk_context)
+
+        assert client._delivery_pending is True
+        assert client._delivered_item_index == 1
+        written = mock_write.await_args.args[1]
+        assert written[0][1] == int(3860001).to_bytes(4, 'little')
+
+    assert "Skipping malformed ReceivedItems entry" in caplog.text

--- a/worlds/kirbyam/test/test_fuzzer.py
+++ b/worlds/kirbyam/test/test_fuzzer.py
@@ -1,0 +1,31 @@
+"""Tests for Kirby AM protocol fuzz helpers."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ..client import KirbyAmClient
+from .fuzzer import run_protocol_fuzz_suite, write_markdown_report
+
+
+@pytest.mark.asyncio
+async def test_protocol_fuzz_suite_completes_without_failures(mock_bizhawk_context, tmp_path: Path):
+    client = KirbyAmClient()
+
+    async def mock_read(_bizhawk_ctx, reads):
+        return [(0).to_bytes(size, "little") for _addr, size, _bus in reads]
+
+    with patch("worlds.kirbyam.client.bizhawk.read", new=AsyncMock(side_effect=mock_read)), \
+         patch("worlds.kirbyam.client.bizhawk.write", new=AsyncMock(return_value=None)):
+        summary = await run_protocol_fuzz_suite(client, mock_bizhawk_context)
+
+    assert summary.total_cases >= 7
+    assert summary.failed_cases == 0
+    assert summary.coverage_percent == pytest.approx(100.0)
+
+    report_path = tmp_path / "protocol_fuzz_report.md"
+    write_markdown_report(summary, report_path)
+    report_text = report_path.read_text(encoding="utf-8")
+    assert "KirbyAM Protocol Fuzz Report" in report_text
+    assert "Coverage:" in report_text


### PR DESCRIPTION
## Summary
- add a reusable KirbyAM protocol fuzz helper at worlds/kirbyam/test/fuzzer.py
- add fuzz regression test coverage in worlds/kirbyam/test/test_fuzzer.py with scenario coverage reporting
- harden item delivery in worlds/kirbyam/client.py to skip malformed ReceivedItems entries with warning logs instead of crashing
- add a malformed-entry delivery regression in worlds/kirbyam/test/test_client.py
- document fuzz workflow in worlds/kirbyam/TESTING.md

## Evidence Trail
- Claim: malformed protocol payloads should not crash client delivery logic and should be observable in logs
- Source: Issue #150 requirements plus existing delivery flow in worlds/kirbyam/client.py and AP ReceivedItems flow assumptions
- Adaptation: malformed entries are now validated (u32 bounds plus required fields), logged, persisted as skipped, and delivery continues to next valid item
- Validation: python -m pytest worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_fuzzer.py (14 passed)

Closes #150
