### PR TITLE
Align location polling to level-based reconnect-safe contract (#53)

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -83,15 +83,28 @@ if has_address("shard_bitfield_native"):
 else:
     bitfield = RAM[0x0202C000] as u32  # transport mailbox mirror
 
-# For each set bit in the 32-bit shard bitfield:
-for bit in range(32):
+# Collect all locations whose corresponding bit is set in the bitfield.
+# Only consider bits that map to a known location; reserved/unmapped bits are ignored.
+mapped_checked = set()
+for bit in mapped_location_bits:  # only explicitly mapped bits
     if (bitfield >> bit) & 1:
-        if bit not previously seen and bit maps to a known location:
-            location_id = 3860100 + bit + 1
-            send LocationChecks([location_id])
+        mapped_checked.add(location_id_for_bit(bit))
+
+# Level-based, reconnect-safe resend:
+# Send only checks that RAM reports as collected but the server has not acknowledged.
+# This means checks are re-sent on reconnect until the server reflects them back,
+# preventing permanent loss from dropped or early-session message failures.
+missing_on_server = sorted(mapped_checked - server_checked_locations)
+if missing_on_server:
+    send LocationChecks(missing_on_server)
 ```
 
 Bits 8-31 are reserved for future expansion and must be ignored until they are assigned to concrete location mappings.
+
+**Behavior notes:**
+- Detection is **level-based** (current bitfield state), not edge-based, to be reconnect-safe.
+- No checks are sent for bits already in `server_checked_locations`.
+- No checks are sent for reserved/unmapped bits even when set.
 
 ### 3. Item Delivery (Mailbox Protocol)
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -157,3 +157,29 @@ This change is instrumentation groundwork for Issue #110 address identification.
 It does not yet convert boss candidate transitions into authoritative AP location
 checks or implement shard-undo behavior until concrete verified mappings are
 confirmed through manual BizHawk validation.
+
+## Issue #53: Native Location Polling — Level-Based Reconnect-Safe Model
+
+### Problem
+Location checks were previously described in protocol docs using an edge-based
+model ("if bit not previously seen") which could miss checks on reconnect.
+The acceptance criteria also required explicit documentation of the level-based
+contract and a test for the no-duplicate-send case.
+
+### Resolution
+The `_poll_locations` implementation uses a **level-based** model: on each poll,
+it reads the current shard bitfield state, maps set bits to AP location IDs, and
+sends only those checks that RAM reports as set but the server has not yet
+acknowledged. This naturally handles reconnect resend without any edge tracking.
+
+Key behaviors documented and tested:
+- Native `shard_bitfield_native` (0x02038970) is preferred; transport mirror
+  (`shard_bitfield`) is used as fallback when the native address is absent.
+- Only bits with explicit location mappings produce checks; reserved/unmapped bits
+  are filtered out.
+- No `LocationChecks` is sent when all RAM-derived checks are already reflected in
+  `server.checked_locations`.
+- Missing checks are resent until the server acknowledges them (reconnect-safe).
+
+PROTOCOL.md was updated to replace the old edge-based pseudocode with the actual
+level-based contract description.

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -158,6 +158,26 @@ async def test_location_check_resent_when_server_missing_location(mock_bizhawk_c
         ])
 
 
+@pytest.mark.asyncio
+async def test_no_location_checks_sent_when_all_already_server_acknowledged(mock_bizhawk_context):
+    """No LocationChecks message should be sent when all RAM-derived checks are already on the server."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    shard1 = data.locations["SHARD_1"].location_id
+    shard2 = data.locations["SHARD_2"].location_id
+    mock_bizhawk_context.checked_locations = {shard1, shard2}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+
+        mock_read.return_value = [(0x03).to_bytes(4, 'little')]  # bits 0 and 1 set
+
+        await client._poll_locations(mock_bizhawk_context)
+
+        mock_send.assert_not_awaited()
+
+
 def test_client_initialization():
     """Test client state is properly initialized."""
     client = KirbyAmClient()


### PR DESCRIPTION
Closes #53

## Summary
Aligns the location polling contract documentation and test coverage with the actual level-based, reconnect-safe implementation that was already in `_poll_locations`.

## Changes
- **PROTOCOL.md**: Replaces the old edge-based polling pseudocode with the accurate level-based model. Documents that detection is level-based (current bitfield state), reserved bits are ignored, no sends when all checks are already server-acknowledged, and missing checks are resent until acknowledged.
- **test_client.py**: Adds `test_no_location_checks_sent_when_all_already_server_acknowledged` to verify that `send_msgs` is not called when all RAM-derived checks are already in `server.checked_locations`.
- **notes.md**: Adds an Issue #53 resolution entry documenting the level-based model, key behaviors tested, and the protocol doc update.

## Validation
- 25 KirbyAM client tests pass.
- No code logic changes: only doc/test additions aligning written contract with existing behavior.