### PR TITLE
Issue #198: Fix BizHawk reconnect probe baselining (stream object identity)

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -77,7 +77,7 @@ class KirbyAmClient(BizHawkClient):
 
         # Boss candidate probing state
         self._last_boss_probe_snapshot: bytes | None = None
-        self._boss_probe_stream_marker: int | None = None
+        self._boss_probe_stream_marker: object = None
 
         # Runtime gameplay-state gate tracking
         self._last_runtime_gate_reason: str | None = None
@@ -87,7 +87,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_boss_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Research-first unsafe-delivery candidate probing state (Issue #223)
-        self._unsafe_delivery_probe_stream_marker: int | None = None
+        self._unsafe_delivery_probe_stream_marker: object = None
         self._last_unsafe_delivery_counter_values: dict[str, int] = {}
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
@@ -397,10 +397,12 @@ class KirbyAmClient(BizHawkClient):
             return
 
         # Re-baseline on BizHawk reconnect by tracking the stream object identity.
-        stream_marker = id(getattr(ctx.bizhawk_ctx, "streams", None))
+        # Use direct object reference (not id()) to prevent false negatives when CPython
+        # reuses an integer ID for a newly allocated stream after the old one is GC'd.
+        stream_marker = getattr(ctx.bizhawk_ctx, "streams", None)
         if self._boss_probe_stream_marker is None:
             self._boss_probe_stream_marker = stream_marker
-        elif stream_marker != self._boss_probe_stream_marker:
+        elif stream_marker is not self._boss_probe_stream_marker:
             self._boss_probe_stream_marker = stream_marker
             self._last_boss_probe_snapshot = None
 
@@ -461,10 +463,10 @@ class KirbyAmClient(BizHawkClient):
         if not reads:
             return
 
-        stream_marker = id(getattr(ctx.bizhawk_ctx, "streams", None))
+        stream_marker = getattr(ctx.bizhawk_ctx, "streams", None)
         if self._unsafe_delivery_probe_stream_marker is None:
             self._unsafe_delivery_probe_stream_marker = stream_marker
-        elif stream_marker != self._unsafe_delivery_probe_stream_marker:
+        elif stream_marker is not self._unsafe_delivery_probe_stream_marker:
             self._unsafe_delivery_probe_stream_marker = stream_marker
             self._last_unsafe_delivery_counter_values = {}
 


### PR DESCRIPTION
Closes #198

## Problem
Both `_probe_boss_defeat_candidates` and `_probe_unsafe_delivery_candidates` used `id()` integer values to track whether the BizHawk stream object had changed between calls. CPython's garbage collector can reuse integer IDs: if the old stream object is freed before a new stream is allocated, the new object may get the same `id()`. This causes a false-negative — the client does not detect the reconnect and skips rebaselining the probe snapshot, potentially logging spurious rising-edge transitions as if they were new game events.

## Fix
- Store the stream object itself (via `getattr(ctx.bizhawk_ctx, "streams", None)`) in the stream-marker field instead of its integer `id()`.
- Compare with `is not` instead of `!=`.
- Holding a reference to the old stream object prevents CPython from GC'ing it before the marker is overwritten, so a newly created stream cannot receive the same `id()`.

## Changes
- `worlds/kirbyam/client.py`: Changed `_boss_probe_stream_marker` and `_unsafe_delivery_probe_stream_marker` type annotations from `int | None` to `object`. Changed both probe methods to use `getattr(...)` directly (no `id()`) and `is not` comparison.

## Tests
All 43 existing tests pass. The two existing rebaseline tests (`test_probe_boss_candidates_resets_baseline_on_stream_change`, `test_probe_unsafe_delivery_candidates_rebaseline_on_stream_change`) already exercise the correct behavior — they use distinct `object()` instances which the object-identity approach (and the old `id()` approach in tests where both objects are alive simultaneously) both handle correctly. The fix eliminates the CPython id-reuse edge case that only manifests in live reconnect scenarios.