### PR TITLE
Issue #35: Add boss-defeat locations with shard-delivery decoupling

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -13,11 +13,11 @@ EWRAM Layout (0x02000000 - 0x02040000):
   
   0x02000000 - 0x02040000   EWRAM Region (256 KB)
     ├─ 0x02000000 - 0x0202BFFF   Native game state
-        ├─ 0x0202C000 - 0x0202C023   AP Mailbox (reserved, 36 bytes)
-        └─ 0x0202C024 - 0x02040000   Rest of RAM (unused by AP)
+        ├─ 0x0202C000 - 0x0202C027   AP Mailbox (reserved, 40 bytes)
+        └─ 0x0202C028 - 0x02040000   Rest of RAM (unused by AP)
 ```
 
-### AP Mailbox Block (0x0202C000 - 0x0202C023)
+### AP Mailbox Block (0x0202C000 - 0x0202C027)
 
 **Transport Layer: Client ↔ ROM Communication**
 
@@ -33,7 +33,9 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x1C   | 0x0202C01C | 4B | frame_counter         | u32  | ROM → Client | Monotonic frame count (incremented every hook call) |
 | 0x20   | 0x0202C020 | 4B | delivered_item_index  | u32  | Client ↔ ROM | Next item to deliver index (persisted in RAM) |
 
-**Total: 36 bytes (0x0202C000 - 0x0202C023)**
+| 0x24   | 0x0202C024 | 4B | boss_defeat_flags     | u32  | ROM → Client | Bits 0–7 set when each area boss is defeated (same bit ordering as shard_bitfield) |
+
+**Total: 40 bytes (0x0202C000 - 0x0202C027)**
 
 ### Native Game State (Referenced but not Managed by AP)
 
@@ -60,7 +62,8 @@ All location IDs use **BASE_OFFSET = 3860100**.
 | Location Type | ID Range | Description |
 |---------------|----------|-------------|
 | SHARD_1 .. SHARD_8 | 3860101 - 3860108 | Mirror shard check locations (8 items) |
-| *TBD*         | 3860109+ | Chest locations, boss defeats, etc. |
+| BOSS_DEFEAT_1 .. BOSS_DEFEAT_8 | auto-assigned | Area boss defeat locations (8 locations) |
+| *TBD*         | — | Chest locations, door locations, etc. |
 
 ## Client Protocol
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
 
-from .data import data
+from .data import LocationCategory, data
 from .options import Goal
 from .types import KirbyAmBizHawkClientContext
 
@@ -48,11 +48,19 @@ class KirbyAmClient(BizHawkClient):
                     self._goal_location_ids_by_option[Goal.option_100] = loc.location_id
             else:
                 self._non_goal_location_ids_sorted.append(loc.location_id)
+        # Shard bitfield → location IDs (SHARD category only; BOSS_DEFEAT uses separate bitfield)
         self._location_ids_by_bit: dict[int, list[int]] = {}
         for loc in data.locations.values():
-            if loc.bit_index is None:
+            if loc.bit_index is None or loc.category != LocationCategory.SHARD:
                 continue
             self._location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+
+        # Boss defeat bitfield → location IDs (BOSS_DEFEAT category; polled from boss_defeat_flags)
+        self._boss_location_ids_by_bit: dict[int, list[int]] = {}
+        for loc in data.locations.values():
+            if loc.bit_index is None or loc.category != LocationCategory.BOSS_DEFEAT:
+                continue
+            self._boss_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
 
         # One-time RAM state load
         self._ram_state_loaded: bool = False
@@ -115,6 +123,9 @@ class KirbyAmClient(BizHawkClient):
 
         # Location checks (real RAM polling)
         await self._poll_locations(ctx)
+
+        # Boss defeat location polling via transport register
+        await self._poll_boss_defeat_locations(ctx)
 
         # Candidate discovery for non-shard boss defeat signals.
         await self._probe_boss_defeat_candidates(ctx)
@@ -233,6 +244,29 @@ class KirbyAmClient(BizHawkClient):
         # resend them until the server acknowledges and reflects them.
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
 
+        if missing_on_server:
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+
+    async def _poll_boss_defeat_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Read boss_defeat_flags transport bitfield and map set bits to boss-defeat locations.
+
+        This mirrors shard polling semantics: RAM-derived checks are resent until the
+        server acknowledges them in ctx.checked_locations.
+        """
+        boss_addr = data.transport_ram_addresses.get("boss_defeat_flags")
+        if boss_addr is None:
+            return
+
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(boss_addr, 4, "System Bus")]))[0]
+        boss_bits = self._u32_le(raw)
+
+        mapped_checked_locations: set[int] = set()
+        for bit in sorted(self._boss_location_ids_by_bit.keys()):
+            if (boss_bits >> bit) & 1:
+                mapped_checked_locations.update(self._boss_location_ids_by_bit.get(bit, []))
+
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         if missing_on_server:
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
 

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -73,7 +73,7 @@ def _parse_int(value: Any) -> int:
 class LocationCategory(IntEnum):
     SHARD = 0
     GOAL = 1
-    # Add more as you define them, e.g. BOSS = 1, CHEST = 2, etc.
+    BOSS_DEFEAT = 2
 
 
 class ItemData(NamedTuple):

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -9,7 +9,8 @@
       "debug_last_item_id": "0x0202C014",
       "debug_last_from": "0x0202C018",
       "frame_counter": "0x0202C01C",
-      "delivered_item_index": "0x0202C020"
+      "delivered_item_index": "0x0202C020",
+      "boss_defeat_flags": "0x0202C024"
     },
     "native": {
       "shard_bitfield_native": "0x02038970",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -74,5 +74,61 @@
     "parent_region": "REGION_DIMENSION_MIRROR/MAIN",
     "tags": ["Goal", "MAP_DIMENSION_MIRROR"],
     "category": "GOAL"
+  },
+  "BOSS_DEFEAT_1": {
+    "label": "Mustard Mountain - Boss Defeat",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 0,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_2": {
+    "label": "Moonlight Mansion - Boss Defeat",
+    "parent_region": "REGION_MOONLIGHT_MANSION/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 1,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_3": {
+    "label": "Candy Constellation - Boss Defeat",
+    "parent_region": "REGION_CANDY_CONSTELLATION/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 2,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_4": {
+    "label": "Olive Ocean - Boss Defeat",
+    "parent_region": "REGION_OLIVE_OCEAN/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 3,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_5": {
+    "label": "Peppermint Palace - Boss Defeat",
+    "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 4,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_6": {
+    "label": "Cabbage Cavern - Boss Defeat",
+    "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 5,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_7": {
+    "label": "Carrot Castle - Boss Defeat",
+    "parent_region": "REGION_CARROT_CASTLE/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 6,
+    "category": "BOSS_DEFEAT"
+  },
+  "BOSS_DEFEAT_8": {
+    "label": "Radish Ruins - Boss Defeat",
+    "parent_region": "REGION_RADISH_RUINS/MAIN",
+    "tags": ["Boss"],
+    "bit_index": 7,
+    "category": "BOSS_DEFEAT"
   }
 }

--- a/worlds/kirbyam/data/regions/areas.json
+++ b/worlds/kirbyam/data/regions/areas.json
@@ -17,56 +17,56 @@
   },
 
   "REGION_MUSTARD_MOUNTAIN/MAIN": {
-    "locations": ["SHARD_1"],
+    "locations": ["SHARD_1", "BOSS_DEFEAT_1"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_MOONLIGHT_MANSION/MAIN": {
-    "locations": ["SHARD_2"],
+    "locations": ["SHARD_2", "BOSS_DEFEAT_2"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_CANDY_CONSTELLATION/MAIN": {
-    "locations": ["SHARD_3"],
+    "locations": ["SHARD_3", "BOSS_DEFEAT_3"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_OLIVE_OCEAN/MAIN": {
-    "locations": ["SHARD_4"],
+    "locations": ["SHARD_4", "BOSS_DEFEAT_4"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_PEPPERMINT_PALACE/MAIN": {
-    "locations": ["SHARD_5"],
+    "locations": ["SHARD_5", "BOSS_DEFEAT_5"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_CABBAGE_CAVERN/MAIN": {
-    "locations": ["SHARD_6"],
+    "locations": ["SHARD_6", "BOSS_DEFEAT_6"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_CARROT_CASTLE/MAIN": {
-    "locations": ["SHARD_7"],
+    "locations": ["SHARD_7", "BOSS_DEFEAT_7"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_RADISH_RUINS/MAIN": {
-    "locations": ["SHARD_8"],
+    "locations": ["SHARD_8", "BOSS_DEFEAT_8"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -209,3 +209,56 @@ self-correcting behavior of each subsystem.
 
 BIZHAWK_TESTING_GUIDE.md now includes a "Reconnect Lifecycle Check" section
 with step-by-step instructions for validating both BizHawk and server reconnect.
+
+## Issue #35: Boss-Defeat Locations with Shard-Delivery Decoupling
+
+### Problem
+After a boss is defeated in Kirby & The Amazing Mirror, the game calls
+`sub_0801D948` (ROM address `0x0801D948`) which calls `CollectShard(var->unk218)`
+to grant the area shard directly to save-state. In AP randomizer play the shard
+should come through the AP delivery pipeline (SHARD_N item) rather than as a
+direct grant, and the boss defeat itself should be a distinct AP location check.
+
+### Solution
+Implemented the AP-side transport infrastructure for boss-defeat locations:
+
+**Transport register**
+- Added `boss_defeat_flags` at `0x0202C024` (u32, bits 0–7), extending the
+  mailbox from 36 to 40 bytes.
+- Bit N is set by `ap_set_boss_defeat_flag(N)` in the ROM payload when area
+  boss N is defeated.
+
+**ROM payload**
+- Added `AP_BOSS_DEFEAT_FLAGS` macro in `ap_payload.c`.
+- Added `ap_set_boss_defeat_flag(uint32_t boss_index)` stub with a TODO comment
+  directing the caller to install the hook at `sub_0801D948` (ROM address
+  `0x0801D948`, the function that calls `CollectShard(var->unk218)` after a boss
+  collection cutscene). Until the hook is installed the register stays at zero;
+  shard polling and delivery are unaffected.
+
+**Locations**
+- Added 8 `BOSS_DEFEAT_N` locations (bit_index 0–7) to `locations.json`, one per
+  area, in the matching area region.
+- Added `BOSS_DEFEAT = 2` to `LocationCategory` enum in `data.py`.
+
+**Client**
+- `_location_ids_by_bit` is now filtered to `SHARD` category only.
+- New `_boss_location_ids_by_bit` maps BOSS_DEFEAT category locations.
+- New `_poll_boss_defeat_locations()` reads `boss_defeat_flags` and sends
+  AP location checks for set bits, level-based and reconnect-safe.
+
+### Evidence trail
+- **Claim**: beating a boss runs `sub_0801D948` which calls `CollectShard(var->unk218)`.
+- **Source**: `d:\kirbyam-extras\katam\src\code_0801C6F8.c` lines 703–705;
+  `CollectShard` definition at `d:\kirbyam-extras\katam\src\treasures.c` line 41.
+- **Adaptation**: ROM hook (replacing the `BL CollectShard` with `BL ap_set_boss_defeat_flag`)
+  is deferred pending patch-site byte verification via Issue #110. The transport
+  register, AP locations, and client polling are fully wired so no client-side
+  change is required when the hook is eventually installed.
+- **Validation**: 2 new tests (boss defeat send + no-resend), 29+ tests passing.
+
+### Remaining work (post-#35)
+- Install the `sub_0801D948` ROM hook in `patch_rom.py` once the exact BL
+  instruction byte offset inside the function is confirmed via live BizHawk
+  inspection.  That step decouples the shard grant and enables real boss-defeat
+  location checks in gameplay.

--- a/worlds/kirbyam/kirby_ap_payload/ap_payload.c
+++ b/worlds/kirbyam/kirby_ap_payload/ap_payload.c
@@ -17,6 +17,12 @@
 
 // Shard State Registers
 #define AP_SHARD_BITFIELD       (*(volatile uint32_t*)(AP_BASE + 0x00u))
+// Boss Defeat Transport Register (Issue #35: Boss-defeat locations with shard-delivery decoupling)
+// Written by ROM payload when an area boss is defeated; polled by Python client for location checks.
+// Bit N set <=> boss of area N was defeated (same bit ordering as shard_bitfield, bits 0-7 used).
+// TODO: Call ap_set_boss_defeat_flag(boss_index) from the hook at sub_0801D948 (ROM addr 0x0801D948)
+//       once the exact patch-site byte offset is confirmed via Issue #110 address verification.
+#define AP_BOSS_DEFEAT_FLAGS    (*(volatile uint32_t*)(AP_BASE + 0x24u))
 #define KIRBY_SHARD_FLAGS_ADDR  0x02038970u
 #define KIRBY_SHARD_FLAGS       (*(volatile uint8_t*)(KIRBY_SHARD_FLAGS_ADDR))
 
@@ -60,6 +66,18 @@ static void persist_shard_to_sram(uint8_t new_shard_bitfield) {
     SRAM_CHECKSUM_3 = (uint8_t)(SRAM_CHECKSUM_1 + SRAM_CHECKSUM_2); // Derived checksum
 }
 
+
+// Issue #35: Set the boss-defeat flag for <boss_index> (0–7) in the transport register.
+// This function is the intended hook target for sub_0801D948 (ROM address 0x0801D948):
+//   intercept the CollectShard(var->unk218) call site, call this instead, and let AP
+//   item delivery (SHARD_N) grant the actual shard progression.
+// Until the ROM hook is installed, AP_BOSS_DEFEAT_FLAGS stays at zero; the Python
+// client will receive no boss-defeat checks but will not regress any existing behavior.
+static void ap_set_boss_defeat_flag(uint32_t boss_index) {
+    if (boss_index < 8u) {
+        AP_BOSS_DEFEAT_FLAGS |= (1u << boss_index);
+    }
+}
 
 static void ap_apply_item(uint32_t ap_item_id) {
     // 1_UP = BASE+1

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -617,3 +617,84 @@ async def test_game_watcher_skips_all_work_when_slot_data_is_none(mock_bizhawk_c
     with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
         await client.game_watcher(mock_bizhawk_context)
         mock_read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_boss_defeat_sends_location_checks_for_set_bits(mock_bizhawk_context):
+    """Boss defeat transport register with a set bit should produce a LocationChecks send."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.transport_ram_addresses, {"boss_defeat_flags": 0x0202C024}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        # Bit 0 set — Mustard Mountain boss defeated
+        mock_read.return_value = [(0x01).to_bytes(4, 'little')]
+
+        await client._poll_boss_defeat_locations(mock_bizhawk_context)
+
+        mock_send.assert_awaited_once_with([
+            {"cmd": "LocationChecks", "locations": [boss1_loc]}
+        ])
+
+
+@pytest.mark.asyncio
+async def test_poll_boss_defeat_skips_already_server_acknowledged(mock_bizhawk_context):
+    """No LocationChecks sent when boss defeat bit is set but server already acknowledged it."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
+    mock_bizhawk_context.checked_locations = {boss1_loc}
+
+    with patch.dict(data.transport_ram_addresses, {"boss_defeat_flags": 0x0202C024}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.return_value = [(0x01).to_bytes(4, 'little')]
+
+        await client._poll_boss_defeat_locations(mock_bizhawk_context)
+
+        mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_boss_defeat_skips_when_address_missing(mock_bizhawk_context):
+    """When boss_defeat_flags address is not in addresses.json the method should no-op."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    native_backup = dict(data.transport_ram_addresses)
+    transport_without_boss = {k: v for k, v in data.transport_ram_addresses.items() if k != "boss_defeat_flags"}
+
+    with patch.dict(data.transport_ram_addresses, transport_without_boss, clear=True), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        await client._poll_boss_defeat_locations(mock_bizhawk_context)
+        mock_read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shard_poll_does_not_trigger_boss_defeat_locations(mock_bizhawk_context):
+    """Shard bitfield polling must not send boss-defeat location checks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.native_ram_addresses, {}, clear=True), \
+         patch.dict(data.transport_ram_addresses, {"shard_bitfield": 0x0202C000}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        # bit 0 set in shard bitfield
+        mock_read.return_value = [(0x01).to_bytes(4, 'little')]
+
+        await client._poll_locations(mock_bizhawk_context)
+
+        # Should only send SHARD_1, not BOSS_DEFEAT_1
+        calls = mock_send.await_args_list
+        assert len(calls) == 1
+        sent_locations = calls[0].args[0][0]["locations"]
+        assert boss1_loc not in sent_locations


### PR DESCRIPTION
## Summary
- add new BOSS_DEFEAT location category and define BOSS_DEFEAT_1..BOSS_DEFEAT_8 locations
- add boss_defeat_flags transport register (0x0202C024) to protocol/data maps and poll it from the BizHawk client
- keep shard polling isolated to SHARD locations and add dedicated boss-defeat polling path
- add payload-side boss-defeat flag helper stub (p_set_boss_defeat_flag) and protocol/docs/test coverage

## Evidence Trail
- Claim: boss defeat should be tracked independently from shard collection and surfaced as distinct checks.
- Source: katam decomp shows sub_0801D948 calling CollectShard(var->unk218); CollectShard sets shard bitfield (gTreasures.shardField |= 1 << x).
- Adaptation: Archipelago layer introduces separate transport bitfield (oss_defeat_flags) and location category (BOSS_DEFEAT) so shard checks and boss-defeat checks can be handled independently.
- Validation: pytest worlds/kirbyam/test/test_client.py -q (33 passed); payload build from worlds/kirbyam/kirby_ap_payload/Makefile (make: up-to-date).

## Notes
- payload helper is intentionally a stub for hook wiring at the verified ROM patch site in sub_0801D948.
- VS Code task Build payload currently runs make at repository root and fails because the Makefile is under worlds/kirbyam/kirby_ap_payload.

Closes #35