### PR TITLE
Issue #111: Enemy copy-ability randomization with whitelist remap

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -1,5 +1,13 @@
 # KirbyAM APWorld Changelog
 
+## Unreleased
+
+- Add enemy copy-ability randomization option with deterministic whitelist mode.
+- Emit enemy ability whitelist and seed-locked remap table in slot-data for
+	client/payload integration work.
+- Add deterministic/whitelist validation tests for enemy copy-ability remap
+	generation.
+
 ## v0.0.1
 
 - Establish tag-driven draft GitHub release publishing for `kirbyam.apworld`.

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-- Add enemy copy-ability randomization option with deterministic whitelist mode.
-- Emit enemy ability whitelist and seed-locked remap table in slot-data for
-	client/payload integration work.
-- Add deterministic/whitelist validation tests for enemy copy-ability remap
-	generation.
+- Add enemy copy-ability randomization options for vanilla, shuffled, and
+	completely-random enemy grant behavior.
+- Add scope toggles for boss-spawned ability grants and mini-boss ability
+	grants.
+- Emit validated ability whitelist (excluding `Crash`/`Wait`) and deterministic
+	enemy randomization policy in slot-data.
+- Add deterministic/safety validation tests for enemy randomization policy.
 
 ## v0.0.1
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## Unreleased
 
 - Add enemy copy-ability randomization options for vanilla, shuffled, and
-	completely-random enemy grant behavior.
+  completely-random enemy grant behavior.
 - Add scope toggles for boss-spawned ability grants and mini-boss ability
-	grants.
+  grants.
 - Emit validated ability whitelist (excluding `Crash`/`Wait`) and deterministic
-	enemy randomization policy in slot-data.
+  enemy randomization policy in slot-data.
 - Add deterministic/safety validation tests for enemy randomization policy.
 
 ## v0.0.1

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -100,6 +100,13 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 Client → Server: Connect with game="Kirby & The Amazing Mirror", slot="<player>"
 Server → Client: ConnectionRefused | Connected
                  (with items_received, checked_locations, slot_data)
+
+`slot_data` currently includes:
+- `goal` (int): selected goal option.
+- `shards` (int): shard randomization mode.
+- `enemy_copy_ability_randomization` (int): enemy copy-ability mode (`0=vanilla`, `1=shuffle_whitelist`).
+- `enemy_copy_ability_whitelist` (list[str]): validated ability pool used for enemy remap generation.
+- `enemy_copy_ability_remap` (dict[str, str]): deterministic source->target ability mapping for the slot.
 ```
 
 **Preconditions before gameplay watchers run:**

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -104,9 +104,11 @@ Server → Client: ConnectionRefused | Connected
 `slot_data` currently includes:
 - `goal` (int): selected goal option.
 - `shards` (int): shard randomization mode.
-- `enemy_copy_ability_randomization` (int): enemy copy-ability mode (`0=vanilla`, `1=shuffle_whitelist`).
-- `enemy_copy_ability_whitelist` (list[str]): validated ability pool used for enemy remap generation.
-- `enemy_copy_ability_remap` (dict[str, str]): deterministic source->target ability mapping for the slot.
+- `enemy_copy_ability_randomization` (int): enemy copy-ability mode (`0=vanilla`, `1=shuffled`, `2=completely_random`).
+- `randomize_boss_spawned_ability_grants` (bool): include/exclude ability-granting boss-spawned objects.
+- `randomize_miniboss_ability_grants` (bool): include/exclude mini-boss ability grants.
+- `enemy_copy_ability_whitelist` (list[str]): validated ability pool (must exclude `Crash` and `Wait`).
+- `enemy_copy_ability_policy` (dict): deterministic policy payload used by runtime hooks.
 ```
 
 **Preconditions before gameplay watchers run:**

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -14,7 +14,7 @@ from worlds.AutoWorld import WebWorld, World
 from .client import KirbyAmClient  # type: ignore  # Required to register BizHawk client
 from .ability_randomization import (
     VALID_ENEMY_COPY_ABILITIES,
-    build_enemy_copy_ability_remap,
+    build_enemy_copy_ability_policy,
 )
 from .data import LocationCategory
 from .data import data as kirby_data
@@ -108,7 +108,7 @@ class KirbyAmWorld(World):
 
     # Track generation timing
     _generation_start_time: float
