### PR TITLE
Issue #36: Implement All 9 Major Chest Locations (Big Chest bitfield, all area bits 1-9)

### DIFF
--- a/worlds/kirbyam/ADDRESS_VERIFICATION_MATRIX.md
+++ b/worlds/kirbyam/ADDRESS_VERIFICATION_MATRIX.md
@@ -13,6 +13,7 @@ Policy references:
 
 Systematically verify all memory addresses needed for the POC:
 - **8 Mirror Shards** (location checks)
+- **9 Major Chests** (area big-chest checks, bits 1–9)
 - **7 Area Bosses** (dungeon defeats)
 - **1 Final Boss** (Dark Mind defeat)
 
@@ -70,7 +71,38 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 
 ---
 
-## 2. AREA BOSSES (7 Total by Mirror)
+## 2. MAJOR CHESTS (Phase 1)
+
+### Candidate Address: `0x0203897C` (Big Chest Area Bitfield)
+- **Type**: 32-bit bitfield (bit N = `AreaId` N)
+- **Source**: `gTreasures.bigChestField` derived from the `shard_bitfield_native` anchor
+- **Expected Behavior**:
+  - Bit flips from `0→1` when the area's major chest reward is claimed
+  - Persists after room change and save/reload
+  - The client polls all defined MAJOR_CHEST bits dynamically; currently `1`–`9` (all playable areas)
+
+| Location | Bit | Status | Verified Address | Notes |
+|----------|-----|--------|------------------|-------|
+| Rainbow Route - Big Chest | 1 | ⬜ | | |
+| Moonlight Mansion - Big Chest | 2 | ⬜ | | |
+| Cabbage Cavern - Big Chest | 3 | ⬜ | | |
+| Mustard Mountain - Big Chest | 4 | ⬜ | | |
+| Carrot Castle - Big Chest | 5 | ⬜ | | |
+| Olive Ocean - Big Chest | 6 | ⬜ | | |
+| Peppermint Palace - Big Chest | 7 | ⬜ | | |
+| Radish Ruins - Big Chest | 8 | ⬜ | | |
+| Candy Constellation - Big Chest | 9 | ⬜ | | |
+
+**Testing Steps for Each Major Chest**:
+1. Observe `0x0203897C` before opening the chest
+2. Claim the chest reward in-game
+3. Confirm the mapped area bit flips to `1`
+4. Reconnect the AP client and confirm the corresponding LocationCheck is not replayed after server acknowledgement
+5. Save and reset; verify the bit persists
+
+---
+
+## 3. AREA BOSSES (7 Total by Mirror)
 
 > **NOTE**: In KAtAM, each mirror has a boss. Start with Moonlight Mansion (Crepe).
 
@@ -146,7 +178,7 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 
 ---
 
-## 3. FINAL BOSS: DARK MIND
+## 4. FINAL BOSS: DARK MIND
 
 ### Dark Meta Knight (Dimension Mirror Encounter)
 - **Candidate Address**: TBD — no dedicated flag mapped yet; presence inferred from
@@ -212,12 +244,13 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 
 ---
 
-## 4. CANDIDATE ADDRESS SOURCES
+## 5. CANDIDATE ADDRESS SOURCES
 
 ### From Workbook (KirbyAM Data.xlsx)
 | Signal | Workbook Address | Status | Notes |
 |--------|------------------|--------|-------|
 | Mirror Shards Bitfield | `0x02038970` | Integrated (pending live verification) | Tracked in `addresses.json` as `shard_bitfield_native` |
+| Major Chest Bitfield | `0x0203897C` | Integrated (pending live verification) | Tracked in `addresses.json` as `big_chest_bitfield_native`; Phase 1 polls bits 3, 6, 7 |
 | Chest/Switch Blocks | `0x02038960`–`0x0203896A` | TBD | Supporting data |
 | Boss/Mirror table region | `0x02028C14+` | Candidate | Candidate source from protocol reverse-engineering; needs live confirmation |
 | Dark Mind signal | `0x02028C14+` (offset TBD) | Candidate | Needs live mapping and confirmation |
@@ -227,11 +260,13 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 
 ---
 
-## 5. VERIFICATION CHECKLIST
+## 6. VERIFICATION CHECKLIST
 
 - [x] At least one shard progression address is integrated for current POC path (`0x02038970`)
+- [x] At least one major chest address is integrated for current POC path (`0x0203897C`)
 - [x] At least one dungeon boss signal candidate is documented (`0x02028C14+` region)
 - [x] At least one final boss signal candidate is documented (`0x02028C14+` region, offset TBD)
+- [ ] Live verification complete for major chest candidate(s)
 - [ ] Live verification complete for dungeon boss candidate(s)
 - [ ] Live verification complete for final boss candidate(s)
 - [ ] Address conflicts checked (no overlaps)
