### PR TITLE
Add KirbyAM ability gate logic stubs

### DIFF
--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -10,6 +10,7 @@ import pkgutil
 from dataclasses import dataclass
 from enum import IntEnum
 from importlib import resources
+from pathlib import Path
 from typing import Any, Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple, Union
 
 import orjson
@@ -34,6 +35,10 @@ def _list_data_files(subdir: str) -> list[str]:
 
     Returns file names only (not full paths).
     """
+    source_dir = Path(__file__).with_name("data") / subdir
+    if source_dir.is_dir():
+        return sorted(path.name for path in source_dir.iterdir() if path.is_file())
+
     try:
         base = resources.files(__name__).joinpath("data", subdir)
         if not base.is_dir():
@@ -112,6 +117,7 @@ class RegionData:
     warps: list[str]
     locations: list[str]
     events: list[EventData]
+    ability_gates: dict[str, dict[str, Any]]
 
     def __init__(self, name: str) -> None:
         self.name = name
@@ -119,6 +125,7 @@ class RegionData:
         self.warps = []
         self.locations = []
         self.events = []
+        self.ability_gates = {}
 
 
 class Warp:
@@ -413,6 +420,11 @@ def _init() -> None:
         for ev in region_def.get("events", []):
             if isinstance(ev, str):
                 region.events.append(EventData(ev, region_name))
+
+        # Ability-gate annotations for future chest/transition rollout.
+        for gate_name, gate_def in region_def.get("ability_gates", {}).items():
+            if isinstance(gate_name, str) and isinstance(gate_def, dict):
+                region.ability_gates[gate_name] = dict(gate_def)
 
         # Warps (encoded strings, optional)
         for encoded_warp in region_def.get("warps", []):

--- a/worlds/kirbyam/data/regions/areas.json
+++ b/worlds/kirbyam/data/regions/areas.json
@@ -20,28 +20,96 @@
     "locations": ["SHARD_1", "BOSS_DEFEAT_1"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanUseMini": {
+        "status": "semantic_candidate",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=310 edge_tile_transition_coordinates -> room 534 @ (62,6)",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Candidate mini crawl gate in Mustard Mountain pending live verification."
+      },
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Room-level unresolved rope semantics exist in this area, but no shipping AP location consumes them yet."
+      }
+    }
   },
 
   "REGION_MOONLIGHT_MANSION/MAIN": {
     "locations": ["SHARD_2", "BOSS_DEFEAT_2"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=195 unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Moonlight Mansion has unresolved rope gating in the current big-chest evidence set."
+      },
+      "CanUseMini": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=195 unresolved mini_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Mini routing remains a semantic candidate only and is not safe to enforce yet."
+      }
+    }
   },
 
   "REGION_CANDY_CONSTELLATION/MAIN": {
     "locations": ["SHARD_3", "BOSS_DEFEAT_3"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanUseMini": {
+        "status": "semantic_candidate",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=406 edge_tile_transition_coordinates -> room 401 @ (28,49)",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Candy Constellation includes at least one candidate mini crawl transition with room-level evidence."
+      },
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Rope semantics remain unresolved across Candy Constellation candidate chest routes."
+      }
+    }
   },
 
   "REGION_OLIVE_OCEAN/MAIN": {
     "locations": ["SHARD_4", "BOSS_DEFEAT_4"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanBreakBlocks": {
+        "status": "confirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=815 object_types=OBJ_DESTROYABLE_ROCK_BLOCK,OBJ_STAR_STONE_BLOCK",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Confirmed block-breaking objects appear on at least one Olive Ocean candidate route."
+      },
+      "CanPoundPegs": {
+        "status": "confirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=816 object_types=OBJ_HAMMER_PEG",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Confirmed hammer-peg object appears on an Olive Ocean candidate route."
+      },
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Rope semantics are still unresolved for Olive Ocean chest routing."
+      },
+      "CanUseMini": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved mini_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Mini traversal evidence exists only as an unresolved semantic candidate here."
+      }
+    }
   },
 
   "REGION_PEPPERMINT_PALACE/MAIN": {
@@ -55,21 +123,69 @@
     "locations": ["SHARD_6", "BOSS_DEFEAT_6"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanBreakBlocks": {
+        "status": "confirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=531 object_types=OBJ_DESTROYABLE_ROCK_BLOCK",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Confirmed breakable rock block on a Cabbage Cavern candidate chest route."
+      },
+      "CanUseMini": {
+        "status": "semantic_candidate",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=531 edge_tile_transition_coordinates -> room 981 @ (3,74)",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Mini access looks plausible from transition coordinates but still needs live verification."
+      },
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Unresolved rope semantics retained as future rollout metadata only."
+      }
+    }
   },
 
   "REGION_CARROT_CASTLE/MAIN": {
     "locations": ["SHARD_7", "BOSS_DEFEAT_7"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanUseMini": {
+        "status": "semantic_candidate",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=732 edge_tile_transition_coordinates -> room 600 @ (44,4)",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Candidate mini traversal path identified for later major chest modeling."
+      },
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Rope gating remains unresolved and is not enforced in current logic."
+      }
+    }
   },
 
   "REGION_RADISH_RUINS/MAIN": {
     "locations": ["SHARD_8", "BOSS_DEFEAT_8"],
     "events": [],
     "exits": ["REGION_GAME_START"],
-    "warps": []
+    "warps": [],
+    "ability_gates": {
+      "CanUseMini": {
+        "status": "semantic_candidate",
+        "evidence": "katam_unresolved_big_chest_gates_report.json usa_room_id_dec=617 edge_tile_transition_coordinates -> room 502 @ (54,17)",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Candidate mini transition in Radish Ruins reserved for future chest logic."
+      },
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Rope gating is still only tracked as unresolved evidence."
+      }
+    }
   },
 
   "REGION_DIMENSION_MIRROR/MAIN": {

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -620,3 +620,39 @@ Generation behavior retained:
   - useful catalog contains both map and vitality categories
   - boss-defeat default pool is composed of useful items and includes both
     categories
+
+## Issue #37: Ability-Related Location Logic Stubs
+
+### Problem
+Phase 2 major chest rollout needs stable logic categories for copy-ability gates,
+but the current AP item pool does not yet randomize ability items or ability
+statues. That meant future chest routing had nowhere to record verified gate
+evidence without accidentally blocking current generation.
+
+### Solution
+Added five placeholder ability-gate helpers in `worlds/kirbyam/rules.py`:
+- `CanCutRopes`
+- `CanBreakBlocks`
+- `CanUseMini`
+- `CanLightFuses`
+- `CanPoundPegs`
+
+Current contract:
+- every helper defaults to `True`
+- current shard/goal logic remains unchanged
+- no new progression restrictions are enforced in shipped seeds yet
+
+Added structured `ability_gates` annotations to
+`worlds/kirbyam/data/regions/areas.json` and preserved them in `RegionData` so
+future major chest logic can consume them directly.
+
+### Evidence Status Policy
+- `confirmed`: explicit object evidence already seen in room analysis
+- `semantic_candidate`: geometry/transition evidence suggests the gate, but live
+  verification is still needed
+- `unconfirmed`: unresolved semantic hint tracked for later review only
+
+### Seed-Safe Scope
+This issue only establishes naming and evidence scaffolding. Ability items are
+still absent from the pool, so all five helpers intentionally resolve to true
+until a later issue introduces actual ability acquisition logic.

--- a/worlds/kirbyam/rules.py
+++ b/worlds/kirbyam/rules.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 from BaseClasses import CollectionState
 from worlds.generic.Rules import set_rule
 
+from .data import data
 from .generation_logging import logger
 from .options import Goal
 
@@ -52,10 +53,69 @@ _GOAL_LOCATION_LABELS = {
 }
 
 _DMK_DIMENSION_MIRROR_EVENT = "Defeat Dark Meta Knight (Dimension Mirror)"
+_ABILITY_GATE_STATUS_VALUES = frozenset({"confirmed", "semantic_candidate", "unconfirmed"})
+
+# These gates intentionally default to True until ability items/statues become
+# part of the item pool. The names match the planned logic categories from #37.
+_ABILITY_GATE_PLACEHOLDER_SOURCES = {
+    "CanCutRopes": frozenset({"Cutter", "Sword", "Cupid", "Smash", "Master"}),
+    "CanBreakBlocks": frozenset({"Hammer", "Stone", "Throw", "Burning", "Missile", "UFO", "Smash", "Master"}),
+    "CanUseMini": frozenset({"Mini"}),
+    "CanLightFuses": frozenset({"Fire", "Burning", "Bomb", "Laser", "UFO", "Master"}),
+    "CanPoundPegs": frozenset({"Hammer", "Stone", "Smash", "Master"}),
+}
 
 
 def _has_all_shards(state: CollectionState, player: int) -> bool:
     return state.has_from_list_unique(_SHARD_ITEM_LABELS, player, len(_SHARD_ITEM_LABELS))
+
+
+def _allow_pending_ability_gate(_state: CollectionState, _player: int, _gate_name: str) -> bool:
+    return True
+
+
+def can_cut_ropes(state: CollectionState, player: int) -> bool:
+    return _allow_pending_ability_gate(state, player, "CanCutRopes")
+
+
+def can_break_blocks(state: CollectionState, player: int) -> bool:
+    return _allow_pending_ability_gate(state, player, "CanBreakBlocks")
+
+
+def can_use_mini(state: CollectionState, player: int) -> bool:
+    return _allow_pending_ability_gate(state, player, "CanUseMini")
+
+
+def can_light_fuses(state: CollectionState, player: int) -> bool:
+    return _allow_pending_ability_gate(state, player, "CanLightFuses")
+
+
+def can_pound_pegs(state: CollectionState, player: int) -> bool:
+    return _allow_pending_ability_gate(state, player, "CanPoundPegs")
+
+
+CanCutRopes = can_cut_ropes
+CanBreakBlocks = can_break_blocks
+CanUseMini = can_use_mini
+CanLightFuses = can_light_fuses
+CanPoundPegs = can_pound_pegs
+
+
+ABILITY_GATE_RULES = {
+    "CanCutRopes": can_cut_ropes,
+    "CanBreakBlocks": can_break_blocks,
+    "CanUseMini": can_use_mini,
+    "CanLightFuses": can_light_fuses,
+    "CanPoundPegs": can_pound_pegs,
+}
+
+
+def get_region_ability_gate_annotations() -> dict[str, dict[str, dict[str, object]]]:
+    annotations: dict[str, dict[str, dict[str, object]]] = {}
+    for region_name, region_data in data.regions.items():
+        if region_data.ability_gates:
+            annotations[region_name] = region_data.ability_gates
+    return annotations
 
 
 def set_rules(world: KirbyAmWorld) -> None:

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from unittest.mock import patch
 
+from ..data import data
 from ..options import Goal
-from ..rules import set_rules
+from ..rules import ABILITY_GATE_RULES, _ABILITY_GATE_STATUS_VALUES, get_region_ability_gate_annotations, set_rules
 
 
 @dataclass
@@ -187,4 +188,40 @@ def test_dmk_event_present_in_dimension_mirror_region() -> None:
     assert _DMK_EVENT in events, (
         f"{_DMK_EVENT!r} event must be declared in REGION_DIMENSION_MIRROR/MAIN events in areas.json"
     )
+
+
+def test_ability_gate_helpers_default_true_without_ability_items() -> None:
+    state = _FakeState()
+
+    for gate_name, gate_rule in ABILITY_GATE_RULES.items():
+        assert gate_rule(state, 1), f"{gate_name} should default to True until ability items exist"
+
+
+def test_region_ability_gate_annotations_load_for_future_big_chest_rollout() -> None:
+    annotations = get_region_ability_gate_annotations()
+
+    expected_regions = {
+        "REGION_MUSTARD_MOUNTAIN/MAIN",
+        "REGION_MOONLIGHT_MANSION/MAIN",
+        "REGION_CANDY_CONSTELLATION/MAIN",
+        "REGION_OLIVE_OCEAN/MAIN",
+        "REGION_CABBAGE_CAVERN/MAIN",
+        "REGION_CARROT_CASTLE/MAIN",
+        "REGION_RADISH_RUINS/MAIN",
+    }
+    assert expected_regions.issubset(annotations)
+
+    for region_name in expected_regions:
+        region_annotations = annotations[region_name]
+        assert region_annotations == data.regions[region_name].ability_gates
+        for gate_name, gate_annotation in region_annotations.items():
+            assert gate_name in ABILITY_GATE_RULES
+            assert gate_annotation["status"] in _ABILITY_GATE_STATUS_VALUES
+            assert gate_annotation["applies_to"] == ["future_major_chest_locations"]
+            assert gate_annotation["evidence"]
+
+    assert annotations["REGION_OLIVE_OCEAN/MAIN"]["CanBreakBlocks"]["status"] == "confirmed"
+    assert annotations["REGION_OLIVE_OCEAN/MAIN"]["CanPoundPegs"]["status"] == "confirmed"
+    assert annotations["REGION_CABBAGE_CAVERN/MAIN"]["CanBreakBlocks"]["status"] == "confirmed"
+    assert annotations["REGION_CABBAGE_CAVERN/MAIN"]["CanUseMini"]["status"] == "semantic_candidate"
 


### PR DESCRIPTION
## Summary
- add seed-safe placeholder ability gate helpers for rope, block, mini, fuse, and peg checks
- preserve structured ability gate annotations from region JSON for future major chest rollout
- document the evidence policy and add tests covering stub behavior plus annotation loading

## Evidence trail
- Claim: establish named ability gate categories without changing current seed accessibility
- Source: d:/kirbyam-extras/KATAM_AI_REFERENCE.md Section 9 copy ability affordances and d:/kirbyam-extras/katam_unresolved_big_chest_gates_report.json room-level gate evidence
- Adaptation: kept every ability gate default-true because ability items/statues are not yet in the AP pool, but recorded confirmed, semantic_candidate, and unconfirmed region annotations for later chest logic
- Validation: & "d:/Google Drive/Git/Archipelago-kirbyam/.venv/Scripts/python.exe" -m pytest worlds/kirbyam/test/test_rules.py -q; & "d:/Google Drive/Git/Archipelago-kirbyam/.venv/Scripts/python.exe" -m pytest worlds/kirbyam/test -q

Closes #37