### PR TITLE
Ensure release APWorld is always named kirbyam.apworld

### DIFF
--- a/.github/scripts/kirbyam_release_metadata.py
+++ b/.github/scripts/kirbyam_release_metadata.py
@@ -42,7 +42,7 @@ def build_release_metadata(github_ref: str) -> ReleaseMetadata:
     if match:
         version = match.group("version")
         return ReleaseMetadata(
-            apworld_name=f"kirbyam-{version}.apworld",
+            apworld_name="kirbyam.apworld",
             release_name=f"KirbyAM APWorld v{version}",
             release_tag=ref_name,
             version=version,

--- a/worlds/kirbyam/TESTING.md
+++ b/worlds/kirbyam/TESTING.md
@@ -144,7 +144,7 @@ Maintainer release steps:
 4. Wait for `.github/workflows/kirbyam-apworld.yml` to finish.
 5. Open the draft GitHub release and verify:
    - release title is `KirbyAM APWorld v0.0.1`
-   - attached asset name is `kirbyam-0.0.1.apworld`
+   - attached asset name is `kirbyam.apworld`
    - the asset downloads and loads as an APWorld
 6. Publish the draft release manually when ready.
 

--- a/worlds/kirbyam/WORKFLOW.md
+++ b/worlds/kirbyam/WORKFLOW.md
@@ -164,7 +164,7 @@ Use tag-driven draft releases for APWorld publication.
 2. Create annotated tag: kirbyam-vMAJOR.MINOR.PATCH
 3. Push the tag to origin
 4. Verify the KirbyAM APWorld workflow created or updated a draft release
-5. Confirm asset name: kirbyam-<version>.apworld
+5. Confirm asset name: kirbyam.apworld
 6. Publish the draft manually when maintainer validation is complete
 ```
 

--- a/worlds/kirbyam/test/test_release_metadata.py
+++ b/worlds/kirbyam/test/test_release_metadata.py
@@ -23,7 +23,7 @@ def test_build_release_metadata_for_valid_tag_ref() -> None:
     assert metadata.version == "0.0.1"
     assert metadata.release_tag == "kirbyam-v0.0.1"
     assert metadata.release_name == "KirbyAM APWorld v0.0.1"
-    assert metadata.apworld_name == "kirbyam-0.0.1.apworld"
+    assert metadata.apworld_name == "kirbyam.apworld"
 
 
 def test_build_release_metadata_for_branch_ref_disables_release() -> None:


### PR DESCRIPTION
## Summary\n- force release metadata to always emit kirbyam.apworld\n- update release metadata tests to assert stable filename for tag builds\n- update workflow/testing docs to reflect stable asset naming\n\n## Validation\n- python -m pytest worlds/kirbyam/test/test_release_metadata.py -q\n- python .github/scripts/kirbyam_release_metadata.py --github-ref refs/tags/kirbyam-v0.0.2\n\nCloses #188