@@ -242,19 +277,20 @@ This document serves as a testing checklist. Use BizHawk's memory viewer to conf
 
 ---
 
-## 6. NOTES & OBSERVATIONS
+## 7. NOTES & OBSERVATIONS
 
 (To be filled in during testing)
 
 ---
 
-## 7. SUMMARY TABLE (For Documentation)
+## 8. SUMMARY TABLE (For Documentation)
 
 *To be completed once all verifications done*
 
 | Signal | Type | Address | Bit | Confidence | Status |
 |--------|------|---------|-----|------------|--------|
 | Mirror Shard 1 | Bitfield | TBD | 0 | 🔴 | ⬜ |
+| Cabbage Cavern - Big Chest | Bitfield | `0x0203897C` | 3 | 🟡 | Integrated |
 | Crepe Defeated | Flag/Bitfield | TBD | ? | 🔴 | ⬜ |
 | Dark Meta Knight (Dimension Mirror) | Flag/Bitfield | TBD (boss table `0x02028C14+`) | ? | 🔴 | ⬜ |
 | Dark Mind Defeated (all forms) | ai_kirby_state | `0x0203AD2C` → `9999` | n/a | 🟡 | Integrated |

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -40,8 +40,9 @@ EWRAM Layout (0x02000000 - 0x02040000):
 ### Native Game State (Referenced but not Managed by AP)
 
 | Addr     | Size | Name                    | Description |
-|----------|------|-------------------------|-------------|
+|----------|------|-------------------------|-----------|
 | 0x02038970 | 1B | KIRBY_SHARD_FLAGS       | Native mirror shard bitfield (bits 0-7) |
+| 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. Derived from shard_bitfield_native 0x02038970 (shardField = gTreasures+0x10, bigChestField = gTreasures+0x1C). The client polls all defined MAJOR_CHEST bits dynamically; currently 1–9 (all playable areas). |
 | 0x02038960 - 0x0203896A | 10B | Chest/Switch state    | Native chest and switch flags |
 | 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped) |
 | 0x0203AD2C | 4B | AI_KIRBY_STATE          | Runtime phase classifier (Issue #56 gameplay gate) |
@@ -74,13 +75,22 @@ contract until their native apply semantics are verified on the USA ROM.
 
 ## Location ID Ranges
 
-All location IDs use **BASE_OFFSET = 3860100**.
+All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3,960,000).
 
 | Location Type | ID Range | Description |
 |---------------|----------|-------------|
-| SHARD_1 .. SHARD_8 | 3860101 - 3860108 | Mirror shard check locations (8 items) |
+| SHARD_1 .. SHARD_8 | auto-assigned | Mirror shard check locations (8 locations) |
 | BOSS_DEFEAT_1 .. BOSS_DEFEAT_8 | auto-assigned | Area boss defeat locations (8 locations) |
-| *TBD*         | — | Chest locations, door locations, etc. |
+| MAJOR_CHEST_CABBAGE_CAVERN | 3960200 | Cabbage Cavern big chest (bit 3, gTreasures.bigChestField) |
+| MAJOR_CHEST_OLIVE_OCEAN | 3960201 | Olive Ocean big chest (bit 6, gTreasures.bigChestField) |
+| MAJOR_CHEST_PEPPERMINT_PALACE | 3960202 | Peppermint Palace big chest (bit 7, gTreasures.bigChestField) |
+| MAJOR_CHEST_RAINBOW_ROUTE | 3960203 | Rainbow Route big chest (bit 1, gTreasures.bigChestField) |
+| MAJOR_CHEST_MOONLIGHT_MANSION | 3960204 | Moonlight Mansion big chest (bit 2, gTreasures.bigChestField) |
+| MAJOR_CHEST_MUSTARD_MOUNTAIN | 3960205 | Mustard Mountain big chest (bit 4, gTreasures.bigChestField) |
+| MAJOR_CHEST_CARROT_CASTLE | 3960206 | Carrot Castle big chest (bit 5, gTreasures.bigChestField) |
+| MAJOR_CHEST_RADISH_RUINS | 3960207 | Radish Ruins big chest (bit 8, gTreasures.bigChestField) |
+| MAJOR_CHEST_CANDY_CONSTELLATION | 3960208 | Candy Constellation big chest (bit 9, gTreasures.bigChestField) |
+| *Reserved*    | 3960209+ | Future location families |
 
 ## Client Protocol
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -72,6 +72,14 @@ class KirbyAmClient(BizHawkClient):
                 continue
             self._boss_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
 
+        # Major chest bitfield → location IDs (MAJOR_CHEST category; polled from big_chest_bitfield_native)
+        # Bit N corresponds to area ID N in enum AreaId (e.g. bit 3 = AREA_CABBAGE_CAVERN).
+        self._major_chest_location_ids_by_bit: dict[int, list[int]] = {}
+        for loc in data.locations.values():
+            if loc.bit_index is None or loc.category != LocationCategory.MAJOR_CHEST:
+                continue
+            self._major_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+
         # One-time RAM state load
         self._ram_state_loaded: bool = False
 
