### PR TITLE
Issue #83: design and implement in-game receive/send notification pipeline

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -187,6 +187,34 @@ Research-first note for Issue #223:
 - Delivery remains gated only by the gameplay-active contract from Issue #56.
 - Candidate miniboss/travel probes must not suppress delivery until their semantics are repeatably verified.
 
+### 3.1 Player Notification Pipeline (Issue #83)
+
+KirbyAM now defines a player-facing notification pipeline for item traffic,
+using BizHawk text rendering for Phase 1.
+
+Event sources:
+- Receive notifications: emitted on mailbox ACK completion for a delivered
+    `ctx.items_received` index.
+- Send notifications: emitted from `PrintJSON` packets when `type == "ItemSend"`
+    and the local slot is the sender.
+
+Display strategy:
+- Phase 1: BizHawk connector text path (`display_message`).
+- Phase 2 (future): native ROM/UI display only after stable hooks are verified.
+
+Reconnect-safe dedupe:
+- Receive dedupe key: delivered index.
+- Send dedupe key: `(item_id, sender_id, receiver_id, location_id)`.
+- Dedupe state is session-local and suppresses reconnect replay spam.
+
+Optional slot-data toggles (default: enabled when absent):
+- `enable_receive_notifications`
+- `enable_send_notifications`
+
+Notification rendering is non-blocking for gameplay protocol behavior.
+Delivery, location checks, and goal reporting continue even if notification
+rendering fails.
+
 ### 4. Goal Reporting
 
 **Current Implementation (native AI-state polling):**

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
+import Utils
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
 
@@ -38,6 +39,7 @@ class KirbyAmClient(BizHawkClient):
         self._delivered_item_index: int = 0
         self._delivery_pending: bool = False  # True after writing mailbox until ROM clears flag
         self._delivery_pending_frame: int | None = None
