### PR TITLE
Issue #74: implement local outgoing send notifications

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -220,6 +220,15 @@ Notification rendering is non-blocking for gameplay protocol behavior.
 Delivery, location checks, and goal reporting continue even if notification
 rendering fails.
 
+Send-specific contract (Issue #74):
+- Send notifications emit only for `PrintJSON` `ItemSend` packets where local
+    slot is the sender.
+- Unrelated ItemSend packets between other players are ignored.
+- Burst rate limit policy:
+    - at most 5 send notifications per 2-second window
+    - additional sends in the same window are suppressed
+    - a summary message reports suppressed count when the window rolls over
+
 ### 4. Goal Reporting
 
 **Current Implementation (native AI-state polling):**

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
+import time
 import Utils
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
@@ -24,6 +25,8 @@ _OPTIONAL_UNSAFE_DELIVERY_COUNTERS = (
     ("shadow_kirby_encounters_native", "shadow_kirby_encounters"),
     ("mirra_encounters_native", "mirra_encounters"),
 )
+_SEND_NOTIFY_WINDOW_SECONDS = 2.0
+_SEND_NOTIFY_MAX_PER_WINDOW = 5
 
 
 class KirbyAmClient(BizHawkClient):
@@ -95,6 +98,9 @@ class KirbyAmClient(BizHawkClient):
         self._send_notifications_enabled: bool = True
         self._notified_receive_indices: set[int] = set()
         self._notified_send_keys: set[tuple[int, int, int, int]] = set()
+        self._send_notify_window_start: float = 0.0
+        self._send_notify_window_count: int = 0
+        self._send_notify_window_suppressed: int = 0
 
         # Research-first unsafe-delivery candidate probing state (Issue #223)
         self._unsafe_delivery_probe_stream_marker: object = None
@@ -244,6 +250,34 @@ class KirbyAmClient(BizHawkClient):
         message = f"Sent {item_name} to {receiver_name}"
 
         from CommonClient import logger
+
+        now = time.monotonic()
+        if self._send_notify_window_start == 0.0:
+            self._send_notify_window_start = now
+
+        elapsed = now - self._send_notify_window_start
+        if elapsed >= _SEND_NOTIFY_WINDOW_SECONDS:
+            if self._send_notify_window_suppressed > 0:
+                summary = f"Suppressed {self._send_notify_window_suppressed} send notifications"
+                logger.info(
+                    "KirbyAM: send notification burst suppression summary (suppressed=%s)",
+                    self._send_notify_window_suppressed,
+                )
+                Utils.async_start(bizhawk.display_message(ctx.bizhawk_ctx, summary))
+            self._send_notify_window_start = now
+            self._send_notify_window_count = 0
+            self._send_notify_window_suppressed = 0
+
+        if self._send_notify_window_count >= _SEND_NOTIFY_MAX_PER_WINDOW:
+            self._send_notify_window_suppressed += 1
+            logger.debug(
+                "KirbyAM: send notification suppressed by rate limit (item=%s, receiver=%s)",
+                item_name,
+                receiver_name,
+            )
+            return
+
+        self._send_notify_window_count += 1
 
         logger.info(
             "KirbyAM: send notification queued (item=%s, receiver=%s)",

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -23,6 +23,7 @@
 | `KirbyAM: ROM item counter advanced from X to Y; fast-forwarding delivery cursor` | ROM is ahead of client cursor; cursor fast-forwarded. |
 | `KirbyAM: receive notification queued (index=N, item=..., sender=...)` | Receive notification was queued after mailbox ACK for delivered index `N`. |
 | `KirbyAM: send notification queued (item=..., receiver=...)` | Outgoing ItemSend notification was queued for local sender traffic. |
+| `KirbyAM: send notification burst suppression summary (suppressed=N)` | A send burst exceeded policy; `N` notifications were suppressed in the previous window. |
 | `KirbyAM: native goal signal seen (goal_option=N)` | Native ai_kirby_state value matched the selected goal condition for the first time. |
 | `KirbyAM: sending goal location check (location_id=N)` | Goal location check sent to server. |
 | `KirbyAM: goal complete; sending CLIENT_GOAL status (goal_option=N)` | Server acknowledged goal location; CLIENT_GOAL status sent. |
@@ -92,6 +93,12 @@ Issue #73 receive-focused checks:
 - Skipped malformed items should not produce receive notification text.
 - Cursor fast-forward/rewind reconciliation should not replay old receive notifications.
 - New ACK-completed deliveries after reconnect should still notify exactly once.
+
+Issue #74 send-focused checks:
+- Only local-sender ItemSend events should emit send notification text.
+- ItemSend traffic between other players should not emit local send notifications.
+- During rapid send bursts, notifications should rate-limit (max 5 per 2s) and
+   later report a suppression summary message.
 
 ## Unsafe Delivery Candidate Research (Issue #223)
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -253,6 +253,27 @@ actual mailbox ACK path, not just generic packet flow.
   - reconnect replay dedupe on rewound indexes
   - no notification on fast-forward-only reconciliation
 
+## Issue #74: Send Notifications (Local Outgoing ItemSend Events)
+
+### Problem
+Send notifications needed explicit local-sender filtering and burst handling so
+high-traffic ItemSend scenarios do not spam the player.
+
+### Implementation
+- Send notifications are emitted from `PrintJSON` `ItemSend` packets only when
+  local slot is the sender.
+- Non-local ItemSend traffic is ignored.
+- Dedupe remains key-based on `(item_id, sender_id, receiver_id, location_id)`.
+- Added burst rate-limit policy:
+  - max 5 send notifications per 2-second window
+  - excess sends are suppressed
+  - suppression summary is displayed when window rolls over
+
+### Validation
+- Added targeted tests for:
+  - unrelated ItemSend suppression
+  - burst-rate limiting + suppression summary behavior
+
 ## Issue #44: Final Boss Access Rules (Dimension Mirror Sequence)
 
 ### Problem

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -763,6 +763,71 @@ def test_send_notification_dedupes_outgoing_printjson_events(mock_bizhawk_contex
     assert display_args[1] == "Sent Mirror Shard to PlayerTwo"
 
 
+def test_send_notification_ignores_unrelated_itemsend_traffic(mock_bizhawk_context):
+    """ItemSend traffic not sent by local slot should not emit local send notifications."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.slot = 1
+    mock_bizhawk_context.player_names = {2: "PlayerTwo"}
+    mock_bizhawk_context.item_names = Mock()
+    mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
+
+    unrelated_payload = {
+        "type": "ItemSend",
+        "item": Mock(item=3860001, player=3, location=123),
+        "receiving": 2,
+    }
+
+    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display, \
+         patch('worlds.kirbyam.client.Utils.async_start') as mock_async_start:
+        mock_async_start.side_effect = lambda coro: coro.close()
+        client.on_package(mock_bizhawk_context, "PrintJSON", unrelated_payload)
+
+    assert mock_async_start.call_count == 0
+    assert mock_display.call_count == 0
+
+
+def test_send_notification_rate_limit_suppresses_burst(mock_bizhawk_context):
+    """Burst sends should be rate-limited with summary notification when window rolls over."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.slot = 1
+    mock_bizhawk_context.player_names = {2: "PlayerTwo"}
+    mock_bizhawk_context.item_names = Mock()
+    mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
+
+    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display, \
+         patch('worlds.kirbyam.client.Utils.async_start') as mock_async_start, \
+         patch('worlds.kirbyam.client.time.monotonic') as mock_monotonic:
+        mock_async_start.side_effect = lambda coro: coro.close()
+
+        # First 6 sends inside same 2s window: 5 visible + 1 suppressed.
+        mock_monotonic.return_value = 100.0
+        for idx in range(6):
+            payload = {
+                "type": "ItemSend",
+                "item": Mock(item=3860000 + idx, player=1, location=200 + idx),
+                "receiving": 2,
+            }
+            client.on_package(mock_bizhawk_context, "PrintJSON", payload)
+
+        # Advance time to roll window and flush suppression summary.
+        mock_monotonic.return_value = 103.0
+        payload = {
+            "type": "ItemSend",
+            "item": Mock(item=3860999, player=1, location=999),
+            "receiving": 2,
+        }
+        client.on_package(mock_bizhawk_context, "PrintJSON", payload)
+
+    # 5 visible in first window, 1 summary on rollover, 1 visible after rollover.
+    assert mock_async_start.call_count == 7
+    summary_call = mock_display.call_args_list[-2].args
+    assert summary_call[1] == "Suppressed 1 send notifications"
+
+
 @pytest.mark.asyncio
 async def test_probe_boss_candidates_logs_rising_edges(mock_bizhawk_context):
     """Boss probe should log rising bit transitions for candidate mapping."""


### PR DESCRIPTION
## Summary

Closes #74.

Implements send-side notification behavior for local outgoing ItemSend events, with reconnect-safe dedupe and explicit burst rate-limit policy.

## Changes

### Client behavior
- Send notifications are emitted only for PrintJSON ItemSend packets where local slot is sender.
- Unrelated ItemSend traffic between other players is ignored.
- Existing key-based dedupe remains in place: (item_id, sender_id, receiver_id, location_id).
- Added burst policy to avoid notification storms:
  - max 5 send notifications per 2-second window
  - additional sends are suppressed
  - suppression summary message is shown when window rolls over

### Tests
Added #74-focused tests:
- unrelated ItemSend suppression
- burst rate-limit + suppression summary behavior

### Documentation
- worlds/kirbyam/PROTOCOL.md: send-specific contract and burst policy
- worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md: send-focused verification bullets + summary log line
- worlds/kirbyam/docs/notes.md: dedicated Issue #74 section

## Validation
- pytest worlds/kirbyam/test/test_client.py -q -> 55 passed
- pytest worlds/kirbyam/test/ -q -> 87 passed

## Evidence trail
- Claim: local sender should receive clear send notifications without burst spam.
- Source: issue #74 acceptance criteria + #83 display pipeline architecture.
- Adaptation: sender filtering plus bounded burst window with summary output.
- Validation: targeted and full KirbyAM tests above.