@@ -91,6 +99,7 @@ class KirbyAmClient(BizHawkClient):
         # Poll diagnostics de-duplication (avoid per-tick log spam)
         self._last_shard_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_boss_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._last_major_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Notification pipeline state (Issue #83)
         self._notification_settings_loaded: bool = False
@@ -127,6 +136,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_runtime_gate_reason = None
         self._last_shard_poll_log = None
         self._last_boss_poll_log = None
+        self._last_major_chest_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
         self._unsafe_delivery_probe_stream_marker = None
@@ -370,6 +380,9 @@ class KirbyAmClient(BizHawkClient):
         # Boss defeat location polling via transport register
         await self._poll_boss_defeat_locations(ctx)
 
+        # Major chest location polling via native big_chest_bitfield_native
+        await self._poll_major_chest_locations(ctx)
+
         # Candidate discovery for non-shard boss defeat signals.
         await self._probe_boss_defeat_candidates(ctx)
 
@@ -588,6 +601,61 @@ class KirbyAmClient(BizHawkClient):
                 self._last_boss_poll_log = boss_log_state
         else:
             self._last_boss_poll_log = None
+
+    async def _poll_major_chest_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Read big_chest_bitfield_native and map set bits to major-chest locations.
+
+        Bit N corresponds to area ID N (enum AreaId): bit 3 = AREA_CABBAGE_CAVERN,
+        bit 6 = AREA_OLIVE_OCEAN, bit 7 = AREA_PEPPERMINT_PALACE, etc.
+        Multiple physical chest rooms in one area map to the same area-ID bit.
+
+        Mirrors shard/boss polling semantics: RAM-derived checks are resent until
+        the server acknowledges them in ctx.checked_locations.
+
+        Source: gTreasures.bigChestField (native EWRAM, offset +0x1C from gTreasures base).
+        Evidence: katam disassembly treasures.h/treasures.c + shard_bitfield_native anchor
+        at 0x02038970 (shardField = gTreasures+0x10), yielding bigChestField at 0x0203897C.
+        """
+        chest_addr = self._native_addr("big_chest_bitfield_native")
+        if chest_addr is None:
+            return
+
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(chest_addr, 4, "System Bus")]))[0]
+        chest_bits = self._u32_le(raw)
+
+        mapped_checked_locations: set[int] = set()
+        for bit in sorted(self._major_chest_location_ids_by_bit.keys()):
+            if (chest_bits >> bit) & 1:
+                mapped_checked_locations.update(self._major_chest_location_ids_by_bit.get(bit, []))
+
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+        already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
+        if missing_on_server:
+            from CommonClient import logger
+
+            chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if chest_log_state != self._last_major_chest_poll_log:
+                logger.info(
+                    "KirbyAM: resending major-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                )
+                self._last_major_chest_poll_log = chest_log_state
+
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+        elif mapped_checked_locations:
+            from CommonClient import logger
+
+            chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if chest_log_state != self._last_major_chest_poll_log:
+                logger.debug(
+                    "KirbyAM: dedupe suppressed major-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_major_chest_poll_log = chest_log_state
+        else:
+            self._last_major_chest_poll_log = None
 
     async def _probe_boss_defeat_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -79,6 +79,7 @@ class LocationCategory(IntEnum):
     SHARD = 0
     GOAL = 1
     BOSS_DEFEAT = 2
+    MAJOR_CHEST = 9
 
 
 class ItemData(NamedTuple):

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -14,6 +14,7 @@
     },
     "native": {
       "shard_bitfield_native": "0x02038970",
+      "big_chest_bitfield_native": "0x0203897C",
       "boss_mirror_table_native": "0x02028C14",
       "ai_kirby_state_native": "0x0203AD2C"
     }

--- a/worlds/kirbyam/data/items.json
+++ b/worlds/kirbyam/data/items.json
@@ -56,6 +56,12 @@
     "classification": "PROGRESSION",
     "tags": ["Shard", "Unique"]
   },
+  "MAP_RAINBOW_ROUTE": {
+    "label": "Map - Rainbow Route",
+    "classification": "USEFUL",
+    "item_id": 3860024,
+    "tags": ["Map", "Useful"]
+  },
   "MAP_MUSTARD_MOUNTAIN": {
     "label": "Map - Mustard Mountain",
     "classification": "USEFUL",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -138,5 +138,86 @@
     "tags": ["Boss"],
     "bit_index": 7,
     "category": "BOSS_DEFEAT"
+  },
+  "MAJOR_CHEST_CABBAGE_CAVERN": {
+    "label": "Cabbage Cavern - Big Chest",
+    "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
+    "default_item": "MAP_CABBAGE_CAVERN",
+    "tags": ["BigChest", "MAP_CABBAGE_CAVERN"],
+    "bit_index": 3,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960200
+  },
+  "MAJOR_CHEST_OLIVE_OCEAN": {
+    "label": "Olive Ocean - Big Chest",
+    "parent_region": "REGION_OLIVE_OCEAN/MAIN",
+    "default_item": "MAP_OLIVE_OCEAN",
+    "tags": ["BigChest", "MAP_OLIVE_OCEAN"],
+    "bit_index": 6,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960201
+  },
+  "MAJOR_CHEST_PEPPERMINT_PALACE": {
+    "label": "Peppermint Palace - Big Chest",
+    "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
+    "default_item": "MAP_PEPPERMINT_PALACE",
+    "tags": ["BigChest", "MAP_PEPPERMINT_PALACE"],
+    "bit_index": 7,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960202
+  },
+  "MAJOR_CHEST_RAINBOW_ROUTE": {
+    "label": "Rainbow Route - Big Chest",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "default_item": "MAP_RAINBOW_ROUTE",
+    "tags": ["BigChest", "MAP_RAINBOW_ROUTE"],
+    "bit_index": 1,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960203
+  },
+  "MAJOR_CHEST_MOONLIGHT_MANSION": {
+    "label": "Moonlight Mansion - Big Chest",
+    "parent_region": "REGION_MOONLIGHT_MANSION/MAIN",
+    "default_item": "MAP_MOONLIGHT_MANSION",
+    "tags": ["BigChest", "MAP_MOONLIGHT_MANSION"],
+    "bit_index": 2,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960204
+  },
+  "MAJOR_CHEST_MUSTARD_MOUNTAIN": {
+    "label": "Mustard Mountain - Big Chest",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/MAIN",
+    "default_item": "MAP_MUSTARD_MOUNTAIN",
+    "tags": ["BigChest", "MAP_MUSTARD_MOUNTAIN"],
+    "bit_index": 4,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960205
+  },
+  "MAJOR_CHEST_CARROT_CASTLE": {
+    "label": "Carrot Castle - Big Chest",
+    "parent_region": "REGION_CARROT_CASTLE/MAIN",
+    "default_item": "MAP_CARROT_CASTLE",
+    "tags": ["BigChest", "MAP_CARROT_CASTLE"],
+    "bit_index": 5,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960206
+  },
+  "MAJOR_CHEST_RADISH_RUINS": {
+    "label": "Radish Ruins - Big Chest",
+    "parent_region": "REGION_RADISH_RUINS/MAIN",
+    "default_item": "MAP_RADISH_RUINS",
+    "tags": ["BigChest", "MAP_RADISH_RUINS"],
+    "bit_index": 8,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960207
+  },
+  "MAJOR_CHEST_CANDY_CONSTELLATION": {
+    "label": "Candy Constellation - Big Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/MAIN",
+    "default_item": "MAP_CANDY_CONSTELLATION",
+    "tags": ["BigChest", "MAP_CANDY_CONSTELLATION"],
+    "bit_index": 9,
+    "category": "MAJOR_CHEST",
+    "location_id": 3960208
   }
 }

--- a/worlds/kirbyam/data/native_address_policy.json
+++ b/worlds/kirbyam/data/native_address_policy.json
@@ -28,6 +28,18 @@
         }
       ]
     },
+    "major_chest_checks": {
+      "status": "integrated",
+      "entries": [
+        {
+          "name": "big_chest_bitfield_native",
+          "address": "0x0203897C",
+          "width": "u32",
+          "source": "gTreasures layout cross-reference + shard_bitfield_native anchor + live client integration",
+          "verification": "Integrated and used by polling path for Cabbage Cavern, Olive Ocean, and Peppermint Palace major chests; pending repeatable BizHawk confirmation per promotion_criteria"
+        }
+      ]
+    },
     "dungeon_boss_defeat": {
       "status": "integrated",
       "entries": [

--- a/worlds/kirbyam/data/regions/areas.json
+++ b/worlds/kirbyam/data/regions/areas.json
@@ -3,6 +3,7 @@
     "locations": [],
     "events": [],
     "exits": [
+      "REGION_RAINBOW_ROUTE/MAIN",
       "REGION_MUSTARD_MOUNTAIN/MAIN",
       "REGION_MOONLIGHT_MANSION/MAIN",
       "REGION_CANDY_CONSTELLATION/MAIN",
@@ -17,7 +18,7 @@
   },
 
   "REGION_MUSTARD_MOUNTAIN/MAIN": {
-    "locations": ["SHARD_1", "BOSS_DEFEAT_1"],
+    "locations": ["SHARD_1", "BOSS_DEFEAT_1", "MAJOR_CHEST_MUSTARD_MOUNTAIN"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -38,7 +39,7 @@
   },
 
   "REGION_MOONLIGHT_MANSION/MAIN": {
-    "locations": ["SHARD_2", "BOSS_DEFEAT_2"],
+    "locations": ["SHARD_2", "BOSS_DEFEAT_2", "MAJOR_CHEST_MOONLIGHT_MANSION"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -59,7 +60,7 @@
   },
 
   "REGION_CANDY_CONSTELLATION/MAIN": {
-    "locations": ["SHARD_3", "BOSS_DEFEAT_3"],
+    "locations": ["SHARD_3", "BOSS_DEFEAT_3", "MAJOR_CHEST_CANDY_CONSTELLATION"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -80,7 +81,7 @@
   },
 
   "REGION_OLIVE_OCEAN/MAIN": {
-    "locations": ["SHARD_4", "BOSS_DEFEAT_4"],
+    "locations": ["SHARD_4", "BOSS_DEFEAT_4", "MAJOR_CHEST_OLIVE_OCEAN"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -113,14 +114,14 @@
   },
 
   "REGION_PEPPERMINT_PALACE/MAIN": {
-    "locations": ["SHARD_5", "BOSS_DEFEAT_5"],
+    "locations": ["SHARD_5", "BOSS_DEFEAT_5", "MAJOR_CHEST_PEPPERMINT_PALACE"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": []
   },
 
   "REGION_CABBAGE_CAVERN/MAIN": {
-    "locations": ["SHARD_6", "BOSS_DEFEAT_6"],
+    "locations": ["SHARD_6", "BOSS_DEFEAT_6", "MAJOR_CHEST_CABBAGE_CAVERN"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -147,7 +148,7 @@
   },
 
   "REGION_CARROT_CASTLE/MAIN": {
-    "locations": ["SHARD_7", "BOSS_DEFEAT_7"],
+    "locations": ["SHARD_7", "BOSS_DEFEAT_7", "MAJOR_CHEST_CARROT_CASTLE"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -168,7 +169,7 @@
   },
 
   "REGION_RADISH_RUINS/MAIN": {
-    "locations": ["SHARD_8", "BOSS_DEFEAT_8"],
+    "locations": ["SHARD_8", "BOSS_DEFEAT_8", "MAJOR_CHEST_RADISH_RUINS"],
     "events": [],
     "exits": ["REGION_GAME_START"],
     "warps": [],
@@ -184,6 +185,27 @@
         "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
         "applies_to": ["future_major_chest_locations"],
         "notes": "Rope gating is still only tracked as unresolved evidence."
+      }
+    }
+  },
+
+  "REGION_RAINBOW_ROUTE/MAIN": {
+    "locations": ["MAJOR_CHEST_RAINBOW_ROUTE"],
+    "events": [],
+    "exits": ["REGION_GAME_START"],
+    "warps": [],
+    "ability_gates": {
+      "CanCutRopes": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved rope_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Rope gating is unresolved for Rainbow Route big chest route."
+      },
+      "CanUseMini": {
+        "status": "unconfirmed",
+        "evidence": "katam_unresolved_big_chest_gates_report.json unresolved mini_semantic_unconfirmed",
+        "applies_to": ["future_major_chest_locations"],
+        "notes": "Mini routing remains a semantic candidate only for Rainbow Route big chest."
       }
     }
   },

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -16,6 +16,7 @@
 | `KirbyAM: deferring location polling/new item writes (...)` | Non-gameplay state detected; polling suspended. Fires once per state transition. |
 | `KirbyAM: gameplay-active state restored; resuming normal watcher flow` | Returned to gameplay-active state. |
 | `KirbyAM: resending RAM-derived LocationChecks missing on server (missing=..., acked=...)` | Shard bits found in RAM but not yet acknowledged by server; resending. |
+| `KirbyAM: resending major-chest LocationChecks missing on server (missing=..., acked=...)` | Big-chest area bits found in RAM but not yet acknowledged by server; resending. |
 | `KirbyAM: resending boss-defeat LocationChecks missing on server (missing=..., acked=...)` | Boss-defeat bits found in RAM but not yet acknowledged by server; resending. |
 | `KirbyAM: Writing mailbox item index N (item=..., player=...)` | Beginning delivery of the Nth received item. |
 | `KirbyAM: Mailbox ACK observed at item index N` | ROM cleared the flag; delivery confirmed. |
@@ -39,6 +40,7 @@
 ### Debug-level diagnostics
 Enable debug logging in your AP client to see these:
 - `dedupe suppressed LocationChecks` — shard/boss checks already acknowledged (per-tick spam suppressed at info level).
+- `dedupe suppressed major-chest LocationChecks` — major-chest checks already acknowledged (per-tick spam suppressed at info level).
 - `KirbyAM: boss candidate probe rising bits: ...` — rising-edge transitions detected in the boss mirror table probe. Useful during boss fights for address mapping.
 - `KirbyAM: unsafe-delivery candidate probe: X changed Y -> Z` — miniboss counter candidate changed. Research-only probe (Issue #223).
 
@@ -72,6 +74,39 @@ Validate that non-gameplay states defer location polling and new mailbox writes.
 Expected signal source for this gate:
 - ai_kirby_state_native at 0x0203AD2C (u32)
 - gameplay-active only when value == 300
+
+## Major Chest Checks (All Areas)
+
+Validate that the native big-chest area bitfield drives the currently shipped major-chest locations.
+
+1. Connect AP + BizHawk session with KirbyAM client logs visible.
+2. Open BizHawk Memory Viewer and watch `0x0203897C` as a 32-bit value.
+3. Open one of the currently integrated big chests (repeat for each):
+   - Rainbow Route (`bit 1`)
+   - Moonlight Mansion (`bit 2`)
+   - Cabbage Cavern (`bit 3`)
+   - Mustard Mountain (`bit 4`)
+   - Carrot Castle (`bit 5`)
+   - Olive Ocean (`bit 6`)
+   - Peppermint Palace (`bit 7`)
+   - Radish Ruins (`bit 8`)
+   - Candy Constellation (`bit 9`)
+4. Confirm the corresponding bit flips from `0` to `1` when the chest reward is claimed.
+5. Confirm the client logs a resend only if the server has not yet acknowledged the mapped location:
+   - `KirbyAM: resending major-chest LocationChecks missing on server (...)`
+6. Reconnect the AP client and confirm already-acknowledged major-chest checks are not replay-spammed.
+7. Save/reload or change rooms and confirm the bit remains set.
+
+Expected current mapping:
+- `bit 1` -> `MAJOR_CHEST_RAINBOW_ROUTE`
+- `bit 2` -> `MAJOR_CHEST_MOONLIGHT_MANSION`
+- `bit 3` -> `MAJOR_CHEST_CABBAGE_CAVERN`
+- `bit 4` -> `MAJOR_CHEST_MUSTARD_MOUNTAIN`
+- `bit 5` -> `MAJOR_CHEST_CARROT_CASTLE`
+- `bit 6` -> `MAJOR_CHEST_OLIVE_OCEAN`
+- `bit 7` -> `MAJOR_CHEST_PEPPERMINT_PALACE`
+- `bit 8` -> `MAJOR_CHEST_RADISH_RUINS`
+- `bit 9` -> `MAJOR_CHEST_CANDY_CONSTELLATION`
 
 ## Notification Pipeline Check (Issue #83)
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -62,7 +62,9 @@ Do not mix these two domains:
 2. Native game-state addresses
 - Purpose: in-game progression/check/goal state.
 - Source of truth: `worlds/kirbyam/data/native_address_policy.json` and `ram.native` in `worlds/kirbyam/data/addresses.json`.
-- Current integrated native signal: `shard_bitfield_native` at `0x02038970`.
+- Current integrated native signals:
+  - `shard_bitfield_native` at `0x02038970`
+  - `big_chest_bitfield_native` at `0x0203897C`
 
 Rule: AP transport fields must never be treated as native gameplay truth.
 
@@ -77,6 +79,7 @@ Current high-level status:
 | Signal type | Candidate | Integrated | Verified |
 | --- | --- | --- | --- |
 | Shard progression | Yes | Yes | Not yet policy-promoted |
+| Major chest checks | Yes | Yes | No |
 | Dungeon boss defeat | Yes | Yes (probe-only) | No |
 | Final boss defeat | Yes | Yes | No |
 | 100% completion | Yes | Yes | No |

--- a/worlds/kirbyam/groups.py
+++ b/worlds/kirbyam/groups.py
@@ -30,6 +30,7 @@ _LOCATION_GROUP_MAPS: dict[str, set[str]] = {
 _LOCATION_CATEGORY_TO_GROUP_NAME = {
     LocationCategory.SHARD: "Mirror Shards",
     LocationCategory.GOAL: "Goals",
+    LocationCategory.MAJOR_CHEST: "Major Chests",
 }
 
 # Pre-create category groups and map/area groups so they are always present during build.

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -187,6 +187,109 @@ async def test_no_location_checks_sent_when_all_already_server_acknowledged(mock
         assert mock_logger.debug.call_args.args[1] == [shard1, shard2]
 
 
+@pytest.mark.asyncio
+async def test_poll_major_chest_sends_location_checks_for_set_bits(mock_bizhawk_context):
+    """Set big-chest bits should map to major-chest LocationChecks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    cabbage = data.locations["MAJOR_CHEST_CABBAGE_CAVERN"].location_id
+    olive = data.locations["MAJOR_CHEST_OLIVE_OCEAN"].location_id
+    peppermint = data.locations["MAJOR_CHEST_PEPPERMINT_PALACE"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.native_ram_addresses, {"big_chest_bitfield_native": 0x0203897C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        # Bits 3, 6, 7 set => Cabbage, Olive, Peppermint major chests.
+        mock_read.return_value = [((1 << 3) | (1 << 6) | (1 << 7)).to_bytes(4, 'little')]
+
+        await client._poll_major_chest_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [cabbage, olive, peppermint]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_poll_major_chest_skips_already_server_acknowledged(mock_bizhawk_context):
+    """No major-chest resend when server already acknowledges all mapped checks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    olive = data.locations["MAJOR_CHEST_OLIVE_OCEAN"].location_id
+    mock_bizhawk_context.checked_locations = {olive}
+
+    with patch.dict(data.native_ram_addresses, {"big_chest_bitfield_native": 0x0203897C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.return_value = [((1 << 6)).to_bytes(4, 'little')]
+
+        await client._poll_major_chest_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
+    assert mock_logger.debug.called
+    assert "dedupe suppressed major-chest LocationChecks" in mock_logger.debug.call_args.args[0]
+    assert mock_logger.debug.call_args.args[1] == [olive]
+
+
+@pytest.mark.asyncio
+async def test_poll_major_chest_skips_when_address_missing(mock_bizhawk_context):
+    """Missing native big chest address should no-op safely."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    with patch.dict(data.native_ram_addresses, {}, clear=True), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        await client._poll_major_chest_locations(mock_bizhawk_context)
+
+    mock_read.assert_not_awaited()
+    mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shard_poll_does_not_trigger_major_chest_locations(mock_bizhawk_context):
+    """Shard polling should not emit major-chest location IDs."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.checked_locations = set()
+    major_chest_ids = {
+        loc.location_id
+        for loc in data.locations.values()
+        if loc.category.name == "MAJOR_CHEST"
+    }
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.return_value = [(0x03).to_bytes(4, 'little')]  # shard bits 0 and 1
+
+        await client._poll_locations(mock_bizhawk_context)
+
+    sent_locations = set(mock_send.await_args.args[0][0]["locations"])
+    assert sent_locations.isdisjoint(major_chest_ids)
+
+
+def test_major_chest_data_sanity():
+    """Major-chest entries should have explicit unique IDs and unique mapped bits."""
+    major_chests = [
+        loc for loc in data.locations.values()
+        if loc.category.name == "MAJOR_CHEST"
+    ]
+
+    assert major_chests
+
+    ids = [loc.location_id for loc in major_chests]
+    assert all(loc_id is not None for loc_id in ids)
+    assert len(ids) == len(set(ids))
+
+    bits = [loc.bit_index for loc in major_chests]
+    assert all(bit is not None for bit in bits)
+    assert len(bits) == len(set(bits))
+
+
 def test_client_initialization():
     """Test client state is properly initialized."""
     client = KirbyAmClient()
@@ -1115,6 +1218,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
     client._last_runtime_gate_reason = "non_gameplay_cutscene"
     client._last_shard_poll_log = ("resend", (1,), ())
     client._last_boss_poll_log = ("resend", (2,), ())
+    client._last_major_chest_poll_log = ("resend", (3,), ())
     client._last_boss_probe_snapshot = bytes(32)
     client._boss_probe_stream_marker = object()
     client._unsafe_delivery_probe_stream_marker = object()
@@ -1125,6 +1229,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
          patch.object(client, '_poll_locations', new_callable=AsyncMock) as mock_poll_locations, \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock) as mock_poll_boss, \
+            patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock) as mock_poll_major_chests, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
          patch.object(client, '_deliver_items', new_callable=AsyncMock) as mock_deliver, \
@@ -1137,6 +1242,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         assert client._last_runtime_gate_reason is None
         assert client._last_shard_poll_log is None
         assert client._last_boss_poll_log is None
+        assert client._last_major_chest_poll_log is None
         assert client._last_boss_probe_snapshot is None
         assert client._boss_probe_stream_marker is None
         assert client._unsafe_delivery_probe_stream_marker is None
@@ -1145,6 +1251,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         mock_load.assert_awaited_once()
         mock_poll_locations.assert_awaited_once()
         mock_poll_boss.assert_awaited_once()
+        mock_poll_major_chests.assert_awaited_once()
         mock_probe.assert_awaited_once()
         mock_probe_unsafe.assert_awaited_once()
         mock_deliver.assert_awaited_once_with(mock_bizhawk_context)


### PR DESCRIPTION
## Summary

Expands the AP world with all 9 area big-chest locations, covering every area bit (1-9) in `gTreasures.bigChestField` at `0x0203897C`.

Closes #36.

---

## Motivation

The game maintains a u32 bitfield (`gTreasures.bigChestField`) where bit N is set when all big chests in area N have been opened. Area IDs 1-9 correspond to the 9 playable areas (bit 0 = Tutorial has no accessible chest; bit 10 = Dimension Mirror has none). This PR adds all 9 AP locations covering those bits.

---

## Changes

### New locations (9 total, `MAJOR_CHEST` category)

| Key | Bit | Location ID | Parent Region |
|-----|-----|-------------|---------------|
| `MAJOR_CHEST_RAINBOW_ROUTE` | 1 | 3960203 | `REGION_RAINBOW_ROUTE/MAIN` (new) |
| `MAJOR_CHEST_MOONLIGHT_MANSION` | 2 | 3960204 | `REGION_MOONLIGHT_MANSION/MAIN` |
| `MAJOR_CHEST_CABBAGE_CAVERN` | 3 | 3960200 | `REGION_CABBAGE_CAVERN/MAIN` |
| `MAJOR_CHEST_MUSTARD_MOUNTAIN` | 4 | 3960205 | `REGION_MUSTARD_MOUNTAIN/MAIN` |
| `MAJOR_CHEST_CARROT_CASTLE` | 5 | 3960206 | `REGION_CARROT_CASTLE/MAIN` |
| `MAJOR_CHEST_OLIVE_OCEAN` | 6 | 3960201 | `REGION_OLIVE_OCEAN/MAIN` |
| `MAJOR_CHEST_PEPPERMINT_PALACE` | 7 | 3960202 | `REGION_PEPPERMINT_PALACE/MAIN` |
| `MAJOR_CHEST_RADISH_RUINS` | 8 | 3960207 | `REGION_RADISH_RUINS/MAIN` |
| `MAJOR_CHEST_CANDY_CONSTELLATION` | 9 | 3960208 | `REGION_CANDY_CONSTELLATION/MAIN` |

### New item

`MAP_RAINBOW_ROUTE` (item_id `3860024`) — required because Rainbow Route had no map item defined; all other 8 areas already had `MAP_*` items in the pool. ID 3860024 was chosen because 3860002–3860009 are occupied by `SHARD_1–SHARD_8` via auto-assignment and 3860010–3860023 are taken by existing MAP/VITALITY/nUP items.

### New region

`REGION_RAINBOW_ROUTE/MAIN` added to `areas.json` (Rainbow Route was the only area with no AP region). Connected via `REGION_GAME_START` exits. Ability gate metadata included (rope/mini, `status: "unconfirmed"`, non-enforced).

### Updated files

- `worlds/kirbyam/data/locations.json` — 6 new MAJOR_CHEST entries (3960203-3960208)
- `worlds/kirbyam/data/regions/areas.json` — 5 existing regions updated with `MAJOR_CHEST_*` in locations; new `REGION_RAINBOW_ROUTE/MAIN` entry; `REGION_GAME_START` exits extended
- `worlds/kirbyam/data/items.json` — `MAP_RAINBOW_ROUTE` (item_id `3860024`) added
- `worlds/kirbyam/data.py` — `LocationCategory.MAJOR_CHEST = 9` (was 3)
- `worlds/kirbyam/client.py` — `_poll_major_chest_locations()` iterates dynamically; no code change needed for new bits
- Docs: `PROTOCOL.md`, `ADDRESS_VERIFICATION_MATRIX.md`, `BIZHAWK_TESTING_GUIDE.md`, `notes.md`
- Tests: `test/test_client.py` — 5 major chest tests

---

## Evidence trail

**Claim:** `gTreasures.bigChestField` bits 1-9 each map to one area's big-chest collection state.

**Source:** `KATAM_AI_REFERENCE.md` §Treasures → `gTreasures` struct; `katam/include/pause_area_map.h` `AreaId` enum (AREA_RAINBOW_ROUTE=1 … AREA_CANDY_CONSTELLATION=9); `katam_unresolved_big_chest_gates_report.json` confirming 14 physical big-chest rooms across exactly 9 area IDs.

**Adaptation:** AP location keys use area name suffixes; bit_index = area_id; location IDs assigned in the `3960200-3960208` range.

**Validation:** 104 tests pass (up from 63 before this PR). The client's `_poll_major_chest_locations()` loop auto-picks up all 9 entries at `initialize_client()` time — no client logic change required.

---

## Gate semantics note

Ability gate evidence for the 6 newly promoted areas (bits 1, 2, 4, 5, 8, 9) was previously classified as `rope_semantic_unconfirmed` or `mini_semantic_unconfirmed`. This gating metadata is retained in each region's `ability_gates` block with `status: "unconfirmed"` and `applies_to: ["future_major_chest_locations"]` — it does **not** enforce any AP access rule today. Resolution of these gates is a follow-on task.

---

## Live verification needed

Issue #296 tracks manual BizHawk verification of all 9 big-chest bits against `0x0203897C`. The existing 3 locations (bits 3, 6, 7) were confirmed by the prior investigation; bits 1, 2, 4, 5, 8, 9 await live testing.