-    _enemy_copy_ability_remap: dict[str, str]
+    _enemy_copy_ability_policy: dict[str, Any]
 
     # Generation stages
     _FILLER_ITEM_WEIGHTS: ClassVar[tuple[tuple[str, int], ...]] = (
@@ -145,23 +145,36 @@ class KirbyAmWorld(World):
                 logger.info(f"[P{self.player}] Shards mode: {self.options.shards.current_key}")
 
             mode = int(self.options.enemy_copy_ability_randomization.value)
-            self._enemy_copy_ability_remap = build_enemy_copy_ability_remap(self.random, mode)
+            randomize_boss_spawned = bool(self.options.randomize_boss_spawned_ability_grants.value)
+            randomize_miniboss = bool(self.options.randomize_miniboss_ability_grants.value)
+            self._enemy_copy_ability_policy = build_enemy_copy_ability_policy(
+                self.random,
+                mode,
+                randomize_boss_spawned,
+                randomize_miniboss,
+            )
             if mode == EnemyCopyAbilityRandomization.option_vanilla:
                 logger.info(
                     "[P%s] Enemy copy-ability randomization: vanilla (%s whitelist entries)",
                     self.player,
                     len(VALID_ENEMY_COPY_ABILITIES),
                 )
+            elif mode == EnemyCopyAbilityRandomization.option_shuffled:
+                logger.info(
+                    "[P%s] Enemy copy-ability randomization: shuffled (%s whitelist entries)",
+                    self.player,
+                    len(VALID_ENEMY_COPY_ABILITIES),
+                )
             else:
                 logger.info(
-                    "[P%s] Enemy copy-ability randomization: shuffle_whitelist (%s whitelist entries)",
+                    "[P%s] Enemy copy-ability randomization: completely_random (%s whitelist entries)",
                     self.player,
                     len(VALID_ENEMY_COPY_ABILITIES),
                 )
                 logger.debug(
-                    "[P%s] Enemy copy-ability remap table: %s",
+                    "[P%s] Enemy copy-ability policy: %s",
                     self.player,
-                    self._enemy_copy_ability_remap,
+                    self._enemy_copy_ability_policy,
                 )
 
     # Create world regions
@@ -326,13 +339,22 @@ class KirbyAmWorld(World):
             "goal",
             "shards",
             "enemy_copy_ability_randomization",
+            "randomize_boss_spawned_ability_grants",
+            "randomize_miniboss_ability_grants",
         )
-        remap = getattr(self, "_enemy_copy_ability_remap", None)
-        if remap is None:
+        policy = getattr(self, "_enemy_copy_ability_policy", None)
+        if policy is None:
             mode = int(self.options.enemy_copy_ability_randomization.value)
-            remap = build_enemy_copy_ability_remap(self.random, mode)
+            randomize_boss_spawned = bool(self.options.randomize_boss_spawned_ability_grants.value)
+            randomize_miniboss = bool(self.options.randomize_miniboss_ability_grants.value)
+            policy = build_enemy_copy_ability_policy(
+                self.random,
+                mode,
+                randomize_boss_spawned,
+                randomize_miniboss,
+            )
         slot_data["enemy_copy_ability_whitelist"] = list(VALID_ENEMY_COPY_ABILITIES)
-        slot_data["enemy_copy_ability_remap"] = dict(remap)
+        slot_data["enemy_copy_ability_policy"] = dict(policy)
         return slot_data
 
     # Helper methods to create items and events

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -12,6 +12,10 @@ from BaseClasses import ItemClassification, LocationProgressType, MultiWorld, Tu
 from worlds.AutoWorld import WebWorld, World
 
 from .client import KirbyAmClient  # type: ignore  # Required to register BizHawk client
