### PR TITLE
Align issue #192 docs/rules with native goal signals

### DIFF
--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -33,8 +33,9 @@ Current high-level status:
 | Signal type | Candidate | Integrated | Verified |
 | --- | --- | --- | --- |
 | Shard progression | Yes | Yes | Not yet policy-promoted |
-| Dungeon boss defeat | Yes | No | No |
-| Final boss defeat | Yes | No | No |
+| Dungeon boss defeat | Yes | Yes (probe-only) | No |
+| Final boss defeat | Yes | Yes | No |
+| 100% completion | Yes | Yes | No |
 
 Detailed signal registry: `worlds/kirbyam/data/native_address_policy.json`
 

--- a/worlds/kirbyam/rules.py
+++ b/worlds/kirbyam/rules.py
@@ -11,9 +11,9 @@ Current rules:
         * 100%: collect 100% Save File.
         * DEBUG: always completable.
 
-NOTE: Dark Mind and 100% are currently modeled as explicit AP goal locations.
-The client reports those locations using placeholder logic until native game
-signals are integrated for final boss defeat and full completion.
+NOTE: Dark Mind and 100% are modeled as explicit AP goal locations.
+The client reports these goal locations from native AI-state signals and sends
+CLIENT_GOAL after server acknowledgement of the selected goal location check.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- remove stale placeholder goal-completion wording from worlds/kirbyam/rules.py
- update native signal status summary in worlds/kirbyam/docs/notes.md to reflect integrated Dark Mind/100% signaling from #210
- keep behavior/docs consistent with protocol and implemented client flow

## Validation
- python -m pytest worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_rules.py -q

Refs #192