### PR TITLE
Issue #290: fix generation failure in KirbyAM sanity validation

### DIFF
--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -1,5 +1,32 @@
 # Kirby & The Amazing Mirror (GBA) - Address Policy Notes
 
+## Issue #290: Generation Failure from Global bit_index Collision Check
+
+### Problem
+KirbyAM generation failed in `stage_assert_generate` because `validate_regions()` treated
+all location `bit_index` values as one global namespace. That rule incorrectly rejected
+valid cross-category reuse such as:
+- SHARD bit `0`
+- BOSS_DEFEAT bit `0`
+
+These locations are polled from different bitfield domains, so shared numeric bit indices
+across categories are expected and valid.
+
+### Solution
+Updated `worlds/kirbyam/sanity_check.py` so bit-index uniqueness is enforced per location
+category instead of globally.
+
+The validator now:
+- allows cross-category bit index reuse
+- still fails on duplicate bit indices inside the same category
+- logs category-specific collision messages for easier triage
+
+### Validation
+- Added `worlds/kirbyam/test/test_sanity_check.py`.
+- New tests verify:
+  - cross-category bit index reuse passes validation
+  - same-category bit index collisions fail validation
+
 ## POC baseline
 
 - Baseline ROM for the POC is `Kirby & The Amazing Mirror (USA).gba` only.

--- a/worlds/kirbyam/sanity_check.py
+++ b/worlds/kirbyam/sanity_check.py
@@ -3,7 +3,6 @@ Looks through data object to double-check it makes sense. Will fail for missing 
 duplicate claims and give warnings for unused and unignored locations or warps.
 """
 import logging
-from typing import List
 
 
 def validate_group_maps() -> bool:
@@ -71,18 +70,21 @@ def validate_regions() -> bool:
         if location_name not in claimed_locations:
             warn(f"Kirby & The Amazing Mirror: Location [{location_name}] was not claimed by any region")
 
-    # Optional: Validate that bitfield indices (if present) are unique.
-    bit_to_loc: dict[int, str] = {}
+    # Optional: Validate that bitfield indices (if present) are unique within
+    # their location category/bitfield domain.
+    bit_to_loc_by_category: dict[str, dict[int, str]] = {}
     for loc_key, loc in data.locations.items():
         if loc.bit_index is None:
             continue
-        if loc.bit_index in bit_to_loc and bit_to_loc[loc.bit_index] != loc_key:
+        category_name = getattr(loc.category, "name", str(loc.category))
+        category_bit_map = bit_to_loc_by_category.setdefault(category_name, {})
+        if loc.bit_index in category_bit_map and category_bit_map[loc.bit_index] != loc_key:
             error(
-                "Kirby & The Amazing Mirror: bit_index %s is assigned to multiple locations (%s, %s)"
-                % (loc.bit_index, bit_to_loc[loc.bit_index], loc_key)
+                "Kirby & The Amazing Mirror: category %s bit_index %s is assigned to multiple locations (%s, %s)"
+                % (category_name, loc.bit_index, category_bit_map[loc.bit_index], loc_key)
             )
         else:
-            bit_to_loc[loc.bit_index] = loc_key
+            category_bit_map[loc.bit_index] = loc_key
 
     warn_messages.sort()
     error_messages.sort()

--- a/worlds/kirbyam/test/test_sanity_check.py
+++ b/worlds/kirbyam/test/test_sanity_check.py
@@ -1,0 +1,87 @@
+"""Tests for KirbyAM sanity-check data validation rules."""
+
+from unittest.mock import Mock, patch
+
+from .. import data as data_module
+from ..data import LocationCategory, LocationData
+from ..sanity_check import validate_regions
+
+
+def _location(
+    name: str,
+    *,
+    category: LocationCategory,
+    bit_index: int,
+    location_id: int,
+) -> LocationData:
+    return LocationData(
+        name=name,
+        label=name,
+        parent_region="REGION_GAME_START",
+        default_item=None,
+        bit_index=bit_index,
+        location_id=location_id,
+        category=category,
+        tags=frozenset(),
+    )
+
+
+def _region_with_locations(*location_names: str) -> Mock:
+    region = Mock()
+    region.exits = []
+    region.locations = list(location_names)
+    return region
+
+
+def test_validate_regions_allows_cross_category_bit_index_reuse() -> None:
+    """Bit-index reuse across categories is valid because each category uses a separate bitfield domain."""
+    locations = {
+        "SHARD_A": _location(
+            "SHARD_A",
+            category=LocationCategory.SHARD,
+            bit_index=0,
+            location_id=3_960_100,
+        ),
+        "BOSS_A": _location(
+            "BOSS_A",
+            category=LocationCategory.BOSS_DEFEAT,
+            bit_index=0,
+            location_id=3_960_101,
+        ),
+    }
+    regions = {"REGION_GAME_START": _region_with_locations("SHARD_A", "BOSS_A")}
+
+    with patch.object(data_module.data, "locations", locations), patch.object(
+        data_module.data,
+        "regions",
+        regions,
+    ), patch("worlds.kirbyam.data.load_json_data", return_value={k: {} for k in locations}):
+        assert validate_regions()
+
+
+def test_validate_regions_rejects_same_category_bit_index_collision(caplog) -> None:
+    """Bit-index collisions inside the same category should remain hard failures."""
+    locations = {
+        "SHARD_A": _location(
+            "SHARD_A",
+            category=LocationCategory.SHARD,
+            bit_index=2,
+            location_id=3_960_200,
+        ),
+        "SHARD_B": _location(
+            "SHARD_B",
+            category=LocationCategory.SHARD,
+            bit_index=2,
+            location_id=3_960_201,
+        ),
+    }
+    regions = {"REGION_GAME_START": _region_with_locations("SHARD_A", "SHARD_B")}
+
+    with patch.object(data_module.data, "locations", locations), patch.object(
+        data_module.data,
+        "regions",
+        regions,
+    ), patch("worlds.kirbyam.data.load_json_data", return_value={k: {} for k in locations}):
+        assert not validate_regions()
+
+    assert "category SHARD bit_index 2 is assigned to multiple locations" in caplog.text


### PR DESCRIPTION
## Summary
- fix KirbyAM region sanity validation to enforce bit_index uniqueness per location category instead of globally
- preserve hard failures for collisions within the same category with improved category-aware error messages
- add targeted sanity-check tests covering valid cross-category reuse and invalid same-category collisions
- document issue #290 root cause and resolution in KirbyAM notes

## Validation
- python -m pytest worlds/kirbyam/test/test_sanity_check.py -q
- python -m pytest worlds/kirbyam/test/test_client.py -q
- make (from worlds/kirbyam/kirby_ap_payload)
- python -c "from worlds.kirbyam.sanity_check import validate_regions; print(validate_regions())"

Closes #290
