### PR TITLE
Add reconnect chaos tests for BizHawk client idempotency

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add DeathLink runtime receive/apply flow via native Kirby HP (`0x02020FE0`) and local alive->dead outgoing send handling.
 - Add end-to-end DeathLink manual validation guidance and remove stale not-ready option wording.
 - Add slot_data contract parity tests to prevent drift between PROTOCOL.md and emitted world slot_data fields.
+- Add reconnect chaos tests for location polling, mailbox delivery resume, and goal-reporting idempotency.
 
 ## v0.0.6
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -564,6 +564,30 @@ Added `worlds/kirbyam/test/test_slot_data_contract.py` with contract tests that:
 - These tests are part of the standard KirbyAM test suite and therefore covered
   by existing CI test jobs.
 
+## Issue #302: Reconnect Chaos Tests for BizHawk Client Idempotency
+
+### Problem
+Reconnect behavior is safety-critical for live sessions but prior coverage was
+mostly per-subsystem unit checks rather than stateful multi-cycle chaos tests.
+
+### Solution
+Added dedicated reconnect chaos tests in
+`worlds/kirbyam/test/test_reconnect_chaos.py` that simulate repeated
+connect/disconnect cycles during:
+- location polling
+- mailbox item delivery
+- goal reporting
+
+The tests assert:
+- no duplicate location sends after server acknowledgement
+- item delivery resumes correctly after reconnect without replaying already-
+  pending first-item writes
+- goal location/status flow remains idempotent across reconnect cycles
+
+### Validation
+- Targeted local pytest for `test_reconnect_chaos.py`.
+- Additional local run including existing reconnect-related client tests.
+
 ## Issue #82: DeathLink End-to-End Closure
 
 ### Problem

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -1,0 +1,173 @@
+"""Reconnect chaos tests for KirbyAM BizHawk client idempotency (Issue #302)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from ..client import KirbyAmClient
+from ..data import data
+
+
+@pytest.mark.asyncio
+async def test_reconnect_chaos_location_polling_resends_once_then_dedupes(mock_bizhawk_context):
+    """Reconnect cycles should not duplicate shard LocationChecks after server acknowledgement."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    shard1_id = data.locations["SHARD_1"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+         patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
+         patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
+         patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
+         patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_deliver_items', new_callable=AsyncMock), \
+         patch.object(client, '_maybe_report_goal', new_callable=AsyncMock):
+        mock_gate.return_value = (True, "gameplay_active", 300)
+        # Connected cycle: shard bit set.
+        mock_read.return_value = [(0x01).to_bytes(1, 'little')]
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Disconnect cycle: watcher should skip entirely.
+        mock_bizhawk_context.server.socket.closed = True
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Reconnect cycle with server already acknowledging shard 1.
+        mock_bizhawk_context.server.socket.closed = False
+        mock_bizhawk_context.checked_locations = {shard1_id}
+        mock_read.return_value = [(0x01).to_bytes(1, 'little')]
+        await client.game_watcher(mock_bizhawk_context)
+
+    # Exactly one LocationChecks send across connect/disconnect/reconnect.
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [shard1_id]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_reconnect_chaos_item_delivery_resumes_without_duplicate_first_item(mock_bizhawk_context):
+    """Delivery should resume after reconnect without replaying already-pending first item."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    item1 = 3860001
+    item2 = 3860002
+    mock_bizhawk_context.items_received = [
+        Mock(item=item1, player=1),
+        Mock(item=item2, player=1),
+    ]
+
+    id_addr = data.transport_ram_addresses["incoming_item_id"]
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write, \
+         patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
+         patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+         patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
+         patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
+         patch.object(client, '_poll_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_maybe_report_goal', new_callable=AsyncMock):
+        mock_gate.return_value = (True, "gameplay_active", 300)
+
+        # Cycle 1 (connected): write first item, pending ACK.
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (0).to_bytes(4, 'little'),
+            (10).to_bytes(4, 'little'),
+        ]
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Cycle 2 (disconnected): no watcher delivery work.
+        mock_bizhawk_context.server.socket.closed = True
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Cycle 3 (reconnected): ACK first item.
+        mock_bizhawk_context.server.socket.closed = False
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (1).to_bytes(4, 'little'),
+            (20).to_bytes(4, 'little'),
+        ]
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Cycle 4 (connected): write second item.
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (1).to_bytes(4, 'little'),
+            (21).to_bytes(4, 'little'),
+        ]
+        await client.game_watcher(mock_bizhawk_context)
+
+    # Ensure first item write occurred once and second item write occurred once.
+    mailbox_writes = [
+        batch
+        for batch in (call.args[1] for call in mock_write.await_args_list)
+        if any(addr == id_addr for addr, *_ in batch)
+    ]
+    item_ids_written = [
+        int.from_bytes(next(payload for addr, payload, _ in batch if addr == id_addr), 'little')
+        for batch in mailbox_writes
+    ]
+    assert item_ids_written.count(item1) == 1
+    assert item_ids_written.count(item2) == 1
+    assert item_ids_written == [item1, item2]
+    assert client._delivered_item_index >= 1
+
+
+@pytest.mark.asyncio
+async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_bizhawk_context):
+    """Goal flow should send location then status once, with no duplicate status on later reconnects."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    goal_id = data.locations["GOAL_DARK_MIND"].location_id
+    mock_bizhawk_context.slot_data["goal"] = 0
+    mock_bizhawk_context.checked_locations = set()
+    mock_bizhawk_context.locations_checked = set()
+
+    with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
+         patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+         patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
+         patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
+         patch.object(client, '_poll_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
+         patch.object(client, '_deliver_items', new_callable=AsyncMock):
+        # Use ai_state override for deterministic goal signal without RAM reads.
+        mock_gate.return_value = (True, "gameplay_active", 9999)
+
+        # Cycle 1: send goal location check.
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Cycle 2: disconnected no-op.
+        mock_bizhawk_context.server.socket.closed = True
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Cycle 3: reconnected with goal location acknowledged by server; send CLIENT_GOAL.
+        mock_bizhawk_context.server.socket.closed = False
+        mock_bizhawk_context.checked_locations.add(goal_id)
+        await client.game_watcher(mock_bizhawk_context)
+
+        # Cycle 4: another reconnect-safe watcher run should not send duplicate status.
+        await client.game_watcher(mock_bizhawk_context)
+
+    payloads = [call.args[0][0] for call in mock_bizhawk_context.send_msgs.await_args_list]
+    location_msgs = [p for p in payloads if p.get("cmd") == "LocationChecks"]
+    status_msgs = [p for p in payloads if p.get("cmd") == "StatusUpdate"]
+
+    assert len(location_msgs) == 1
+    assert location_msgs[0]["locations"] == [goal_id]
+    assert len(status_msgs) == 1


### PR DESCRIPTION
## Summary
- add dedicated reconnect chaos tests in `worlds/kirbyam/test/test_reconnect_chaos.py`
- simulate repeated connect/disconnect cycles during location polling, mailbox delivery, and goal reporting
- assert idempotent behavior: no duplicate sends, no lost progress, and reconnect-safe resume
- update docs/changelog notes for Issue #302

## Validation
- `.venv\Scripts\python.exe -m pytest worlds/kirbyam/test/test_reconnect_chaos.py worlds/kirbyam/test/test_client.py -k "reconnect or chaos" -q`
  - result: 7 passed

## Evidence trail
- claim: reconnect/disconnect instability should not break idempotency
- source: Issue #302 acceptance criteria
- adaptation: stateful multi-cycle chaos tests around watcher flows
- validation: targeted local reconnect-focused pytest pass