+from .ability_randomization import (
+    VALID_ENEMY_COPY_ABILITIES,
+    build_enemy_copy_ability_remap,
+)
 from .data import LocationCategory
 from .data import data as kirby_data
 from .generation_logging import (
@@ -26,7 +30,13 @@ from .generation_logging import (
 from .groups import ITEM_GROUPS, LOCATION_GROUPS
 from .items import KirbyAmItem, create_item_label_to_code_map, get_item_classification
 from .locations import KirbyAmLocation, create_location_label_to_id_map
-from .options import OPTION_GROUPS, Goal, KirbyAmOptions, RandomizeShards
+from .options import (
+    OPTION_GROUPS,
+    EnemyCopyAbilityRandomization,
+    Goal,
+    KirbyAmOptions,
+    RandomizeShards,
+)
 from .rom import KirbyAmProcedurePatch, write_tokens
 
 if TYPE_CHECKING:
@@ -98,6 +108,7 @@ class KirbyAmWorld(World):
 
     # Track generation timing
     _generation_start_time: float
+    _enemy_copy_ability_remap: dict[str, str]
 
     # Generation stages
     _FILLER_ITEM_WEIGHTS: ClassVar[tuple[tuple[str, int], ...]] = (
@@ -132,6 +143,26 @@ class KirbyAmWorld(World):
                 logger.info(f"[P{self.player}] Shards marked as local items (shuffle mode)")
             else:
                 logger.info(f"[P{self.player}] Shards mode: {self.options.shards.current_key}")
+
+            mode = int(self.options.enemy_copy_ability_randomization.value)
+            self._enemy_copy_ability_remap = build_enemy_copy_ability_remap(self.random, mode)
+            if mode == EnemyCopyAbilityRandomization.option_vanilla:
+                logger.info(
+                    "[P%s] Enemy copy-ability randomization: vanilla (%s whitelist entries)",
+                    self.player,
+                    len(VALID_ENEMY_COPY_ABILITIES),
+                )
+            else:
+                logger.info(
+                    "[P%s] Enemy copy-ability randomization: shuffle_whitelist (%s whitelist entries)",
+                    self.player,
+                    len(VALID_ENEMY_COPY_ABILITIES),
+                )
+                logger.debug(
+                    "[P%s] Enemy copy-ability remap table: %s",
+                    self.player,
+                    self._enemy_copy_ability_remap,
+                )
 
     # Create world regions
     def create_regions(self) -> None:
@@ -291,10 +322,18 @@ class KirbyAmWorld(World):
     # Helper method to fill slot data
     def fill_slot_data(self) -> dict[str, Any]:
         # Slot data needed by client. Keep minimal while you iterate.
-        return self.options.as_dict(
+        slot_data = self.options.as_dict(
             "goal",
             "shards",
+            "enemy_copy_ability_randomization",
         )
+        remap = getattr(self, "_enemy_copy_ability_remap", None)
+        if remap is None:
+            mode = int(self.options.enemy_copy_ability_randomization.value)
+            remap = build_enemy_copy_ability_remap(self.random, mode)
+        slot_data["enemy_copy_ability_whitelist"] = list(VALID_ENEMY_COPY_ABILITIES)
+        slot_data["enemy_copy_ability_remap"] = dict(remap)
+        return slot_data
 
     # Helper methods to create items and events
     def create_item(self, name: str) -> KirbyAmItem:

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -343,17 +343,11 @@ class KirbyAmWorld(World):
             "randomize_miniboss_ability_grants",
         )
         policy = getattr(self, "_enemy_copy_ability_policy", None)
-        if policy is None:
-            mode = int(self.options.enemy_copy_ability_randomization.value)
-            randomize_boss_spawned = bool(self.options.randomize_boss_spawned_ability_grants.value)
-            randomize_miniboss = bool(self.options.randomize_miniboss_ability_grants.value)
-            policy = build_enemy_copy_ability_policy(
-                self.random,
-                mode,
-                randomize_boss_spawned,
-                randomize_miniboss,
-            )
-        slot_data["enemy_copy_ability_whitelist"] = list(VALID_ENEMY_COPY_ABILITIES)
+        assert policy is not None, (
+            "Enemy copy ability policy must be initialized before fill_slot_data is called."
+        )
+        allowed_abilities = policy.get("allowed_abilities", VALID_ENEMY_COPY_ABILITIES)
+        slot_data["enemy_copy_ability_whitelist"] = list(allowed_abilities)
         slot_data["enemy_copy_ability_policy"] = dict(policy)
         return slot_data
 

--- a/worlds/kirbyam/ability_randomization.py
+++ b/worlds/kirbyam/ability_randomization.py
@@ -1,0 +1,69 @@
+"""Deterministic enemy copy-ability remap helpers for KirbyAM.
+
+Issue #111 introduces option-level randomization for enemy-granted copy
+abilities using a conservative whitelist. This module is intentionally pure
+Python so generation/test behavior remains deterministic and easy to validate.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+from .options import EnemyCopyAbilityRandomization
+
+# Conservative whitelist used by issue #111. Ability names align with existing
+# gate/source terminology in rules.py and design notes.
+VALID_ENEMY_COPY_ABILITIES: tuple[str, ...] = (
+    "Burning",
+    "Cutter",
+    "Fire",
+    "Hammer",
+    "Laser",
+    "Mini",
+    "Missile",
+    "Needle",
+    "Parasol",
+    "Sleep",
+    "Spark",
+    "Stone",
+    "Sword",
+    "Tornado",
+    "UFO",
+)
+
+
+def _normalize_whitelist(values: Iterable[str]) -> list[str]:
+    normalized = sorted({value.strip() for value in values if value and value.strip()})
+    if not normalized:
+        raise ValueError("enemy copy-ability whitelist cannot be empty")
+    return normalized
+
+
+def build_enemy_copy_ability_remap(
+    rng: random.Random,
+    mode: int,
+    whitelist: Iterable[str] = VALID_ENEMY_COPY_ABILITIES,
+) -> dict[str, str]:
+    """Build a deterministic enemy ability remap table for slot-data.
+
+    Returns an identity mapping for vanilla mode, and a seeded permutation for
+    whitelist shuffle mode.
+    """
+    ordered = _normalize_whitelist(whitelist)
+
+    if mode == EnemyCopyAbilityRandomization.option_vanilla:
+        return {name: name for name in ordered}
+
+    if mode != EnemyCopyAbilityRandomization.option_shuffle_whitelist:
+        raise ValueError(f"unsupported enemy copy-ability randomization mode: {mode}")
+
+    shuffled = list(ordered)
+    rng.shuffle(shuffled)
+    return {source: target for source, target in zip(ordered, shuffled)}
+
+
+def remap_is_whitelist_preserving(remap: dict[str, str], whitelist: Iterable[str]) -> bool:
+    """Validate remap source/target keys stay within the supplied whitelist."""
+    ordered = set(_normalize_whitelist(whitelist))
+    return set(remap.keys()) == ordered and set(remap.values()) == ordered

--- a/worlds/kirbyam/ability_randomization.py
+++ b/worlds/kirbyam/ability_randomization.py
@@ -45,6 +45,9 @@ def _normalize_whitelist(values: Iterable[str]) -> list[str]:
     forbidden = FORBIDDEN_ENEMY_COPY_ABILITIES.intersection(normalized)
     if forbidden:
         raise ValueError(f"forbidden enemy copy abilities present: {sorted(forbidden)}")
+    unknown = set(normalized).difference(VALID_ENEMY_COPY_ABILITIES)
+    if unknown:
+        raise ValueError(f"unknown enemy copy abilities present: {sorted(unknown)}")
     return normalized
 
 
@@ -153,11 +156,9 @@ def build_enemy_copy_ability_remap(
         return {name: name for name in ordered}
 
     if mode == EnemyCopyAbilityRandomization.option_shuffled:
-        seed = rng.getrandbits(64)
-        mapping: dict[str, str] = {}
-        for source in ordered:
-            mapping[source] = ordered[_stable_index(seed, source, len(ordered))]
-        return mapping
+        shuffled = list(ordered)
+        random.Random(rng.getrandbits(64)).shuffle(shuffled)
+        return {source: target for source, target in zip(ordered, shuffled)}
 
     if mode == EnemyCopyAbilityRandomization.option_completely_random:
         # Snapshot remap for compatibility only; runtime per-event behavior uses

--- a/worlds/kirbyam/ability_randomization.py
+++ b/worlds/kirbyam/ability_randomization.py
@@ -1,19 +1,24 @@
-"""Deterministic enemy copy-ability remap helpers for KirbyAM.
+"""Enemy copy-ability randomization helpers for KirbyAM.
 
-Issue #111 introduces option-level randomization for enemy-granted copy
-abilities using a conservative whitelist. This module is intentionally pure
-Python so generation/test behavior remains deterministic and easy to validate.
+Issue #111 defines three enemy randomization modes:
+- vanilla
+- shuffled (enemy type deterministic)
+- completely random (per grant event)
+
+Enemy statues are intentionally out of scope (issue #209).
 """
 
 from __future__ import annotations
 
+import hashlib
 import random
-from typing import Iterable
+from typing import Any, Iterable
 
 from .options import EnemyCopyAbilityRandomization
 
-# Conservative whitelist used by issue #111. Ability names align with existing
-# gate/source terminology in rules.py and design notes.
+# Crash/Wait are intentionally excluded by design (issue #111).
+FORBIDDEN_ENEMY_COPY_ABILITIES: frozenset[str] = frozenset({"Crash", "Wait"})
+
 VALID_ENEMY_COPY_ABILITIES: tuple[str, ...] = (
     "Burning",
     "Cutter",
@@ -37,7 +42,98 @@ def _normalize_whitelist(values: Iterable[str]) -> list[str]:
     normalized = sorted({value.strip() for value in values if value and value.strip()})
     if not normalized:
         raise ValueError("enemy copy-ability whitelist cannot be empty")
+    forbidden = FORBIDDEN_ENEMY_COPY_ABILITIES.intersection(normalized)
+    if forbidden:
+        raise ValueError(f"forbidden enemy copy abilities present: {sorted(forbidden)}")
     return normalized
+
+
+def build_enemy_copy_ability_policy(
+    rng: random.Random,
+    mode: int,
+    randomize_boss_spawned_ability_grants: bool,
+    randomize_miniboss_ability_grants: bool,
+    whitelist: Iterable[str] = VALID_ENEMY_COPY_ABILITIES,
+
+) -> dict[str, Any]:
+    """Build deterministic slot-data policy for enemy copy-ability randomization.
+
+    For shuffled mode, enemy types can be mapped with `ability_for_enemy_type`.
+    For completely random mode, grant events can be mapped with
+    `ability_for_enemy_grant_event`.
+    """
+    ordered = _normalize_whitelist(whitelist)
+
+    policy: dict[str, Any] = {
+        "mode": int(mode),
+        "allowed_abilities": ordered,
+        "randomize_boss_spawned_ability_grants": bool(randomize_boss_spawned_ability_grants),
+        "randomize_miniboss_ability_grants": bool(randomize_miniboss_ability_grants),
+    }
+
+    if mode == EnemyCopyAbilityRandomization.option_vanilla:
+        policy["identity_map"] = {name: name for name in ordered}
+        return policy
+
+    seed_value = rng.getrandbits(64)
+    policy["seed"] = seed_value
+
+    if mode == EnemyCopyAbilityRandomization.option_shuffled:
+        policy["mapping_style"] = "per_enemy_type"
+        return policy
+
+    if mode == EnemyCopyAbilityRandomization.option_completely_random:
+        policy["mapping_style"] = "per_grant_event"
+        return policy
+
+    raise ValueError(f"unsupported enemy copy-ability randomization mode: {mode}")
+
+
+def _stable_index(seed: int, key: str, pool_size: int) -> int:
+    payload = f"{seed}:{key}".encode("utf-8")
+    digest = hashlib.sha256(payload).digest()
+    return int.from_bytes(digest[:8], "little") % pool_size
+
+
+def ability_for_enemy_type(policy: dict[str, Any], enemy_type_key: str) -> str:
+    """Return the deterministic shuffled ability for an enemy type key."""
+    if int(policy.get("mode", -1)) != EnemyCopyAbilityRandomization.option_shuffled:
+        raise ValueError("ability_for_enemy_type requires shuffled mode policy")
+
+    abilities = list(policy.get("allowed_abilities", []))
+    if not abilities:
+        raise ValueError("policy allowed_abilities cannot be empty")
+
+    seed = int(policy.get("seed", 0))
+    index = _stable_index(seed, enemy_type_key, len(abilities))
+    return abilities[index]
+
+
+def ability_for_enemy_grant_event(policy: dict[str, Any], event_index: int, enemy_type_key: str) -> str:
+    """Return the deterministic per-event ability for completely random mode."""
+    if int(policy.get("mode", -1)) != EnemyCopyAbilityRandomization.option_completely_random:
+        raise ValueError("ability_for_enemy_grant_event requires completely random mode policy")
+
+    abilities = list(policy.get("allowed_abilities", []))
+    if not abilities:
+        raise ValueError("policy allowed_abilities cannot be empty")
+
+    seed = int(policy.get("seed", 0))
+    event_key = f"{enemy_type_key}:{event_index}"
+    index = _stable_index(seed, event_key, len(abilities))
+    return abilities[index]
+
+
+def policy_is_whitelist_preserving(policy: dict[str, Any], whitelist: Iterable[str]) -> bool:
+    ordered = set(_normalize_whitelist(whitelist))
+    allowed = set(policy.get("allowed_abilities", []))
+    return allowed == ordered
+
+
+def remap_is_whitelist_preserving(remap: dict[str, str], whitelist: Iterable[str]) -> bool:
+    """Backwards-compatible helper for identity/remap tables."""
+    ordered = set(_normalize_whitelist(whitelist))
+    return set(remap.keys()) == ordered and set(remap.values()) == ordered
 
 
 def build_enemy_copy_ability_remap(
@@ -45,25 +141,29 @@ def build_enemy_copy_ability_remap(
     mode: int,
     whitelist: Iterable[str] = VALID_ENEMY_COPY_ABILITIES,
 ) -> dict[str, str]:
-    """Build a deterministic enemy ability remap table for slot-data.
+    """Backwards-compatible helper used by older tests/callers.
 
-    Returns an identity mapping for vanilla mode, and a seeded permutation for
-    whitelist shuffle mode.
+    - vanilla returns identity
+    - shuffled returns deterministic permutation
+    - completely random returns a deterministic permutation snapshot
     """
     ordered = _normalize_whitelist(whitelist)
 
     if mode == EnemyCopyAbilityRandomization.option_vanilla:
         return {name: name for name in ordered}
 
-    if mode != EnemyCopyAbilityRandomization.option_shuffle_whitelist:
-        raise ValueError(f"unsupported enemy copy-ability randomization mode: {mode}")
+    if mode == EnemyCopyAbilityRandomization.option_shuffled:
+        seed = rng.getrandbits(64)
+        mapping: dict[str, str] = {}
+        for source in ordered:
+            mapping[source] = ordered[_stable_index(seed, source, len(ordered))]
+        return mapping
 
-    shuffled = list(ordered)
-    rng.shuffle(shuffled)
-    return {source: target for source, target in zip(ordered, shuffled)}
+    if mode == EnemyCopyAbilityRandomization.option_completely_random:
+        # Snapshot remap for compatibility only; runtime per-event behavior uses
+        # ability_for_enemy_grant_event with policy mode.
+        shuffled = list(ordered)
+        rng.shuffle(shuffled)
+        return {source: target for source, target in zip(ordered, shuffled)}
 
-
-def remap_is_whitelist_preserving(remap: dict[str, str], whitelist: Iterable[str]) -> bool:
-    """Validate remap source/target keys stay within the supplied whitelist."""
-    ordered = set(_normalize_whitelist(whitelist))
-    return set(remap.keys()) == ordered and set(remap.values()) == ordered
+    raise ValueError(f"unsupported enemy copy-ability randomization mode: {mode}")

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -704,6 +704,30 @@ This issue only establishes naming and evidence scaffolding. Ability items are
 still absent from the pool, so all five helpers intentionally resolve to true
 until a later issue introduces actual ability acquisition logic.
 
+## Issue #111: Enemy Copy-Ability Randomization with Whitelist
+
+### Problem
+Enemy copy abilities were still fully vanilla/static, and there was no
+seed-deterministic mapping artifact that downstream client/payload work could
+consume safely. We also needed a conservative whitelist boundary so generation
+never emits unknown or invalid ability names.
+
+### Solution
+Added deterministic enemy copy-ability remap generation in
+`worlds/kirbyam/ability_randomization.py` with two modes:
+- `vanilla`: identity mapping
+- `shuffle_whitelist`: seeded permutation inside a validated whitelist
+
+The world now emits the following slot-data contract:
+- `enemy_copy_ability_randomization`
+- `enemy_copy_ability_whitelist`
+- `enemy_copy_ability_remap`
+
+### Deliberate Scope Limit
+This issue establishes generation-time mapping and protocol exposure only. It
+does not patch statue randomization paths (#209) and does not yet introduce
+ability-item ownership gating (#84).
+
 ## Issue #41: Multi-Item Filler Pool (Phase 1)
 
 ### Problem

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -713,15 +713,20 @@ consume safely. We also needed a conservative whitelist boundary so generation
 never emits unknown or invalid ability names.
 
 ### Solution
-Added deterministic enemy copy-ability remap generation in
-`worlds/kirbyam/ability_randomization.py` with two modes:
+Added deterministic enemy copy-ability policy generation in
+`worlds/kirbyam/ability_randomization.py` with three modes:
 - `vanilla`: identity mapping
-- `shuffle_whitelist`: seeded permutation inside a validated whitelist
+- `shuffled`: deterministic per-enemy-type assignment
+- `completely_random`: deterministic per-grant-event assignment
+
+The validated whitelist explicitly excludes `Crash` and `Wait`.
 
 The world now emits the following slot-data contract:
 - `enemy_copy_ability_randomization`
+- `randomize_boss_spawned_ability_grants`
+- `randomize_miniboss_ability_grants`
 - `enemy_copy_ability_whitelist`
-- `enemy_copy_ability_remap`
+- `enemy_copy_ability_policy`
 
 ### Deliberate Scope Limit
 This issue establishes generation-time mapping and protocol exposure only. It

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -3,7 +3,7 @@ Option definitions for Kirby & The Amazing Mirror
 """
 from dataclasses import dataclass
 
-from Options import Choice, DeathLink, PerGameCommonOptions
+from Options import Choice, DeathLink, PerGameCommonOptions, Toggle
 
 
 class Goal(Choice):
@@ -41,13 +41,28 @@ class EnemyCopyAbilityRandomization(Choice):
         Controls randomization of enemy-granted copy abilities.
 
         - Vanilla: Enemy copy abilities stay at native defaults.
-        - Shuffle Whitelist: Enemy copy abilities are remapped deterministically
-            within a validated whitelist.
+        - Shuffled: Enemy types are remapped deterministically so all enemies of
+            the same type grant the same ability.
+        - Completely Random: Each eligible enemy ability grant can roll a different
+            ability.
         """
         display_name = "Enemy Copy-Ability Randomization"
         default = 0
         option_vanilla = 0
-        option_shuffle_whitelist = 1
+        option_shuffled = 1
+        option_completely_random = 2
+
+
+class RandomizeBossSpawnedAbilityGrants(Toggle):
+        """Whether ability-granting objects spawned by bosses are randomized."""
+        display_name = "Randomize Boss-Spawned Ability Grants"
+        default = 1
+
+
+class RandomizeMiniBossAbilityGrants(Toggle):
+        """Whether mini-boss ability grants are randomized."""
+        display_name = "Randomize Mini-Boss Ability Grants"
+        default = 1
 
 
 class KirbyAmDeathLink(DeathLink):
@@ -61,6 +76,10 @@ class KirbyAmOptions(PerGameCommonOptions):
     shards: RandomizeShards
 
     enemy_copy_ability_randomization: EnemyCopyAbilityRandomization
+
+    randomize_boss_spawned_ability_grants: RandomizeBossSpawnedAbilityGrants
+
+    randomize_miniboss_ability_grants: RandomizeMiniBossAbilityGrants
 
     death_link: KirbyAmDeathLink
 

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -54,15 +54,15 @@ class EnemyCopyAbilityRandomization(Choice):
 
 
 class RandomizeBossSpawnedAbilityGrants(Toggle):
-        """Whether ability-granting objects spawned by bosses are randomized."""
-        display_name = "Randomize Boss-Spawned Ability Grants"
-        default = 1
+    """Whether ability-granting objects spawned by bosses are randomized."""
+    display_name = "Randomize Boss-Spawned Ability Grants"
+    default = 1
 
 
 class RandomizeMiniBossAbilityGrants(Toggle):
-        """Whether mini-boss ability grants are randomized."""
-        display_name = "Randomize Mini-Boss Ability Grants"
-        default = 1
+    """Whether mini-boss ability grants are randomized."""
+    display_name = "Randomize Mini-Boss Ability Grants"
+    default = 1
 
 
 class KirbyAmDeathLink(DeathLink):

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -36,6 +36,20 @@ class RandomizeShards(Choice):
     option_completely_random = 2
 
 
+class EnemyCopyAbilityRandomization(Choice):
+        """
+        Controls randomization of enemy-granted copy abilities.
+
+        - Vanilla: Enemy copy abilities stay at native defaults.
+        - Shuffle Whitelist: Enemy copy abilities are remapped deterministically
+            within a validated whitelist.
+        """
+        display_name = "Enemy Copy-Ability Randomization"
+        default = 0
+        option_vanilla = 0
+        option_shuffle_whitelist = 1
+
+
 class KirbyAmDeathLink(DeathLink):
     __doc__ = (DeathLink.__doc__ or "") + "\n\n    NOT READY YET: In Kirby & The Amazing Mirror, dying sets your current health to zero."
 
@@ -45,6 +59,8 @@ class KirbyAmOptions(PerGameCommonOptions):
     goal: Goal
 
     shards: RandomizeShards
+
+    enemy_copy_ability_randomization: EnemyCopyAbilityRandomization
 
     death_link: KirbyAmDeathLink
 

--- a/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
@@ -1,0 +1,62 @@
+"""Tests for enemy copy-ability randomization remap generation (Issue #111)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from ..ability_randomization import (
+    VALID_ENEMY_COPY_ABILITIES,
+    build_enemy_copy_ability_remap,
+    remap_is_whitelist_preserving,
+)
+from ..options import EnemyCopyAbilityRandomization
+
+
+def test_vanilla_mode_returns_identity_mapping() -> None:
+    remap = build_enemy_copy_ability_remap(
+        random.Random(12345),
+        EnemyCopyAbilityRandomization.option_vanilla,
+    )
+
+    assert len(remap) == len(VALID_ENEMY_COPY_ABILITIES)
+    assert all(remap[name] == name for name in VALID_ENEMY_COPY_ABILITIES)
+    assert remap_is_whitelist_preserving(remap, VALID_ENEMY_COPY_ABILITIES)
+
+
+def test_shuffle_whitelist_mode_is_deterministic_for_fixed_seed() -> None:
+    remap_a = build_enemy_copy_ability_remap(
+        random.Random(20260322),
+        EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+    )
+    remap_b = build_enemy_copy_ability_remap(
+        random.Random(20260322),
+        EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+    )
+
+    assert remap_a == remap_b
+    assert remap_is_whitelist_preserving(remap_a, VALID_ENEMY_COPY_ABILITIES)
+
+
+def test_shuffle_whitelist_mode_changes_at_least_one_mapping() -> None:
+    remap = build_enemy_copy_ability_remap(
+        random.Random(7),
+        EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+    )
+
+    assert any(source != target for source, target in remap.items())
+
+
+def test_invalid_mode_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unsupported enemy copy-ability randomization mode"):
+        build_enemy_copy_ability_remap(random.Random(1), 999)
+
+
+def test_empty_whitelist_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="enemy copy-ability whitelist cannot be empty"):
+        build_enemy_copy_ability_remap(
+            random.Random(1),
+            EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+            whitelist=[],
+        )

--- a/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
@@ -98,3 +98,35 @@ def test_forbidden_abilities_in_custom_whitelist_raise() -> None:
             True,
             whitelist=["Sword", "Crash"],
         )
+
+
+def test_unknown_abilities_in_custom_whitelist_raise() -> None:
+    with pytest.raises(ValueError, match="unknown enemy copy abilities present"):
+        build_enemy_copy_ability_policy(
+            random.Random(10),
+            EnemyCopyAbilityRandomization.option_shuffled,
+            True,
+            True,
+            whitelist=["Sword", "TotallyFakeAbility"],
+        )
+
+
+def test_build_policy_is_deterministic_for_same_seed_and_options() -> None:
+    rng_seed = 20260322
+    policy1 = build_enemy_copy_ability_policy(
+        random.Random(rng_seed),
+        EnemyCopyAbilityRandomization.option_shuffled,
+        randomize_boss_spawned_ability_grants=True,
+        randomize_miniboss_ability_grants=True,
+    )
+    policy2 = build_enemy_copy_ability_policy(
+        random.Random(rng_seed),
+        EnemyCopyAbilityRandomization.option_shuffled,
+        randomize_boss_spawned_ability_grants=True,
+        randomize_miniboss_ability_grants=True,
+    )
+
+    assert policy1 == policy2
+    enemies = ["WADDLE_DEE", "BLADE_KNIGHT", "HOT_HEAD"]
+    for enemy in enemies:
+        assert ability_for_enemy_type(policy1, enemy) == ability_for_enemy_type(policy2, enemy)

--- a/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
@@ -1,4 +1,4 @@
-"""Tests for enemy copy-ability randomization remap generation (Issue #111)."""
+"""Tests for enemy copy-ability randomization policy generation (Issue #111)."""
 
 from __future__ import annotations
 
@@ -7,56 +7,94 @@ import random
 import pytest
 
 from ..ability_randomization import (
+    FORBIDDEN_ENEMY_COPY_ABILITIES,
     VALID_ENEMY_COPY_ABILITIES,
-    build_enemy_copy_ability_remap,
+    ability_for_enemy_grant_event,
+    ability_for_enemy_type,
+    build_enemy_copy_ability_policy,
     remap_is_whitelist_preserving,
 )
 from ..options import EnemyCopyAbilityRandomization
 
 
-def test_vanilla_mode_returns_identity_mapping() -> None:
-    remap = build_enemy_copy_ability_remap(
+def test_vanilla_mode_returns_identity_mapping_policy() -> None:
+    policy = build_enemy_copy_ability_policy(
         random.Random(12345),
         EnemyCopyAbilityRandomization.option_vanilla,
+        randomize_boss_spawned_ability_grants=True,
+        randomize_miniboss_ability_grants=True,
     )
 
+    remap = policy["identity_map"]
     assert len(remap) == len(VALID_ENEMY_COPY_ABILITIES)
     assert all(remap[name] == name for name in VALID_ENEMY_COPY_ABILITIES)
     assert remap_is_whitelist_preserving(remap, VALID_ENEMY_COPY_ABILITIES)
+    assert policy["randomize_boss_spawned_ability_grants"] is True
+    assert policy["randomize_miniboss_ability_grants"] is True
 
 
-def test_shuffle_whitelist_mode_is_deterministic_for_fixed_seed() -> None:
-    remap_a = build_enemy_copy_ability_remap(
+def test_shuffled_mode_maps_enemy_type_consistently() -> None:
+    policy = build_enemy_copy_ability_policy(
         random.Random(20260322),
-        EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+        EnemyCopyAbilityRandomization.option_shuffled,
+        randomize_boss_spawned_ability_grants=False,
+        randomize_miniboss_ability_grants=False,
     )
-    remap_b = build_enemy_copy_ability_remap(
-        random.Random(20260322),
-        EnemyCopyAbilityRandomization.option_shuffle_whitelist,
-    )
+    first = ability_for_enemy_type(policy, "WADDLE_DEE")
+    second = ability_for_enemy_type(policy, "WADDLE_DEE")
+    other = ability_for_enemy_type(policy, "BLADE_KNIGHT")
 
-    assert remap_a == remap_b
-    assert remap_is_whitelist_preserving(remap_a, VALID_ENEMY_COPY_ABILITIES)
+    assert first == second
+    assert first in VALID_ENEMY_COPY_ABILITIES
+    assert other in VALID_ENEMY_COPY_ABILITIES
+    assert policy["randomize_boss_spawned_ability_grants"] is False
+    assert policy["randomize_miniboss_ability_grants"] is False
 
 
-def test_shuffle_whitelist_mode_changes_at_least_one_mapping() -> None:
-    remap = build_enemy_copy_ability_remap(
+def test_completely_random_mode_varies_by_event() -> None:
+    policy = build_enemy_copy_ability_policy(
         random.Random(7),
-        EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+        EnemyCopyAbilityRandomization.option_completely_random,
+        randomize_boss_spawned_ability_grants=True,
+        randomize_miniboss_ability_grants=True,
     )
+    first = ability_for_enemy_grant_event(policy, 1, "WADDLE_DEE")
+    second = ability_for_enemy_grant_event(policy, 2, "WADDLE_DEE")
 
-    assert any(source != target for source, target in remap.items())
+    assert first in VALID_ENEMY_COPY_ABILITIES
+    assert second in VALID_ENEMY_COPY_ABILITIES
+    # Most seeds should differ across events; if not, a different enemy key still should.
+    if first == second:
+        third = ability_for_enemy_grant_event(policy, 1, "BLADE_KNIGHT")
+        assert third in VALID_ENEMY_COPY_ABILITIES
 
 
 def test_invalid_mode_raises_value_error() -> None:
     with pytest.raises(ValueError, match="unsupported enemy copy-ability randomization mode"):
-        build_enemy_copy_ability_remap(random.Random(1), 999)
+        build_enemy_copy_ability_policy(random.Random(1), 999, True, True)
 
 
 def test_empty_whitelist_raises_value_error() -> None:
     with pytest.raises(ValueError, match="enemy copy-ability whitelist cannot be empty"):
-        build_enemy_copy_ability_remap(
+        build_enemy_copy_ability_policy(
             random.Random(1),
-            EnemyCopyAbilityRandomization.option_shuffle_whitelist,
+            EnemyCopyAbilityRandomization.option_shuffled,
+            True,
+            True,
             whitelist=[],
+        )
+
+
+def test_forbidden_abilities_are_excluded_from_default_pool() -> None:
+    assert FORBIDDEN_ENEMY_COPY_ABILITIES.isdisjoint(VALID_ENEMY_COPY_ABILITIES)
+
+
+def test_forbidden_abilities_in_custom_whitelist_raise() -> None:
+    with pytest.raises(ValueError, match="forbidden enemy copy abilities present"):
+        build_enemy_copy_ability_policy(
+            random.Random(10),
+            EnemyCopyAbilityRandomization.option_shuffled,
+            True,
+            True,
+            whitelist=["Sword", "Crash"],
         )


### PR DESCRIPTION
## Summary
- implement enemy copy-ability randomization with 3 modes:
  - `vanilla`
  - `shuffled` (same enemy type -> consistent remapped ability)
  - `completely_random` (per eligible grant event)
- enforce safe ability pool exclusion: never `Crash` or `Wait`
- add options to exclude boss-spawned ability grants and mini-boss ability grants
- keep enemy statues out of scope (tracked in #209)

Closes #111.

## Implementation
- added option surface in `worlds/kirbyam/options.py`
- added deterministic enemy randomization policy helpers in `worlds/kirbyam/ability_randomization.py`
- slot-data now includes:
  - `enemy_copy_ability_randomization`
  - `randomize_boss_spawned_ability_grants`
  - `randomize_miniboss_ability_grants`
  - `enemy_copy_ability_whitelist`
  - `enemy_copy_ability_policy`
- updated docs: `PROTOCOL.md`, `docs/notes.md`, `CHANGELOG.md`
- added tests for mode semantics, deterministic behavior, and forbidden ability exclusion

## Validation
- `python -m pytest worlds/kirbyam/test/test_enemy_copy_ability_randomization.py -q` -> 7 passed
- `python -m pytest worlds/kirbyam/test/ -q` -> 111 passed