### PR TITLE
Add golden snapshot tests for deterministic slot_data and generated mappings

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add golden snapshot tests for deterministic slot_data and enemy randomization mapping outputs, with committed JSON fixtures and an explicit snapshot update workflow.
 - Remove `worlds/kirbyam/kirbyam.apworld` from source control; add `*.apworld` to `.gitignore` to prevent re-committing the build artifact.
 - Add release integrity checks: changelog section verification and `--changelog` gate in the release metadata script and CI.
 - Wire `death_link` option into KirbyAM slot-data and runtime DeathLink tag synchronization.

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -546,6 +546,37 @@ Implemented full runtime DeathLink flow in `worlds/kirbyam/client.py`:
   - local alive->dead send exactly once
   - incoming-apply echo suppression
 
+## Issue #311: Golden Snapshot Tests for slot_data and Generated Artifacts
+
+### Problem
+The test suite had contract and behavior checks, but no committed golden
+snapshots for deterministic outputs. That made it harder to review exact payload
+or mapping drift in PRs.
+
+### Solution
+- Added `worlds/kirbyam/test/test_snapshot_outputs.py` with two snapshot tests:
+  - representative `slot_data` payload emitted from `KirbyAmWorld.fill_slot_data`
+  - deterministic generated enemy mapping artifacts for fixed seeds
+- Added committed snapshot fixtures in
+  `worlds/kirbyam/test/data/snapshots/`:
+  - `slot_data_representative.json`
+  - `enemy_mapping_seed_20260322.json`
+- Added snapshot fixture update guidance in
+  `worlds/kirbyam/test/data/snapshots/README.md`.
+- Updated `worlds/kirbyam/test/test_fixture_data.py` to assert the
+  `snapshots/` fixture directory exists.
+
+### Snapshot update workflow
+1. Set `KIRBYAM_UPDATE_SNAPSHOTS=1`.
+2. Run `pytest worlds/kirbyam/test/test_snapshot_outputs.py`.
+3. Review generated diff under `worlds/kirbyam/test/data/snapshots/`.
+4. Unset `KIRBYAM_UPDATE_SNAPSHOTS` and rerun tests in strict mode.
+
+### Validation
+- `pytest worlds/kirbyam/test/test_snapshot_outputs.py`
+- `pytest worlds/kirbyam/test/test_fixture_data.py`
+- `pytest worlds/kirbyam/test/test_slot_data_contract.py`
+
 ## Issue #313: Remove Circular Committed kirbyam.apworld Artifact
 
 ### Problem

--- a/worlds/kirbyam/test/data/README.md
+++ b/worlds/kirbyam/test/data/README.md
@@ -12,6 +12,9 @@ This directory contains reusable, pre-generated fixture datasets for unit and in
   - Item delivery examples and mailbox ack transitions.
 - `location_check_transitions.json`
   - Expected location-check behavior for shard progression and resend scenarios.
+- `snapshots/`
+  - Committed golden snapshots for deterministic outputs (slot_data and
+    enemy mapping artifacts).
 
 ## Address Ranges
 

--- a/worlds/kirbyam/test/data/snapshots/README.md
+++ b/worlds/kirbyam/test/data/snapshots/README.md
@@ -6,11 +6,13 @@ This directory contains committed golden snapshots used by
 ## Update workflow
 
 1. Run:
+   - Linux / macOS:
+     - `KIRBYAM_UPDATE_SNAPSHOTS=1 python -m pytest worlds/kirbyam/test/test_snapshot_outputs.py`
    - Windows PowerShell:
      - `$env:KIRBYAM_UPDATE_SNAPSHOTS = "1"`
      - `python -m pytest worlds/kirbyam/test/test_snapshot_outputs.py`
 2. Review the diff in this directory.
-3. Reset the environment variable and rerun tests normally.
+3. Reset the environment variable and rerun tests normally to confirm they pass.
 4. Commit both the code change and updated snapshot files together.
 
 Do not update snapshots unless behavior changes are intentional.

--- a/worlds/kirbyam/test/data/snapshots/README.md
+++ b/worlds/kirbyam/test/data/snapshots/README.md
@@ -1,0 +1,16 @@
+# KirbyAM Snapshot Fixtures
+
+This directory contains committed golden snapshots used by
+[worlds/kirbyam/test/test_snapshot_outputs.py](../../test_snapshot_outputs.py).
+
+## Update workflow
+
+1. Run:
+   - Windows PowerShell:
+     - `$env:KIRBYAM_UPDATE_SNAPSHOTS = "1"`
+     - `python -m pytest worlds/kirbyam/test/test_snapshot_outputs.py`
+2. Review the diff in this directory.
+3. Reset the environment variable and rerun tests normally.
+4. Commit both the code change and updated snapshot files together.
+
+Do not update snapshots unless behavior changes are intentional.

