### PR TITLE
Issue #121: Resolve KirbyAM ROM size warning

### DIFF
--- a/worlds/kirbyam/TESTING.md
+++ b/worlds/kirbyam/TESTING.md
@@ -59,6 +59,15 @@ Compose launches the bootstrap script, which automatically selects the newest `.
    - test items are delivered to client
    - server-client logs can be correlated with `test-output/kirbyam/` logs
 
+## ROM Patch Validation (Issue 121)
+
+For the canonical USA KirbyAM base ROM used by this integration, `patch_rom.py` expects a 16 MB image (`0x1000000` bytes).
+
+Expected behavior:
+
+- No ROM-size warning for the configured USA baseline ROM whose MD5 matches `KirbyAmProcedurePatch.hash`
+- A warning only when the selected ROM size differs from that baseline expectation
+
 ## Shutdown
 
 - Local script: stop with `Ctrl+C`

--- a/worlds/kirbyam/kirby_ap_payload/patch_rom.py
+++ b/worlds/kirbyam/kirby_ap_payload/patch_rom.py
@@ -1,9 +1,21 @@
+import os
+import sys
+
+_SCRIPT_DIR = os.path.realpath(os.path.dirname(__file__))
+_WORLD_DIR = os.path.realpath(os.path.dirname(_SCRIPT_DIR))
+
+# When patch_rom.py is executed from worlds/kirbyam/kirby_ap_payload, Python can
+# still see the parent world directory early enough for worlds/kirbyam/types.py
+# to shadow stdlib types during stdlib imports. Remove that parent world path.
+for path_entry in list(sys.path):
+    resolved = os.path.realpath(path_entry or os.getcwd())
+    if resolved == _WORLD_DIR:
+        sys.path.remove(path_entry)
+
 import argparse
 import hashlib
 import importlib.util
-import os
 import subprocess
-import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -15,6 +27,7 @@ BL_BYTES = bytes.fromhex("0B F0 B3 FC")
 
 ROM_PATH_TMP = "rom_path.tmp"
 INTERMEDIARY_ROM = "baseline_patched.tmp.gba"
+EXPECTED_BASE_ROM_SIZE = 0x1000000
 
 
 # ----------------------------
@@ -147,6 +160,12 @@ def md5_file(path: str, chunk_size: int = 1024 * 1024) -> str:
                 break
             h.update(b)
     return h.hexdigest()
+
+
+def get_rom_size_warning(rom_size: int, expected_size: int = EXPECTED_BASE_ROM_SIZE) -> str | None:
+    if rom_size == expected_size:
+        return None
+    return f"Warning: ROM size is {rom_size:#x}, expected {expected_size:#x}. Proceeding anyway."
 
 
 def load_expected_rom_md5_from_rom_py() -> str:
@@ -405,9 +424,9 @@ def main():
     except FileNotFoundError as e:
         raise SystemExit(f"Error: input ROM not found: {in_path}") from e
 
-    # Basic size sanity for a 4MB ROM
-    if len(rom) != 0x400000:
-        print(f"Warning: ROM size is {len(rom):#x}, expected 0x400000. Proceeding anyway.")
+    warning = get_rom_size_warning(len(rom))
+    if warning is not None:
+        print(warning)
 
     # 4) Insert payload
     rom[PAYLOAD_OFFSET:PAYLOAD_OFFSET + len(payload)] = payload

--- a/worlds/kirbyam/test/test_patch_rom.py
+++ b/worlds/kirbyam/test/test_patch_rom.py
@@ -1,0 +1,23 @@
+"""Regression tests for Kirby AM patch ROM tooling."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+PATCH_ROM_PATH = Path(__file__).resolve().parents[1] / "kirby_ap_payload" / "patch_rom.py"
+PATCH_ROM_SPEC = importlib.util.spec_from_file_location("kirbyam_patch_rom", PATCH_ROM_PATH)
+if PATCH_ROM_SPEC is None or PATCH_ROM_SPEC.loader is None:
+    raise RuntimeError(f"Failed to load patch_rom module from {PATCH_ROM_PATH}")
+patch_rom = importlib.util.module_from_spec(PATCH_ROM_SPEC)
+PATCH_ROM_SPEC.loader.exec_module(patch_rom)
+
+
+def test_patch_rom_accepts_expected_usa_rom_size() -> None:
+    assert patch_rom.get_rom_size_warning(0x1000000) is None
+
+
+def test_patch_rom_warns_for_unexpected_rom_size() -> None:
+    warning = patch_rom.get_rom_size_warning(0x400000)
+    assert warning == "Warning: ROM size is 0x400000, expected 0x1000000. Proceeding anyway."


### PR DESCRIPTION
## Summary
- correct the expected KirbyAM USA base ROM size in patch_rom.py so the canonical 16 MB ROM no longer produces a false warning
- keep the size warning for genuinely unexpected ROM sizes via a dedicated helper
- fix patch_rom.py startup path handling so it can be executed directly from kirby_ap_payload without stdlib types shadowing
- add regression coverage in worlds/kirbyam/test/test_patch_rom.py
- document the corrected ROM patch expectation in worlds/kirbyam/TESTING.md

## Evidence Trail
- Claim: the ROM size warning is incorrect for the canonical USA KirbyAM base ROM
- Source: Issue #121 reproduction, patch_rom.log entries showing the configured MD5 matches the expected USA baseline while file size is 0x1000000, and reference ROM inventory showing KirbyAM USA/Europe images are 16 MB
- Adaptation: update the size expectation to the actual baseline, keep warnings for unexpected sizes, and harden the direct script entrypoint
- Validation: python patch_rom.py kirby.gba kirby_ap_test.gba from worlds/kirbyam/kirby_ap_payload, plus python -m pytest worlds/kirbyam/test/test_patch_rom.py worlds/kirbyam/test/

Closes #121
