### PR TITLE
Add protocol contract tests for slot_data/doc parity

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Wire `death_link` option into KirbyAM slot-data and runtime DeathLink tag synchronization.
 - Add DeathLink runtime receive/apply flow via native Kirby HP (`0x02020FE0`) and local alive->dead outgoing send handling.
 - Add end-to-end DeathLink manual validation guidance and remove stale not-ready option wording.
+- Add slot_data contract parity tests to prevent drift between PROTOCOL.md and emitted world slot_data fields.
 
 ## v0.0.6
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -546,6 +546,24 @@ Implemented full runtime DeathLink flow in `worlds/kirbyam/client.py`:
   - local alive->dead send exactly once
   - incoming-apply echo suppression
 
+## Issue #300: slot_data Protocol Contract Parity Tests
+
+### Problem
+`slot_data` fields are defined in both implementation (`fill_slot_data`) and
+protocol docs (`PROTOCOL.md`). Without a parity gate, those can drift silently.
+
+### Solution
+Added `worlds/kirbyam/test/test_slot_data_contract.py` with contract tests that:
+- parse documented `slot_data` keys from `PROTOCOL.md`
+- emit slot_data via `KirbyAmWorld.fill_slot_data(...)`
+- assert exact key parity between documentation and emitted payload
+- assert enemy randomization contract field shapes are present
+
+### Validation
+- Targeted local pytest run on the new contract tests.
+- These tests are part of the standard KirbyAM test suite and therefore covered
+  by existing CI test jobs.
+
 ## Issue #82: DeathLink End-to-End Closure
 
 ### Problem

--- a/worlds/kirbyam/test/test_slot_data_contract.py
+++ b/worlds/kirbyam/test/test_slot_data_contract.py
@@ -1,0 +1,75 @@
+"""Protocol contract tests for KirbyAM slot_data parity (Issue #300)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import Mock
+
+from .. import KirbyAmWorld
+
+
+PROTOCOL_PATH = Path(__file__).resolve().parents[1] / "PROTOCOL.md"
+_DOC_SLOT_DATA_HEADER = "`slot_data` currently includes:"
+_DOC_SLOT_DATA_FOOTER = "DeathLink runtime behavior contract:"
+
+
+def _documented_slot_data_keys() -> list[str]:
+    text = PROTOCOL_PATH.read_text(encoding="utf-8")
+
+    start = text.find(_DOC_SLOT_DATA_HEADER)
+    assert start != -1, "PROTOCOL.md slot_data section header is missing"
+
+    end = text.find(_DOC_SLOT_DATA_FOOTER, start)
+    assert end != -1, "PROTOCOL.md slot_data section footer is missing"
+
+    block = text[start:end]
+    keys = re.findall(r"^- `([a-z0-9_]+)` \(", block, flags=re.MULTILINE)
+    assert keys, "No documented slot_data keys were parsed from PROTOCOL.md"
+    return keys
+
+
+def _emit_slot_data_for_contract_test() -> dict[str, object]:
+    # Use a lightweight world stub so contract tests fail only on key drift,
+    # not on full world-generation dependencies.
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+
+    options = Mock()
+    options.as_dict.return_value = {
+        "goal": 0,
+        "shards": 2,
+        "death_link": True,
+        "enemy_copy_ability_randomization": 1,
+        "randomize_boss_spawned_ability_grants": True,
+        "randomize_miniboss_ability_grants": False,
+    }
+
+    world.options = options
+    world._enemy_copy_ability_policy = {
+        "mode": "shuffled",
+        "allowed_abilities": ["Sword", "Needle", "Burning"],
+        "identity_map": {"Sword": "Needle", "Needle": "Burning", "Burning": "Sword"},
+        "randomize_boss_spawned_ability_grants": True,
+        "randomize_miniboss_ability_grants": False,
+    }
+
+    return KirbyAmWorld.fill_slot_data(world)
+
+
+def test_protocol_slot_data_keys_match_emitted_slot_data_keys() -> None:
+    documented = sorted(set(_documented_slot_data_keys()))
+    emitted = sorted(set(_emit_slot_data_for_contract_test().keys()))
+
+    assert emitted == documented, (
+        "slot_data contract drift detected between emitted fields and PROTOCOL.md. "
+        f"documented={documented}, emitted={emitted}"
+    )
+
+
+def test_enemy_randomization_contract_fields_present_with_expected_shapes() -> None:
+    slot_data = _emit_slot_data_for_contract_test()
+
+    assert isinstance(slot_data["enemy_copy_ability_randomization"], int)
+    assert isinstance(slot_data["enemy_copy_ability_whitelist"], list)
+    assert slot_data["enemy_copy_ability_whitelist"]
+    assert isinstance(slot_data["enemy_copy_ability_policy"], dict)


### PR DESCRIPTION
## Summary\n- add contract tests that parse documented slot_data keys from worlds/kirbyam/PROTOCOL.md\n- emit slot_data via KirbyAmWorld.fill_slot_data(...) in a lightweight test harness\n- assert exact parity between documented and emitted slot_data keys\n- add enemy-randomization shape assertions to keep policy fields covered\n- update notes/changelog for Issue #300\n\n## Validation\n- .venv\\Scripts\\python.exe -m pytest worlds/kirbyam/test/test_slot_data_contract.py -q\n  - result: 2 passed\n\n## Evidence trail\n- claim: prevent silent drift between slot_data docs and implementation\n- source: Issue #300 acceptance criteria\n- adaptation: docs-key parsing + emitted-payload parity assertion in new tests\n- validation: targeted local pytest pass