--- a/worlds/kirbyam/test/data/snapshots/enemy_mapping_seed_20260322.json
+++ b/worlds/kirbyam/test/data/snapshots/enemy_mapping_seed_20260322.json
@@ -1,0 +1,84 @@
+{
+  "random_enemy_event_mapping": {
+    "BLADE_KNIGHT": {
+      "1": "Sleep",
+      "2": "Mini",
+      "3": "Burning"
+    },
+    "HOT_HEAD": {
+      "1": "Stone",
+      "2": "UFO",
+      "3": "Needle"
+    },
+    "SIR_KIBBLE": {
+      "1": "Stone",
+      "2": "Needle",
+      "3": "Tornado"
+    },
+    "SPARKY": {
+      "1": "Sword",
+      "2": "UFO",
+      "3": "Sleep"
+    },
+    "WADDLE_DEE": {
+      "1": "Fire",
+      "2": "Sword",
+      "3": "Mini"
+    }
+  },
+  "random_policy": {
+    "allowed_abilities": [
+      "Burning",
+      "Cutter",
+      "Fire",
+      "Hammer",
+      "Laser",
+      "Mini",
+      "Missile",
+      "Needle",
+      "Parasol",
+      "Sleep",
+      "Spark",
+      "Stone",
+      "Sword",
+      "Tornado",
+      "UFO"
+    ],
+    "mapping_style": "per_grant_event",
+    "mode": 2,
+    "randomize_boss_spawned_ability_grants": true,
+    "randomize_miniboss_ability_grants": true,
+    "seed": 7437834127177459305
+  },
+  "shuffled_enemy_mapping": {
+    "BLADE_KNIGHT": "Burning",
+    "HOT_HEAD": "Stone",
+    "SIR_KIBBLE": "Cutter",
+    "SPARKY": "Sword",
+    "WADDLE_DEE": "Sword"
+  },
+  "shuffled_policy": {
+    "allowed_abilities": [
+      "Burning",
+      "Cutter",
+      "Fire",
+      "Hammer",
+      "Laser",
+      "Mini",
+      "Missile",
+      "Needle",
+      "Parasol",
+      "Sleep",
+      "Spark",
+      "Stone",
+      "Sword",
+      "Tornado",
+      "UFO"
+    ],
+    "mapping_style": "per_enemy_type",
+    "mode": 1,
+    "randomize_boss_spawned_ability_grants": false,
+    "randomize_miniboss_ability_grants": false,
+    "seed": 7437834127177459305
+  }
+}

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -1,0 +1,49 @@
+{
+  "death_link": true,
+  "enemy_copy_ability_policy": {
+    "allowed_abilities": [
+      "Burning",
+      "Cutter",
+      "Fire",
+      "Hammer",
+      "Laser",
+      "Mini",
+      "Missile",
+      "Needle",
+      "Parasol",
+      "Sleep",
+      "Spark",
+      "Stone",
+      "Sword",
+      "Tornado",
+      "UFO"
+    ],
+    "mapping_style": "per_enemy_type",
+    "mode": 1,
+    "randomize_boss_spawned_ability_grants": true,
+    "randomize_miniboss_ability_grants": false,
+    "seed": 7437834127177459305
+  },
+  "enemy_copy_ability_randomization": 1,
+  "enemy_copy_ability_whitelist": [
+    "Burning",
+    "Cutter",
+    "Fire",
+    "Hammer",
+    "Laser",
+    "Mini",
+    "Missile",
+    "Needle",
+    "Parasol",
+    "Sleep",
+    "Spark",
+    "Stone",
+    "Sword",
+    "Tornado",
+    "UFO"
+  ],
+  "goal": 0,
+  "randomize_boss_spawned_ability_grants": true,
+  "randomize_miniboss_ability_grants": false,
+  "shards": 2
+}

--- a/worlds/kirbyam/test/test_fixture_data.py
+++ b/worlds/kirbyam/test/test_fixture_data.py
@@ -18,6 +18,7 @@ def test_fixture_data_files_exist() -> None:
         "shard_bitfields.json",
         "item_delivery_sequences.json",
         "location_check_transitions.json",
+        "snapshots",
         "README.md",
     }
     existing = {p.name for p in data_dir.iterdir()}

