### PR TITLE
Issue #76: wire DeathLink option into KirbyAM client configuration

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- No unreleased changes recorded yet.
+- Wire `death_link` option into KirbyAM slot-data and runtime DeathLink tag synchronization.
 
 ## v0.0.6
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -104,6 +104,7 @@ Server → Client: ConnectionRefused | Connected
 `slot_data` currently includes:
 - `goal` (int): selected goal option.
 - `shards` (int): shard randomization mode.
+- `death_link` (bool): enables/disables AP DeathLink tag synchronization in the client.
 - `enemy_copy_ability_randomization` (int): enemy copy-ability mode (`0=vanilla`, `1=shuffled`, `2=completely_random`).
 - `randomize_boss_spawned_ability_grants` (bool): include/exclude ability-granting boss-spawned objects.
 - `randomize_miniboss_ability_grants` (bool): include/exclude mini-boss ability grants.

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -342,6 +342,7 @@ class KirbyAmWorld(World):
             "enemy_copy_ability_randomization",
             "randomize_boss_spawned_ability_grants",
             "randomize_miniboss_ability_grants",
+            toggles_as_bools=True,
         )
         policy = getattr(self, "_enemy_copy_ability_policy", None)
         assert policy is not None, (

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -133,7 +133,7 @@ class KirbyAmWorld(World):
     def generate_early(self) -> None:
         # Track generation start
         self._generation_start_time = time.time()
-        log_generation_start(self.player, self.player_name, self.options.as_dict("goal", "shards"))
+        log_generation_start(self.player, self.player_name, self.options.as_dict("goal", "shards", "death_link"))
 
         with generation_stage("generate_early", self.player, self.player_name):
             # If shards are shuffled as items, they must be local to the ROM unless you implement remote shard handling.
@@ -338,6 +338,7 @@ class KirbyAmWorld(World):
         slot_data = self.options.as_dict(
             "goal",
             "shards",
+            "death_link",
             "enemy_copy_ability_randomization",
             "randomize_boss_spawned_ability_grants",
             "randomize_miniboss_ability_grants",

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -111,6 +111,9 @@ class KirbyAmClient(BizHawkClient):
         self._send_notify_window_count: int = 0
         self._send_notify_window_suppressed: int = 0
 
+        # DeathLink runtime tag synchronization state
+        self._death_link_enabled: bool | None = None
+
         # Research-first unsafe-delivery candidate probing state (Issue #223)
         self._unsafe_delivery_probe_stream_marker: object = None
         self._last_unsafe_delivery_counter_values: dict[str, int] = {}
@@ -339,9 +342,11 @@ class KirbyAmClient(BizHawkClient):
         # Only run when connected and slot_data is ready
         if not self._server_session_ready(ctx):
             self._watcher_server_ready = False
+            self._death_link_enabled = None
             return
 
         self._load_notification_settings(ctx)
+        await self._sync_death_link_setting(ctx)
 
         if not self._watcher_server_ready:
             logger.info("KirbyAM: AP session ready; reconnect-safe reconciliation active")
@@ -394,6 +399,22 @@ class KirbyAmClient(BizHawkClient):
 
         # Goal reporting
         await self._maybe_report_goal(ctx, ai_state_override=ai_state)
+
+    async def _sync_death_link_setting(self, ctx: "BizHawkClientContext") -> None:
+        """Mirror slot_data death_link into AP DeathLink tag state with de-dupe."""
+        from CommonClient import logger
+
+        slot_data = getattr(ctx, "slot_data", None)
+        enabled = False
+        if isinstance(slot_data, dict):
+            enabled = self._coerce_bool(slot_data.get("death_link", False), False)
+
+        if self._death_link_enabled is enabled:
+            return
+
+        await ctx.update_death_link(enabled)
+        self._death_link_enabled = enabled
+        logger.info("KirbyAM: DeathLink %s", "enabled" if enabled else "disabled")
 
     async def _runtime_gameplay_state(self, ctx: KirbyAmBizHawkClientContext) -> tuple[bool, str, int | None]:
         """

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -149,6 +149,10 @@ class KirbyAmClient(BizHawkClient):
     def _coerce_bool(value: object, default: bool) -> bool:
         if isinstance(value, bool):
             return value
+        if isinstance(value, int):
+            if value in {0, 1}:
+                return bool(value)
+            return default
         if isinstance(value, str):
             lowered = value.strip().lower()
             if lowered in {"1", "true", "yes", "on"}:

--- a/worlds/kirbyam/test/conftest.py
+++ b/worlds/kirbyam/test/conftest.py
@@ -123,6 +123,7 @@ def mock_bizhawk_context() -> Mock:
         return None
 
     ctx.send_msgs = AsyncMock(side_effect=send_msgs_side_effect)  # Mock the async send_msgs method
+    ctx.update_death_link = AsyncMock(return_value=None)
     TEST_LOGGER.debug(
         "client.context created slot=%s team=%s address=%s checked_locations=%s items_received=%s",
         ctx.slot,

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1378,7 +1378,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
     """DeathLink tag state should be enabled when slot_data.death_link is true."""
     client = KirbyAmClient()
     client.initialize_client()
-    mock_bizhawk_context.slot_data["death_link"] = True
+    mock_bizhawk_context.slot_data["death_link"] = 1
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1374,6 +1374,57 @@ async def test_game_watcher_defers_polling_and_new_writes_when_non_gameplay(mock
 
 
 @pytest.mark.asyncio
+async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk_context):
+    """DeathLink tag state should be enabled when slot_data.death_link is true."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data["death_link"] = True
+
+    with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
+         patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+         patch.object(client, '_poll_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_deliver_items', new_callable=AsyncMock), \
+         patch.object(client, '_maybe_report_goal', new_callable=AsyncMock):
+        mock_gate.return_value = (True, "gameplay_active", 300)
+        await client.game_watcher(mock_bizhawk_context)
+
+    mock_bizhawk_context.update_death_link.assert_awaited_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_bizhawk_context):
+    """DeathLink tag update should not repeat every frame when slot_data value is unchanged."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data["death_link"] = False
+
+    with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
+         patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+         patch.object(client, '_poll_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_deliver_items', new_callable=AsyncMock), \
+         patch.object(client, '_maybe_report_goal', new_callable=AsyncMock):
+        mock_gate.return_value = (True, "gameplay_active", 300)
+        await client.game_watcher(mock_bizhawk_context)
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Change slot_data runtime value and ensure one additional sync call.
+        mock_bizhawk_context.slot_data["death_link"] = True
+        await client.game_watcher(mock_bizhawk_context)
+
+    assert mock_bizhawk_context.update_death_link.await_count == 2
+    mock_bizhawk_context.update_death_link.assert_any_await(False)
+    mock_bizhawk_context.update_death_link.assert_any_await(True)
+
+
+@pytest.mark.asyncio
 async def test_deliver_items_defers_new_write_when_gated(mock_bizhawk_context):
     """Delivery gating should preserve state and avoid writing a new mailbox item."""
     client = KirbyAmClient()

--- a/worlds/kirbyam/types.py
+++ b/worlds/kirbyam/types.py
@@ -34,3 +34,6 @@ class KirbyAmBizHawkClientContext(Protocol):
 
     async def send_msgs(self, msgs: list[dict[str, Any]]) -> None:
         ...
+
+    async def update_death_link(self, death_link: bool) -> None:
+        ...


### PR DESCRIPTION
## Summary
- wire `death_link` into KirbyAM `slot_data`
- sync AP DeathLink tag state from `slot_data.death_link` in `game_watcher`
- dedupe `update_death_link(...)` calls so unchanged values do not re-send tags
- reset cached DeathLink sync state on disconnect/reconnect readiness transitions
- add test coverage for enabled sync and value-change dedupe
- document `death_link` in protocol slot_data contract

Closes #76.

## Validation
- `python -m pytest worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_rules.py -q` (75 passed)
- `python -m pytest worlds/kirbyam/test/ -q` (115 passed)