### PR TITLE
Issue #58: eliminate duplicate LocationChecks with explicit diagnostics

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -153,6 +153,8 @@ Bits 8-31 are reserved for future expansion and must be ignored until they are a
 - No checks are sent for bits already in `server_checked_locations`.
 - No checks are sent for reserved/unmapped bits even when set.
 - Client logs resend reasons when RAM-derived checks are missing on server and logs dedupe suppression when all RAM-derived checks are already acknowledged.
+- Diagnostics are transition-based to avoid per-tick log spam when mapped state is unchanged.
+- Boss-defeat polling follows the same level-based resend/dedupe diagnostic contract.
 
 ### 3. Item Delivery (Mailbox Protocol)
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -78,6 +78,10 @@ class KirbyAmClient(BizHawkClient):
         # Runtime gameplay-state gate tracking
         self._last_runtime_gate_reason: str | None = None
 
+        # Poll diagnostics de-duplication (avoid per-tick log spam)
+        self._last_shard_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._last_boss_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         """Validate ROM is Kirby & The Amazing Mirror and initialize client."""
         from CommonClient import logger
@@ -299,19 +303,29 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             from CommonClient import logger
 
-            logger.info(
-                "KirbyAM: resending RAM-derived LocationChecks missing on server (missing=%s, acked=%s)",
-                missing_on_server,
-                already_acknowledged,
-            )
+            shard_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if shard_log_state != self._last_shard_poll_log:
+                logger.info(
+                    "KirbyAM: resending RAM-derived LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                )
+                self._last_shard_poll_log = shard_log_state
+
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             from CommonClient import logger
 
-            logger.debug(
-                "KirbyAM: dedupe suppressed LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                already_acknowledged,
-            )
+            shard_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if shard_log_state != self._last_shard_poll_log:
+                logger.debug(
+                    "KirbyAM: dedupe suppressed LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_shard_poll_log = shard_log_state
+
+        else:
+            self._last_shard_poll_log = None
 
     async def _poll_boss_defeat_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
@@ -333,8 +347,32 @@ class KirbyAmClient(BizHawkClient):
                 mapped_checked_locations.update(self._boss_location_ids_by_bit.get(bit, []))
 
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+        already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
+            from CommonClient import logger
+
+            boss_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if boss_log_state != self._last_boss_poll_log:
+                logger.info(
+                    "KirbyAM: resending boss-defeat LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                )
+                self._last_boss_poll_log = boss_log_state
+
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+        elif mapped_checked_locations:
+            from CommonClient import logger
+
+            boss_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if boss_log_state != self._last_boss_poll_log:
+                logger.debug(
+                    "KirbyAM: dedupe suppressed boss-defeat LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_boss_poll_log = boss_log_state
+        else:
+            self._last_boss_poll_log = None
 
     async def _probe_boss_defeat_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -352,6 +352,8 @@ reconnect-safe behavior:
 
 - Log resend reason when RAM-derived checks are missing from server state.
 - Log dedupe suppression when all RAM-derived checks are already acknowledged.
+- Apply the same resend/dedupe diagnostics pattern to boss-defeat polling.
+- Make diagnostics transition-based so unchanged states do not spam logs each tick.
 
 This keeps canonical dedupe boundaries at AP location ID level while making
 reconnect behavior easier to debug.

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -159,6 +159,8 @@ async def test_location_check_resent_when_server_missing_location(mock_bizhawk_c
         ])
         assert mock_logger.info.called
         assert "resending RAM-derived LocationChecks missing on server" in mock_logger.info.call_args.args[0]
+        assert mock_logger.info.call_args.args[1] == [second_loc]
+        assert mock_logger.info.call_args.args[2] == [first_loc]
 
 
 @pytest.mark.asyncio
@@ -182,6 +184,7 @@ async def test_no_location_checks_sent_when_all_already_server_acknowledged(mock
         mock_send.assert_not_awaited()
         assert mock_logger.debug.called
         assert "dedupe suppressed LocationChecks" in mock_logger.debug.call_args.args[0]
+        assert mock_logger.debug.call_args.args[1] == [shard1, shard2]
 
 
 def test_client_initialization():
@@ -770,7 +773,8 @@ async def test_poll_boss_defeat_sends_location_checks_for_set_bits(mock_bizhawk_
 
     with patch.dict(data.transport_ram_addresses, {"boss_defeat_flags": 0x0202C024}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
         # Bit 0 set — Mustard Mountain boss defeated
         mock_read.return_value = [(0x01).to_bytes(4, 'little')]
 
@@ -779,6 +783,9 @@ async def test_poll_boss_defeat_sends_location_checks_for_set_bits(mock_bizhawk_
         mock_send.assert_awaited_once_with([
             {"cmd": "LocationChecks", "locations": [boss1_loc]}
         ])
+        assert mock_logger.info.called
+        assert "resending boss-defeat LocationChecks missing on server" in mock_logger.info.call_args.args[0]
+        assert mock_logger.info.call_args.args[1] == [boss1_loc]
 
 
 @pytest.mark.asyncio
@@ -792,12 +799,16 @@ async def test_poll_boss_defeat_skips_already_server_acknowledged(mock_bizhawk_c
 
     with patch.dict(data.transport_ram_addresses, {"boss_defeat_flags": 0x0202C024}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
         mock_read.return_value = [(0x01).to_bytes(4, 'little')]
 
         await client._poll_boss_defeat_locations(mock_bizhawk_context)
 
         mock_send.assert_not_awaited()
+        assert mock_logger.debug.called
+        assert "dedupe suppressed boss-defeat LocationChecks" in mock_logger.debug.call_args.args[0]
+        assert mock_logger.debug.call_args.args[1] == [boss1_loc]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- keep level-based location polling and AP location-id dedupe semantics\n- add explicit logs when RAM-derived checks are resent because server state is missing them\n- add explicit logs when dedupe suppresses sends because all RAM-derived checks are already acknowledged\n- add tests for resend logging and dedupe suppression logging\n- update protocol/docs notes to reflect the diagnostics contract\n\n## Validation\n- python -m pytest worlds/kirbyam/test/test_client.py -q\n- result: 40 passed\n\nCloses #58