--- a/worlds/kirbyam/test/test_snapshot_outputs.py
+++ b/worlds/kirbyam/test/test_snapshot_outputs.py
@@ -1,0 +1,121 @@
+"""Golden snapshot tests for deterministic KirbyAM outputs (Issue #311)."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from pathlib import Path
+from unittest.mock import Mock
+
+from .. import KirbyAmWorld
+from ..ability_randomization import (
+    ability_for_enemy_grant_event,
+    ability_for_enemy_type,
+    build_enemy_copy_ability_policy,
+)
+from ..options import EnemyCopyAbilityRandomization
+
+SNAPSHOT_DIR = Path(__file__).resolve().parent / "data" / "snapshots"
+UPDATE_SNAPSHOTS = os.environ.get("KIRBYAM_UPDATE_SNAPSHOTS") == "1"
+
+
+def _write_or_assert_snapshot(snapshot_name: str, payload: dict[str, object]) -> None:
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    snapshot_path = SNAPSHOT_DIR / snapshot_name
+    actual = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    if UPDATE_SNAPSHOTS:
+        snapshot_path.write_text(actual, encoding="utf-8", newline="\n")
+
+    if not snapshot_path.exists():
+        raise AssertionError(
+            f"Missing snapshot file: {snapshot_path}. "
+            "Run with KIRBYAM_UPDATE_SNAPSHOTS=1 to generate it."
+        )
+
+    expected = snapshot_path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"Snapshot mismatch for {snapshot_name}. "
+        "If this behavior change is intentional, regenerate snapshots with "
+        "KIRBYAM_UPDATE_SNAPSHOTS=1 and commit the updated files."
+    )
+
+
+def _build_representative_slot_data() -> dict[str, object]:
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+
+    options = Mock()
+    options.as_dict.return_value = {
+        "goal": 0,
+        "shards": 2,
+        "death_link": True,
+        "enemy_copy_ability_randomization": 1,
+        "randomize_boss_spawned_ability_grants": True,
+        "randomize_miniboss_ability_grants": False,
+    }
+
+    world.options = options
+    world._enemy_copy_ability_policy = build_enemy_copy_ability_policy(
+        random.Random(20260322),
+        EnemyCopyAbilityRandomization.option_shuffled,
+        randomize_boss_spawned_ability_grants=True,
+        randomize_miniboss_ability_grants=False,
+    )
+    return KirbyAmWorld.fill_slot_data(world)
+
+
+def _build_deterministic_mapping_artifacts() -> dict[str, object]:
+    enemy_keys = [
+        "WADDLE_DEE",
+        "BLADE_KNIGHT",
+        "HOT_HEAD",
+        "SIR_KIBBLE",
+        "SPARKY",
+    ]
+
+    shuffled_policy = build_enemy_copy_ability_policy(
+        random.Random(20260322),
+        EnemyCopyAbilityRandomization.option_shuffled,
+        randomize_boss_spawned_ability_grants=False,
+        randomize_miniboss_ability_grants=False,
+    )
+    shuffled_mapping = {
+        key: ability_for_enemy_type(shuffled_policy, key)
+        for key in enemy_keys
+    }
+
+    random_policy = build_enemy_copy_ability_policy(
+        random.Random(20260322),
+        EnemyCopyAbilityRandomization.option_completely_random,
+        randomize_boss_spawned_ability_grants=True,
+        randomize_miniboss_ability_grants=True,
+    )
+    random_mapping = {
+        key: {
+            str(event): ability_for_enemy_grant_event(random_policy, event, key)
+            for event in (1, 2, 3)
+        }
+        for key in enemy_keys
+    }
+
+    return {
+        "shuffled_policy": shuffled_policy,
+        "shuffled_enemy_mapping": shuffled_mapping,
+        "random_policy": random_policy,
+        "random_enemy_event_mapping": random_mapping,
+    }
+
+
+def test_slot_data_snapshot_matches_golden() -> None:
+    _write_or_assert_snapshot(
+        "slot_data_representative.json",
+        _build_representative_slot_data(),
+    )
+
+
+def test_generated_mapping_snapshot_matches_golden() -> None:
+    _write_or_assert_snapshot(
+        "enemy_mapping_seed_20260322.json",
+        _build_deterministic_mapping_artifacts(),
+    )


### PR DESCRIPTION
## Summary
Closes #311.

Adds committed golden snapshot tests for deterministic KirbyAM outputs so PRs show exact payload/mapping diffs when behavior changes.

## Changes
- Added snapshot test module: worlds/kirbyam/test/test_snapshot_outputs.py
  - slot_data representative snapshot from KirbyAmWorld.fill_slot_data
  - deterministic generated mapping snapshot for fixed seeds
  - strict mismatch messages with an explicit update path
- Added committed snapshot fixtures:
  - worlds/kirbyam/test/data/snapshots/slot_data_representative.json
  - worlds/kirbyam/test/data/snapshots/enemy_mapping_seed_20260322.json
- Added snapshot fixture update instructions:
  - worlds/kirbyam/test/data/snapshots/README.md
- Updated fixture checks and docs:
  - worlds/kirbyam/test/test_fixture_data.py
  - worlds/kirbyam/test/data/README.md
  - worlds/kirbyam/CHANGELOG.md
  - worlds/kirbyam/docs/notes.md

## Validation
- pytest worlds/kirbyam/test/test_snapshot_outputs.py worlds/kirbyam/test/test_fixture_data.py worlds/kirbyam/test/test_slot_data_contract.py worlds/kirbyam/test/test_enemy_copy_ability_randomization.py -v
- Result: 16 passed