+        self._delivery_pending_item_index: int | None = None
 
         # Deterministic location ordering
         self._all_location_ids_sorted: list[int] = [
@@ -87,6 +89,13 @@ class KirbyAmClient(BizHawkClient):
         self._last_shard_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_boss_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
+        # Notification pipeline state (Issue #83)
+        self._notification_settings_loaded: bool = False
+        self._receive_notifications_enabled: bool = True
+        self._send_notifications_enabled: bool = True
+        self._notified_receive_indices: set[int] = set()
+        self._notified_send_keys: set[tuple[int, int, int, int]] = set()
+
         # Research-first unsafe-delivery candidate probing state (Issue #223)
         self._unsafe_delivery_probe_stream_marker: object = None
         self._last_unsafe_delivery_counter_values: dict[str, int] = {}
@@ -116,6 +125,128 @@ class KirbyAmClient(BizHawkClient):
         self._boss_probe_stream_marker = None
         self._unsafe_delivery_probe_stream_marker = None
         self._last_unsafe_delivery_counter_values = {}
+
+    @staticmethod
+    def _coerce_bool(value: object, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"1", "true", "yes", "on"}:
+                return True
+            if lowered in {"0", "false", "no", "off"}:
+                return False
+        return default
+
+    def _load_notification_settings(self, ctx: "BizHawkClientContext") -> None:
+        if self._notification_settings_loaded:
+            return
+
+        slot_data = getattr(ctx, "slot_data", None)
+        if isinstance(slot_data, dict):
+            self._receive_notifications_enabled = self._coerce_bool(
+                slot_data.get("enable_receive_notifications", True),
+                True,
+            )
+            self._send_notifications_enabled = self._coerce_bool(
+                slot_data.get("enable_send_notifications", True),
+                True,
+            )
+
+        self._notification_settings_loaded = True
+
+    @staticmethod
+    def _player_name(ctx: "BizHawkClientContext", player_id: int) -> str:
+        player_names = getattr(ctx, "player_names", None)
+        if isinstance(player_names, dict):
+            value = player_names.get(player_id)
+            if isinstance(value, str) and value:
+                return value
+        return f"Player {player_id}"
+
+    @staticmethod
+    def _item_name(ctx: "BizHawkClientContext", item_id: int, item_player: int) -> str:
+        lookup = getattr(ctx, "item_names", None)
+        if lookup is not None:
+            try:
+                resolved = lookup.lookup_in_slot(item_id, item_player)
+                if isinstance(resolved, str) and resolved:
+                    return resolved
+            except Exception:
+                pass
+        return f"Item {item_id}"
+
+    async def _emit_receive_notification(self, ctx: "BizHawkClientContext", delivered_index: int) -> None:
+        if not self._receive_notifications_enabled:
+            return
+        if delivered_index in self._notified_receive_indices:
+            return
+        if delivered_index < 0 or delivered_index >= len(ctx.items_received):
+            return
+
+        item = ctx.items_received[delivered_index]
+        item_fields = self._extract_delivery_item_fields(item)
+        if item_fields is None:
+            return
+
+        self._notified_receive_indices.add(delivered_index)
+        item_id, player_id = item_fields
+        item_name = self._item_name(ctx, item_id, player_id)
+        sender_name = self._player_name(ctx, player_id)
+        message = f"Received {item_name} from {sender_name}"
+
+        from CommonClient import logger
+
+        logger.info(
+            "KirbyAM: receive notification queued (index=%s, item=%s, sender=%s)",
+            delivered_index,
+            item_name,
+            sender_name,
+        )
+        try:
+            await bizhawk.display_message(ctx.bizhawk_ctx, message)
+        except Exception:
+            logger.warning(
+                "KirbyAM: failed to emit receive notification (index=%s)",
+                delivered_index,
+            )
+
+    def _maybe_emit_send_notification(self, ctx: "BizHawkClientContext", args: dict) -> None:
+        if not self._send_notifications_enabled:
+            return
+        if args.get("type") != "ItemSend":
+            return
+
+        item = args.get("item")
+        if item is None:
+            return
+
+        item_id = self._coerce_u32(getattr(item, "item", None))
+        sender_id = self._coerce_u32(getattr(item, "player", None))
+        receiver_id = self._coerce_u32(args.get("receiving"))
+        location_id = self._coerce_u32(getattr(item, "location", None))
+        if item_id is None or sender_id is None or receiver_id is None:
+            return
+        if sender_id != getattr(ctx, "slot", None):
+            return
+
+        send_key = (item_id, sender_id, receiver_id, location_id if location_id is not None else 0xFFFFFFFF)
+        if send_key in self._notified_send_keys:
+            return
+        self._notified_send_keys.add(send_key)
+
+        item_name = self._item_name(ctx, item_id, sender_id)
+        receiver_name = self._player_name(ctx, receiver_id)
+        message = f"Sent {item_name} to {receiver_name}"
+
+        from CommonClient import logger
+
+        logger.info(
+            "KirbyAM: send notification queued (item=%s, receiver=%s)",
+            item_name,
+            receiver_name,
+        )
+        Utils.async_start(bizhawk.display_message(ctx.bizhawk_ctx, message))
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         """Validate ROM is Kirby & The Amazing Mirror and initialize client."""
@@ -161,6 +292,8 @@ class KirbyAmClient(BizHawkClient):
         if not self._server_session_ready(ctx):
             self._watcher_server_ready = False
             return
+
+        self._load_notification_settings(ctx)
 
         if not self._watcher_server_ready:
             logger.info("KirbyAM: AP session ready; reconnect-safe reconciliation active")
@@ -577,6 +710,7 @@ class KirbyAmClient(BizHawkClient):
                     await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
+                self._delivery_pending_item_index = None
                 return
             if rom_received_count < self._delivered_item_index:
                 logger.info(
@@ -587,6 +721,7 @@ class KirbyAmClient(BizHawkClient):
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
+                self._delivery_pending_item_index = None
                 await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
             elif rom_received_count > self._delivered_item_index and rom_received_count <= len(ctx.items_received):
                 logger.info(
@@ -597,6 +732,7 @@ class KirbyAmClient(BizHawkClient):
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
+                self._delivery_pending_item_index = None
                 await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
                 if flag != 0:
                     logger.warning(
@@ -610,14 +746,19 @@ class KirbyAmClient(BizHawkClient):
         # If an item is pending, wait for ROM to clear the flag (ACK)
         if self._delivery_pending:
             if flag == 0:
+                delivered_index = self._delivery_pending_item_index
+                if delivered_index is None:
+                    delivered_index = self._delivered_item_index
                 logger.info("KirbyAM: Mailbox ACK observed at item index %s", self._delivered_item_index)
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
+                self._delivery_pending_item_index = None
                 if rom_received_count is not None and rom_received_count <= len(ctx.items_received):
                     self._delivered_item_index = rom_received_count
                 else:
                     self._delivered_item_index += 1
                 await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
+                await self._emit_receive_notification(ctx, delivered_index)
                 return
 
             if current_frame is not None and self._delivery_pending_frame is not None:
@@ -633,6 +774,7 @@ class KirbyAmClient(BizHawkClient):
                     ])
                     self._delivery_pending = False
                     self._delivery_pending_frame = None
+                    self._delivery_pending_item_index = None
             return
 
         # No pending item; mailbox must be empty to write
@@ -658,6 +800,7 @@ class KirbyAmClient(BizHawkClient):
                 )
                 self._delivered_item_index += 1
                 self._delivery_pending = False
+                self._delivery_pending_item_index = None
                 await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
                 continue
 
@@ -676,6 +819,7 @@ class KirbyAmClient(BizHawkClient):
             ])
             self._delivery_pending = True
             self._delivery_pending_frame = current_frame
