### PR TITLE
Add release integrity checks: changelog section gate in release metadata script and CI

### DIFF
--- a/.github/scripts/kirbyam_release_metadata.py
+++ b/.github/scripts/kirbyam_release_metadata.py
@@ -64,6 +64,23 @@ def build_release_metadata(github_ref: str) -> ReleaseMetadata:
     )
 
 
+def check_changelog_has_version(changelog_path: Path, version: str) -> None:
+    """Raise ValueError if the changelog does not contain a section for version.
+
+    Looks for a heading of the exact form ``## v{version}`` anywhere in the
+    file.  Raises with a descriptive message so the CI step fails clearly.
+    """
+    text = changelog_path.read_text(encoding="utf-8")
+    heading = f"## v{version}"
+    for line in text.splitlines():
+        if line.strip() == heading:
+            return
+    raise ValueError(
+        f"CHANGELOG.md does not contain a section for v{version}. "
+        f"Add a '## v{version}' heading before tagging the release."
+    )
+
+
 def inject_world_version(manifest_path: Path, world_version: str) -> bool:
     """Inject world_version into a world manifest JSON file.
 
@@ -108,12 +125,21 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="Optional world manifest path to receive tag-derived world_version on release builds.",
     )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        help="Optional path to CHANGELOG.md; on release builds, verified to contain a section for the release version.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     metadata = build_release_metadata(args.github_ref)
+
+    if args.changelog and metadata.release_enabled:
+        check_changelog_has_version(args.changelog, metadata.version)
+        print(f"CHANGELOG.md contains section for v{metadata.version}")
 
     if args.world_manifest and metadata.release_enabled:
         updated = inject_world_version(args.world_manifest, metadata.version)

--- a/.github/workflows/kirbyam-apworld.yml
+++ b/.github/workflows/kirbyam-apworld.yml
@@ -47,6 +47,7 @@ jobs:
           python .github/scripts/kirbyam_release_metadata.py \
             --github-ref "${GITHUB_REF}" \
             --world-manifest "worlds/kirbyam/archipelago.json" \
+            --changelog "worlds/kirbyam/CHANGELOG.md" \
             --github-output "${GITHUB_OUTPUT}"
 
       - name: Build kirbyam.apworld from committed patch data

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add release integrity checks: changelog section verification and `--changelog` gate in the release metadata script and CI.
 - Wire `death_link` option into KirbyAM slot-data and runtime DeathLink tag synchronization.
 - Add DeathLink runtime receive/apply flow via native Kirby HP (`0x02020FE0`) and local alive->dead outgoing send handling.
 - Add end-to-end DeathLink manual validation guidance and remove stale not-ready option wording.

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -546,6 +546,20 @@ Implemented full runtime DeathLink flow in `worlds/kirbyam/client.py`:
   - local alive->dead send exactly once
   - incoming-apply echo suppression
 
+## Issue #307: Release Integrity Checks (Changelog/Tag/Apworld Coherence)
+
+### Problem
+No automated check verified that a CHANGELOG section existed for the tagged release version, creating risk that a tag could be pushed without a matching changelog entry.
+
+### Solution
+- Added `check_changelog_has_version(changelog_path, version)` to `.github/scripts/kirbyam_release_metadata.py`. Raises `ValueError` with a clear message if the `## v{version}` heading is absent.
+- Added `--changelog` argument to the same script; when provided and `release_enabled` is True, the check is run before metadata outputs are written.
+- Updated `kirbyam-apworld.yml` CI step to pass `--changelog worlds/kirbyam/CHANGELOG.md`, so release tags that lack a changelog section fail the CI step explicitly.
+- Added 8 new tests in `worlds/kirbyam/test/test_release_metadata.py` covering: section-found, section-missing, Unreleased not treated as version, partial-match guard, real-CHANGELOG smoke, main integration (pass and fail), and branch-ref skip.
+
+### Validation
+- `pytest worlds/kirbyam/test/test_release_metadata.py` — 16 passed.
+
 ## Issue #300: slot_data Protocol Contract Parity Tests
 
 ### Problem

--- a/worlds/kirbyam/test/test_release_metadata.py
+++ b/worlds/kirbyam/test/test_release_metadata.py
@@ -142,3 +142,145 @@ def test_main_does_not_inject_world_version_for_branch_ref(tmp_path: Path, monke
     assert manifest["world_version"] == "0.0.1"
     assert "version=" in output_text
     assert "release_enabled=false" in output_text
+
+
+# ---------------------------------------------------------------------------
+# check_changelog_has_version
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CHANGELOG = """\
+# KirbyAM APWorld Changelog
+
+## Unreleased
+
+- Some work in progress.
+
+## v0.0.2
+
+- Second release notes.
+
+## v0.0.1
+
+- First release notes.
+"""
+
+
+def test_check_changelog_has_version_passes_when_section_exists(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    MODULE.check_changelog_has_version(changelog, "0.0.2")  # should not raise
+
+
+def test_check_changelog_has_version_fails_when_section_missing(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    with pytest.raises(ValueError, match="does not contain a section for v0.0.3"):
+        MODULE.check_changelog_has_version(changelog, "0.0.3")
+
+
+def test_check_changelog_does_not_treat_unreleased_as_a_version(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    # "Unreleased" is not a semantic version; passing it as a version string should fail
+    with pytest.raises(ValueError, match="does not contain a section for vUnreleased"):
+        MODULE.check_changelog_has_version(changelog, "Unreleased")
+
+
+def test_check_changelog_partial_match_does_not_satisfy(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    # "0.0.1" exists but "0.0.10" should not be satisfied by the 0.0.1 line
+    with pytest.raises(ValueError, match="does not contain a section for v0.0.10"):
+        MODULE.check_changelog_has_version(changelog, "0.0.10")
+
+
+def test_real_changelog_has_v006_section() -> None:
+    """Smoke-guard the real CHANGELOG against a release tag of v0.0.6."""
+    real_changelog = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+    MODULE.check_changelog_has_version(real_changelog, "0.0.6")  # should not raise
+
+
+def test_main_checks_changelog_on_release_tag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = tmp_path / "archipelago.json"
+    manifest_path.write_text(
+        json.dumps({"game": "Kirby & The Amazing Mirror", "world_version": "0.0.1"}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    output_path = tmp_path / "github_output.txt"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "kirbyam_release_metadata.py",
+            "--github-ref",
+            "refs/tags/kirbyam-v0.0.2",
+            "--github-output",
+            str(output_path),
+            "--world-manifest",
+            str(manifest_path),
+            "--changelog",
+            str(changelog_path),
+        ],
+    )
+
+    assert MODULE.main() == 0
+    # version was injected and changelog passed without raising
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["world_version"] == "0.0.2"
+
+
+def test_main_fails_when_changelog_missing_release_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = tmp_path / "archipelago.json"
+    manifest_path.write_text(
+        json.dumps({"game": "Kirby & The Amazing Mirror", "world_version": "0.0.1"}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    # Changelog does not contain v0.0.9
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    output_path = tmp_path / "github_output.txt"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "kirbyam_release_metadata.py",
+            "--github-ref",
+            "refs/tags/kirbyam-v0.0.9",
+            "--github-output",
+            str(output_path),
+            "--world-manifest",
+            str(manifest_path),
+            "--changelog",
+            str(changelog_path),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="does not contain a section for v0.0.9"):
+        MODULE.main()
+
+
+def test_main_skips_changelog_check_for_branch_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Changelog deliberately missing any version section — no error expected on branch ref
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text("# Changelog\n\n## Unreleased\n\n- stuff\n", encoding="utf-8")
+    output_path = tmp_path / "github_output.txt"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "kirbyam_release_metadata.py",
+            "--github-ref",
+            "refs/heads/main",
+            "--github-output",
+            str(output_path),
+            "--changelog",
+            str(changelog_path),
+        ],
+    )
+
+    assert MODULE.main() == 0


### PR DESCRIPTION
## Summary

Closes #307.

Adds automated release integrity checks so a `kirbyam-v*` tag pushed without a matching CHANGELOG section fails loudly in CI.

## Changes

### `.github/scripts/kirbyam_release_metadata.py`
- New `check_changelog_has_version(changelog_path, version)` function: reads the CHANGELOG and raises `ValueError` with a descriptive message if the `## v{version}` heading is absent.
- New `--changelog` CLI argument: when provided to `main()` on a release ref, the check runs before metadata outputs are written, causing the CI step to fail with an actionable error.

### `.github/workflows/kirbyam-apworld.yml`
- The "Prepare release metadata" step now passes `--changelog worlds/kirbyam/CHANGELOG.md`, enabling the check on every `kirbyam-v*` tag push.

### `worlds/kirbyam/test/test_release_metadata.py`
- 8 new tests:
  - Section found (passes)
  - Section missing (raises with clear message)
  - `Unreleased` not accepted as a version
  - Partial match (`0.0.1` does not satisfy `0.0.10`)
  - Real CHANGELOG smoke guard (`## v0.0.6` present)
  - `main()` integration: release tag + matching changelog → passes
  - `main()` integration: release tag + missing changelog → raises
  - `main()` branch ref: changelog check skipped entirely

### `worlds/kirbyam/CHANGELOG.md` / `worlds/kirbyam/docs/notes.md`
- Added unreleased entry and implementation note.

## Validation

- `pytest worlds/kirbyam/test/test_release_metadata.py` → 16 passed (Python 3.11.9)
