### PR TITLE
Document and test AP connection/reconnect lifecycle (#52)

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -72,6 +72,26 @@ Server → Client: ConnectionRefused | Connected
                  (with items_received, checked_locations, slot_data)
 ```
 
+**Preconditions before gameplay watchers run:**
+- `ctx.server` is not `None` and the socket is open.
+- `ctx.slot_data` is not `None` (world-specific config was received).
+
+Both conditions are checked at the top of `game_watcher`. If either fails,
+no RAM reads, location sends, item writes, or goal reports occur.
+
+**On initial (or re-)connection, the following resync occurs automatically:**
+
+| State | Resync behavior |
+|---|---|
+| Location checks | Level-based poll resends any RAM-derived checks missing from `checked_locations`. |
+| Item delivery | Cursor is reconciled against ROM's `debug_item_counter`; delivery resumes from the correct index. |
+| Goal reporting | Idempotent: goal location and CLIENT_GOAL are skipped when already reflected in `checked_locations`. |
+| Boss probe | Probe snapshot re-baselines on BizHawk stream-identity change (reconnect safe). |
+
+No explicit reconnect-event handler is required because all gameplay watchers
+implement level-based or cursor-reconciliation semantics that self-correct every
+poll cycle.
+
 ### 2. Location Polling
 
 **Active State:** Every frame (or periodic)

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -24,6 +24,35 @@ When validating AP item receipt behavior in BizHawk, also watch for mailbox time
 
 This behavior is intended to avoid deadlock while still preferring exactly-once ROM outcomes.
 
+## Reconnect Lifecycle Check (Issue #52)
+
+Validate that both BizHawk and AP server reconnect scenarios work correctly:
+
+### BizHawk disconnect/reconnect
+1. Connect AP client + patched ROM normally.
+2. Trigger at least one shard location check (collect a shard in-game) and receive at least one AP item.
+3. Close and re-open BizHawk (or restart the Lua script).
+4. Confirm:
+   - Shard check is **not resent** as a duplicate (already in server `checked_locations`).
+   - When RAM-derived checks are present but server is missing them (e.g., server also restarted), the client **does** resend them.
+   - Item delivery cursor resumes from the correct index (no re-delivery of already-applied items).
+   - No mailbox deadlock: `incoming_item_flag` is clear after normal reattach.
+
+### AP server disconnect/reconnect
+1. Connect AP client + patched ROM normally.
+2. Trigger at least one new location check.
+3. Disconnect the AP server (or stop the AP server process briefly).
+4. Reconnect.
+5. Confirm:
+   - Checks that were acknowledged before disconnect are **not resent**.
+   - Checks collected while disconnected are resent on reconnect until acknowledged.
+   - Goal reporting remains idempotent if goal was already sent before disconnect.
+
+### Expected log indicators
+- Normal resend: no output except standard location-check messages.
+- Cursor resync: `KirbyAM: ROM item counter ... fast-forward delivery cursor` or rewind message.
+- Boss probe: no false positive edge-detection log on reconnect (probe re-baselines cleanly).
+
 ## Quick Reference: Known Candidates
 
 Policy references:

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -183,3 +183,29 @@ Key behaviors documented and tested:
 
 PROTOCOL.md was updated to replace the old edge-based pseudocode with the actual
 level-based contract description.
+
+## Issue #52: AP Connection and Reconnection Lifecycle
+
+### Problem
+The connection section of PROTOCOL.md only described the initial handshake.
+There was no documentation of which preconditions the watcher checks before
+running, how each subsystem self-corrects on reconnect, or how to manually
+verify reconnect behavior in BizHawk.
+
+### Resolution
+No new code was required; all reconnect-safe semantics were already implemented
+across prior issues (#53, #54, #110). This issue formalized the contract:
+
+- **Watcher gating**: `game_watcher` checks `ctx.server` (not None, socket open)
+  and `ctx.slot_data` (not None) before any RAM reads or message sends.
+- **Location resync**: level-based polling from #53 handles reconnect naturally.
+- **Item delivery resync**: cursor-reconciliation from #54 handles both rewind
+  (ROM counter behind) and fast-forward (ROM counter ahead) cases.
+- **Goal reporting**: idempotent; already-reported goals are never re-sent.
+- **Boss probe**: re-baselines snapshot on BizHawk stream-identity change.
+
+PROTOCOL.md Section 1 was updated to document reconnect preconditions and the
+self-correcting behavior of each subsystem.
+
+BIZHAWK_TESTING_GUIDE.md now includes a "Reconnect Lifecycle Check" section
+with step-by-step instructions for validating both BizHawk and server reconnect.

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -566,3 +566,54 @@ async def test_probe_boss_candidates_resets_baseline_on_stream_change(mock_bizha
         await client._probe_boss_defeat_candidates(mock_bizhawk_context)
 
         mock_logger.info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_game_watcher_skips_when_server_is_none(mock_bizhawk_context):
+    """game_watcher should do nothing when ctx.server is None (AP not connected)."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.server = None
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        await client.game_watcher(mock_bizhawk_context)
+        mock_read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_game_watcher_skips_when_slot_data_is_none(mock_bizhawk_context):
+    """game_watcher should do nothing when ctx.slot_data is None (handshake not complete)."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = None
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        await client.game_watcher(mock_bizhawk_context)
+        mock_read.assert_not_awaited()
+
+
+
+@pytest.mark.asyncio
+async def test_game_watcher_skips_all_work_when_server_is_none(mock_bizhawk_context):
+    """game_watcher must do nothing and read no RAM when server is not connected."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.server = None
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        await client.game_watcher(mock_bizhawk_context)
+        mock_read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_game_watcher_skips_all_work_when_slot_data_is_none(mock_bizhawk_context):
+    """game_watcher must do nothing and read no RAM when slot_data is not yet available."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.slot_data = None
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        await client.game_watcher(mock_bizhawk_context)
+        mock_read.assert_not_awaited()


### PR DESCRIPTION
Closes #52

## Summary
Documents and validates the AP connection and reconnection lifecycle for the KirbyAM BizHawk client. All reconnect-safe behavior was already implemented across prior issues (#53, #54, #110); this PR formalizes the contract in docs and adds explicit watcher-gating tests.

## Changes
- **PROTOCOL.md Section 1**: Expanded Connection & Initialization section to document preconditions for watcher execution (server connected, slot_data present), and a table describing how each subsystem self-corrects on reconnect without an explicit event handler.
- **BIZHAWK_TESTING_GUIDE.md**: Added "Reconnect Lifecycle Check" section with step-by-step instructions for validating both BizHawk and AP server reconnect scenarios.
- **notes.md**: Added Issue #52 resolution entry documenting the contract and which prior issues implemented each behavior.
- **test_client.py**: Added `test_game_watcher_skips_when_server_is_none` and `test_game_watcher_skips_when_slot_data_is_none` to explicitly test the watcher gate condition.

## Validation
- 29 KirbyAM client tests pass.
- No code logic changes: doc/test additions only.