+            self._delivery_pending_item_index = self._delivered_item_index
             return
 
     # --------------------------
@@ -787,3 +931,9 @@ class KirbyAmClient(BizHawkClient):
             logger.info("KirbyAM: goal complete; sending CLIENT_GOAL status (goal_option=%s)", slot_goal)
             await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
             self._goal_reported = True
+
+    def on_package(self, ctx: "BizHawkClientContext", cmd: str, args: dict) -> None:
+        if not self._notification_settings_loaded:
+            self._load_notification_settings(ctx)
+        if cmd == "PrintJSON":
+            self._maybe_emit_send_notification(ctx, args)

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -21,6 +21,8 @@
 | `KirbyAM: Mailbox ACK observed at item index N` | ROM cleared the flag; delivery confirmed. |
 | `KirbyAM: ROM item counter regressed from X to Y; rewinding delivery cursor` | ROM reported fewer items received than expected; cursor rewound. |
 | `KirbyAM: ROM item counter advanced from X to Y; fast-forwarding delivery cursor` | ROM is ahead of client cursor; cursor fast-forwarded. |
+| `KirbyAM: receive notification queued (index=N, item=..., sender=...)` | Receive notification was queued after mailbox ACK for delivered index `N`. |
+| `KirbyAM: send notification queued (item=..., receiver=...)` | Outgoing ItemSend notification was queued for local sender traffic. |
 | `KirbyAM: native goal signal seen (goal_option=N)` | Native ai_kirby_state value matched the selected goal condition for the first time. |
 | `KirbyAM: sending goal location check (location_id=N)` | Goal location check sent to server. |
 | `KirbyAM: goal complete; sending CLIENT_GOAL status (goal_option=N)` | Server acknowledged goal location; CLIENT_GOAL status sent. |
@@ -69,6 +71,22 @@ Validate that non-gameplay states defer location polling and new mailbox writes.
 Expected signal source for this gate:
 - ai_kirby_state_native at 0x0203AD2C (u32)
 - gameplay-active only when value == 300
