### PR TITLE
KirbyAM DeathLink End-to-End (Protocol, Runtime, Kill Path)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Wire `death_link` option into KirbyAM slot-data and runtime DeathLink tag synchronization.
 - Add DeathLink runtime receive/apply flow via native Kirby HP (`0x02020FE0`) and local alive->dead outgoing send handling.
+- Add end-to-end DeathLink manual validation guidance and remove stale not-ready option wording.
 
 ## v0.0.6
 

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -135,6 +135,54 @@ Issue #74 send-focused checks:
 - During rapid send bursts, notifications should rate-limit (max 5 per 2s) and
    later report a suppression summary message.
 
+## DeathLink Smoke Check (Issue #82)
+
+Validate the shipped end-to-end DeathLink contract across AP tag sync, incoming
+receive/apply, outgoing send, and reconnect safety.
+
+### Setup
+1. Generate a seed with DeathLink enabled for at least two connected players.
+2. Launch the KirbyAM BizHawk client with logs visible.
+3. Confirm the client logs one of these on connect:
+   - `KirbyAM: DeathLink enabled`
+   - `KirbyAM: DeathLink disabled`
+4. If DeathLink is disabled in slot-data, confirm no incoming kill apply or
+   outgoing send occurs during the remaining checks.
+
+### Incoming DeathLink
+1. Put Kirby in normal gameplay (not menu/cutscene/transition).
+2. Trigger a DeathLink from another player.
+3. Confirm one local defeat occurs.
+4. Confirm the client logs:
+   - `KirbyAM: applied incoming DeathLink (hp_addr=0x02020FE0)`
+5. Repeat while Kirby is already dead and confirm no extra HP write loop or
+   repeated forced-death behavior occurs.
+
+### Gameplay gate safety
+1. Open a menu or trigger a non-gameplay transition.
+2. Trigger a DeathLink from another player during that state.
+3. Confirm no immediate death occurs during the non-gameplay window.
+4. Return to gameplay-active state and confirm the queued DeathLink applies once.
+
+### Outgoing DeathLink
+1. Restore Kirby to a live gameplay state.
+2. Take one normal in-game death locally.
+3. Confirm exactly one outgoing DeathLink is observed by the linked player.
+4. Confirm repeated frames while already dead do not send duplicates.
+
+### Echo suppression and reconnect
+1. Trigger an incoming DeathLink and confirm the resulting forced death does not
+   immediately echo back as a second outgoing DeathLink.
+2. Reconnect the AP client after a recent DeathLink event.
+3. Confirm the client does not replay a stale forced death on reconnect.
+4. Take one fresh local death after reconnect and confirm outgoing DeathLink
+   still works normally.
+
+### Native address reference
+- `kirby_hp_native`: `0x02020FE0` (`s8`)
+- Evidence: `gKirbys = 0x02020EE0` from `katam/linker.ld`, with `hp` field in
+  `katam/include/kirby.h`
+
 ## Unsafe Delivery Candidate Research (Issue #223)
 
 Issue #223 is currently in research-first mode. Do not assume miniboss or travel

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -546,6 +546,29 @@ Implemented full runtime DeathLink flow in `worlds/kirbyam/client.py`:
   - local alive->dead send exactly once
   - incoming-apply echo suppression
 
+## Issue #82: DeathLink End-to-End Closure
+
+### Problem
+After #76 and #75 landed, the remaining parent-level gaps were contract cleanup
+and manual validation guidance: the option surface still claimed DeathLink was
+not ready, and the BizHawk guide did not define an end-to-end smoke pass.
+
+### Solution
+- Updated the DeathLink option description to describe the shipped behavior.
+- Added a BizHawk DeathLink smoke checklist covering:
+  - tag sync state
+  - incoming receive/apply
+  - gameplay-gated deferred application
+  - outgoing send exactly once per death
+  - echo suppression
+  - reconnect safety
+
+### Validation
+- Touched files remain diagnostics-clean in VS Code.
+- Manual BizHawk validation remains the authoritative next step for parent-issue
+  closure because local pytest execution on this machine is blocked by the repo
+  Python-version gate (`3.11.9` through `3.13.x`, current interpreter `3.14`).
+
 
 ## Issue #56: Gameplay-Active Foundation Gate for Polling and Delivery
 

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -66,7 +66,10 @@ class RandomizeMiniBossAbilityGrants(Toggle):
 
 
 class KirbyAmDeathLink(DeathLink):
-    __doc__ = (DeathLink.__doc__ or "") + "\n\n    NOT READY YET: In Kirby & The Amazing Mirror, dying sets your current health to zero."
+    __doc__ = (DeathLink.__doc__ or "") + (
+        "\n\n    KirbyAM DeathLink uses native Kirby HP semantics: incoming DeathLink queues a gameplay-gated"
+        " local defeat, and local alive-to-dead transitions send one outgoing DeathLink event."
+    )
 
 
 @dataclass


### PR DESCRIPTION
## Summary\n- remove stale NOT READY YET wording from the KirbyAM DeathLink option surface\n- add a BizHawk end-to-end DeathLink smoke checklist covering incoming receive/apply, gameplay gating, outgoing send, echo suppression, and reconnect safety\n- record the parent-issue closure notes in KirbyAM docs/changelog\n\n## Validation\n- VS Code diagnostics on touched files: clean\n- local pytest not re-run for this docs-only PR because the current machine is on Python 3.14 and the repo gate in ModuleUpdate.py only supports 3.11.9 through 3.13.x\n\n## Context\n- #76 shipped slot-data/tag sync\n- #75 shipped runtime receive/apply and outgoing send logic\n- this PR closes the remaining parent-level documentation and option-surface gaps for #82