+
+## Notification Pipeline Check (Issue #83)
+
+Validate receive/send notifications and reconnect dedupe behavior.
+
+1. Connect AP + BizHawk session with logs visible.
+2. Receive at least one remote item and confirm notification text appears once.
+3. Trigger at least one outgoing ItemSend (local check sending to another player) and confirm send text appears once.
+4. Disconnect/reconnect AP client session.
+5. Confirm previously shown receive/send notifications are not replay-spammed after reconnect.
+6. Trigger one new receive and one new send event; confirm both still notify.
+
+Expected behavior:
+- Receive notification trigger: mailbox ACK for newly delivered index.
+- Send notification trigger: local-sender `PrintJSON` ItemSend packet.
+- Reconnect-safe dedupe prevents repeats for previously shown events.
 
 ## Unsafe Delivery Candidate Research (Issue #223)
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -195,6 +195,44 @@ Reconnect windows can temporarily expose partial AP context state (for example, 
 - Added tests for watcher no-op when socket is missing or closed.
 - Added test that reconnect-entry resets transient state and only logs readiness once per session-ready transition.
 
+## Issue #83: In-Game Notification Pipeline (Receive + Send)
+
+### Problem
+KirbyAM processed delivery and ItemSend traffic without a dedicated player-facing
+notification contract, which made receive/send events opaque in normal play.
+
+### Solution
+- Added a KirbyAM notification pipeline with two event sources:
+  - Receive notifications on mailbox ACK completion for delivered indexes.
+  - Send notifications from `PrintJSON` `ItemSend` packets when local slot is
+    the sender.
+- Added reconnect-safe dedupe state:
+  - Receive dedupe by delivered index.
+  - Send dedupe by `(item_id, sender_id, receiver_id, location_id)` tuple.
+- Added optional slot-data toggles (default enabled):
+  - `enable_receive_notifications`
+  - `enable_send_notifications`
+- Phase 1 display path uses BizHawk `display_message`.
+
+### #73 Implementation-Ready Criteria (Receive)
+- Notification must trigger only after mailbox ACK for a newly delivered index.
+- Notification content must include item + sender context when resolvable.
+- Reconnect/resync must not replay already shown receive notifications.
+
+### #74 Implementation-Ready Criteria (Send)
+- Notification must trigger only when local slot is ItemSend sender.
+- Unrelated ItemSend packets must not notify locally.
+- Reconnect replay/echoes must dedupe and avoid spam.
+
+### Test Plan Baseline
+- Automated:
+  - receive notification trigger + dedupe tests
+  - send `PrintJSON` local-sender trigger + dedupe tests
+  - toggle-off suppression tests
+- Manual BizHawk:
+  - verify readable receive/send notifications
+  - verify reconnect does not replay old notifications
+
 ## Issue #44: Final Boss Access Rules (Dimension Mirror Sequence)
 
 ### Problem

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -599,6 +599,93 @@ async def test_goal_reporting_logs_client_goal_status(mock_bizhawk_context):
 
 
 @pytest.mark.asyncio
+async def test_receive_notification_emits_once_per_delivery_index(mock_bizhawk_context):
+    """Receive notification should fire on ACK once per delivered item index."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.items_received = [Mock(item=3860001, player=2)]
+    mock_bizhawk_context.player_names = {2: "PlayerTwo"}
+    mock_bizhawk_context.item_names = Mock()
+    mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
+
+    client._delivery_pending = True
+    client._delivery_pending_item_index = 0
+    client._delivered_item_index = 0
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock), \
+         patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display:
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (0).to_bytes(4, 'little'),
+        ]
+
+        await client._deliver_items(mock_bizhawk_context)
+
+        # Simulate an ACK replay for the same pending index; should dedupe.
+        client._delivery_pending = True
+        client._delivery_pending_item_index = 0
+        client._delivered_item_index = 0
+        await client._deliver_items(mock_bizhawk_context)
+
+    mock_display.assert_awaited_once_with(
+        mock_bizhawk_context.bizhawk_ctx,
+        "Received Mirror Shard from PlayerTwo",
+    )
+
+
+@pytest.mark.asyncio
+async def test_receive_notification_honors_slot_data_toggle(mock_bizhawk_context):
+    """Receive notifications should be suppressible by slot-data toggle."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.slot_data["enable_receive_notifications"] = False
+    mock_bizhawk_context.items_received = [Mock(item=3860001, player=2)]
+    mock_bizhawk_context.player_names = {2: "PlayerTwo"}
+    mock_bizhawk_context.item_names = Mock()
+    mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
+
+    client._load_notification_settings(mock_bizhawk_context)
+
+    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display:
+        await client._emit_receive_notification(mock_bizhawk_context, 0)
+
+    mock_display.assert_not_awaited()
+
+
+def test_send_notification_dedupes_outgoing_printjson_events(mock_bizhawk_context):
+    """Outgoing ItemSend PrintJSON should notify once and dedupe reconnect echoes."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.slot = 1
+    mock_bizhawk_context.player_names = {2: "PlayerTwo"}
+    mock_bizhawk_context.item_names = Mock()
+    mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
+
+    item_payload = Mock(item=3860001, player=1, location=123)
+    printjson_payload = {
+        "type": "ItemSend",
+        "item": item_payload,
+        "receiving": 2,
+    }
+
+    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display, \
+         patch('worlds.kirbyam.client.Utils.async_start') as mock_async_start:
+        mock_async_start.side_effect = lambda coro: coro.close()
+
+        client.on_package(mock_bizhawk_context, "PrintJSON", printjson_payload)
+        client.on_package(mock_bizhawk_context, "PrintJSON", printjson_payload)
+
+    assert mock_async_start.call_count == 1
+    assert mock_display.call_count == 1
+    display_args = mock_display.call_args.args
+    assert display_args[1] == "Sent Mirror Shard to PlayerTwo"
+
+
+@pytest.mark.asyncio
 async def test_probe_boss_candidates_logs_rising_edges(mock_bizhawk_context):
     """Boss probe should log rising bit transitions for candidate mapping."""
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary

Closes #83.

Implements a KirbyAM notification pipeline architecture for both receive and send item traffic, with reconnect-safe dedupe semantics and BizHawk Phase 1 display path.

## What changed

### Client pipeline
- Added receive notifications on mailbox ACK completion for delivered item indexes.
- Added send notifications from PrintJSON ItemSend packets when local slot is sender.
- Added reconnect-safe dedupe state:
  - receive dedupe by delivered index
  - send dedupe by (item_id, sender_id, receiver_id, location_id)
- Added optional slot-data toggles (default enabled when absent):
  - nable_receive_notifications
  - nable_send_notifications
- Notification display uses BizHawk display_message and does not block core delivery/polling/goal flow.

### Tests
- Added tests for:
  - receive-notification exactly-once behavior per delivered index
  - receive toggle suppression
  - send PrintJSON local-sender dedupe behavior
- Kept full regression coverage green.

### Documentation
- PROTOCOL.md: added notification pipeline contract section with event sources, dedupe keys, toggles, and non-blocking behavior.
- docs/BIZHAWK_TESTING_GUIDE.md: added notification log lines and manual validation sequence.
- docs/notes.md: added Issue #83 architecture notes plus implementation-ready criteria/test-plan baseline for #73 and #74.

## Validation
- pytest worlds/kirbyam/test/test_client.py -q -> 50 passed
- pytest worlds/kirbyam/test/ -q -> 82 passed

## Evidence trail
- Claim: provide player-facing receive/send notifications with reconnect-safe semantics.
- Source: issue #83 requirements + BizHawk display path in worlds/_bizhawk/context.py.
- Adaptation: integrated into KirbyAM client delivery ACK and PrintJSON handling with explicit dedupe keys and slot-data toggles.
- Validation: targeted + full KirbyAM test suite results above.