### PR TITLE
Standardize manual testing templates into machine-checkable checklists

### DIFF
--- a/.github/ISSUE_TEMPLATE/manual_testing_checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/manual_testing_checklist.yaml
@@ -1,0 +1,100 @@
+name: Manual Testing Checklist
+description: Use this template for non-technical, step-by-step manual verification with machine-checkable results.
+title: "Manual testing: "
+labels:
+  - manual-testing
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is designed for regular testers and machine parsing.
+        Keep steps simple, and paste at least one completed result block in a comment.
+
+  - type: input
+    id: feature
+    attributes:
+      label: Feature or issue being tested
+      description: Example: "Issue #319 DeathLink HP signal promotion"
+      placeholder: "Issue #<number> <short title>"
+    validations:
+      required: true
+
+  - type: input
+    id: build_ref
+    attributes:
+      label: Build or commit under test
+      description: Git commit SHA, PR number, or build tag
+      placeholder: "PR #123 / commit abc1234"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Test environment
+      description: Keep this non-technical and explicit
+      value: |
+        - Platform:
+        - BizHawk version:
+        - ROM region/version:
+        - Save file used:
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Step-by-step checklist
+      description: Write clear steps for non-technical testers
+      value: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What should happen if the test passes
+      value: |
+        - 
+    validations:
+      required: true
+
+  - type: textarea
+    id: pass_fail_criteria
+    attributes:
+      label: Pass/fail criteria
+      description: Keep criteria objective and easy to verify
+      value: |
+        - PASS if:
+        - FAIL if:
+    validations:
+      required: true
+
+  - type: textarea
+    id: machine_checkable_result_comment_template
+    attributes:
+      label: Machine-checkable result comment template
+      description: Testers must paste and fill this in an issue comment after testing
+      value: |
+        <!-- MANUAL_TEST_RESULT:START -->
+        RESULT_SCHEMA_VERSION: 1
+        TEST_CASE_ID: case-001
+        STATUS: PASS
+        BUILD_REF: <commit/pr/tag>
+        PLATFORM: <windows/linux/macos>
+        BIZHAWK_VERSION: <version>
+        ROM_REGION: USA
+        EXPECTED_RESULT: <short expected outcome>
+        OBSERVED_RESULT: <short observed outcome>
+        EVIDENCE: <link/screenshot/log excerpt>
+        NOTES: <optional>
+        <!-- MANUAL_TEST_RESULT:END -->
+
+        Allowed STATUS values: PASS, FAIL, BLOCKED
+    validations:
+      required: true

--- a/.github/scripts/manual_test_checklist_parser.py
+++ b/.github/scripts/manual_test_checklist_parser.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Parse machine-checkable manual testing result blocks from issue comments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from typing import Any, Iterable
+
+BLOCK_PATTERN = re.compile(
+    r"<!--\s*MANUAL_TEST_RESULT:START\s*-->(.*?)<!--\s*MANUAL_TEST_RESULT:END\s*-->",
+    flags=re.DOTALL,
+)
+LINE_PATTERN = re.compile(r"^([A-Z_]+):\s*(.*)$")
+REQUIRED_FIELDS = (
+    "RESULT_SCHEMA_VERSION",
+    "TEST_CASE_ID",
+    "STATUS",
+    "BUILD_REF",
+    "PLATFORM",
+    "BIZHAWK_VERSION",
+    "ROM_REGION",
+    "EXPECTED_RESULT",
+    "OBSERVED_RESULT",
+    "EVIDENCE",
+    "NOTES",
+)
+VALID_STATUS = {"PASS", "FAIL", "BLOCKED"}
+
+
+def _parse_block(block_text: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in block_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = LINE_PATTERN.match(line)
+        if not match:
+            continue
+        key, value = match.group(1), match.group(2)
+        parsed[key] = value
+
+    missing = [field for field in REQUIRED_FIELDS if field not in parsed]
+    if missing:
+        raise ValueError(f"Manual test result block missing required fields: {missing}")
+
+    status = parsed["STATUS"].upper()
+    if status not in VALID_STATUS:
+        raise ValueError(
+            f"Invalid STATUS value '{parsed['STATUS']}'. Expected one of: {sorted(VALID_STATUS)}"
+        )
+    parsed["STATUS"] = status
+    return parsed
+
+
+def parse_manual_test_results(comment_bodies: Iterable[str]) -> list[dict[str, str]]:
+    """Return structured result entries parsed from issue comment bodies."""
+    results: list[dict[str, str]] = []
+    for index, body in enumerate(comment_bodies):
+        for block in BLOCK_PATTERN.findall(body):
+            parsed = _parse_block(block)
+            parsed["COMMENT_INDEX"] = str(index)
+            results.append(parsed)
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Parse MANUAL_TEST_RESULT blocks from text and output JSON. "
+            "Use --input for a file or omit to read stdin."
+        )
+    )
+    parser.add_argument("--input", help="Path to input text containing one or more result blocks")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print output JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.input:
+        with open(args.input, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    else:
+        import sys
+
+        text = sys.stdin.read()
+
+    parsed = parse_manual_test_results([text])
+    if args.pretty:
+        print(json.dumps(parsed, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(parsed, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a structured manual-testing issue template and parser-backed machine-checkable result block format for issue comments.
 - Add golden snapshot tests for deterministic slot_data and enemy randomization mapping outputs, with committed JSON fixtures and an explicit snapshot update workflow.
 - Remove `worlds/kirbyam/kirbyam.apworld` from source control; add `*.apworld` to `.gitignore` to prevent re-committing the build artifact.
 - Add release integrity checks: changelog section verification and `--changelog` gate in the release metadata script and CI.

--- a/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
+++ b/worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
@@ -461,6 +461,29 @@ For each signal, copy this template:
 - [ ] Status: ✅ Verified / ⚠️ Needs work / ❌ Rejected
 ```
 
+### Machine-Checkable Result Comment Template
+
+When reporting manual results on a GitHub issue, paste this block into a
+comment and fill all fields exactly once:
+
+```text
+<!-- MANUAL_TEST_RESULT:START -->
+RESULT_SCHEMA_VERSION: 1
+TEST_CASE_ID: case-001
+STATUS: PASS
+BUILD_REF: <commit/pr/tag>
+PLATFORM: <windows/linux/macos>
+BIZHAWK_VERSION: <version>
+ROM_REGION: USA
+EXPECTED_RESULT: <short expected outcome>
+OBSERVED_RESULT: <short observed outcome>
+EVIDENCE: <link/screenshot/log excerpt>
+NOTES: <optional>
+<!-- MANUAL_TEST_RESULT:END -->
+```
+
+Allowed `STATUS` values: `PASS`, `FAIL`, `BLOCKED`.
+
 ---
 
 ## Troubleshooting

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -546,6 +546,37 @@ Implemented full runtime DeathLink flow in `worlds/kirbyam/client.py`:
   - local alive->dead send exactly once
   - incoming-apply echo suppression
 
+## Issue #312: Standardize Manual Test Templates into Machine-Checkable Checklists
+
+### Problem
+Manual testing issues were readable, but result comments were not standardized
+enough for reliable parsing/reporting.
+
+### Solution
+- Added a dedicated GitHub issue template:
+  `.github/ISSUE_TEMPLATE/manual_testing_checklist.yaml`
+  with required fields and a structured result-comment block.
+- Added parser utility:
+  `.github/scripts/manual_test_checklist_parser.py`
+  that extracts and validates manual test result blocks from issue comments.
+- Added parser tests:
+  `worlds/kirbyam/test/test_manual_test_checklist_parser.py`.
+- Added manual result block guidance to
+  `worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md`.
+
+### Result block contract
+- Delimiters:
+  `<!-- MANUAL_TEST_RESULT:START -->` and
+  `<!-- MANUAL_TEST_RESULT:END -->`
+- Required fields:
+  `RESULT_SCHEMA_VERSION`, `TEST_CASE_ID`, `STATUS`, `BUILD_REF`, `PLATFORM`,
+  `BIZHAWK_VERSION`, `ROM_REGION`, `EXPECTED_RESULT`, `OBSERVED_RESULT`,
+  `EVIDENCE`, `NOTES`
+- Allowed status values: `PASS`, `FAIL`, `BLOCKED`
+
+### Validation
+- Targeted pytest on the new parser test module.
+
 ## Issue #311: Golden Snapshot Tests for slot_data and Generated Artifacts
 
 ### Problem

--- a/worlds/kirbyam/test/test_manual_test_checklist_parser.py
+++ b/worlds/kirbyam/test/test_manual_test_checklist_parser.py
@@ -1,0 +1,76 @@
+"""Tests for machine-checkable manual testing result parsing (Issue #312)."""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / ".github" / "scripts" / "manual_test_checklist_parser.py"
+SPEC = spec_from_file_location("manual_test_checklist_parser", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load manual test parser from {SCRIPT_PATH}")
+MODULE = module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+VALID_BLOCK = """\
+Some comment text.
+
+<!-- MANUAL_TEST_RESULT:START -->
+RESULT_SCHEMA_VERSION: 1
+TEST_CASE_ID: case-001
+STATUS: pass
+BUILD_REF: pr-123
+PLATFORM: windows
+BIZHAWK_VERSION: 2.10
+ROM_REGION: USA
+EXPECTED_RESULT: one deathlink apply
+OBSERVED_RESULT: one deathlink apply
+EVIDENCE: screenshot.png
+NOTES: none
+<!-- MANUAL_TEST_RESULT:END -->
+"""
+
+
+def test_parse_manual_test_results_single_block() -> None:
+    parsed = MODULE.parse_manual_test_results([VALID_BLOCK])
+
+    assert len(parsed) == 1
+    assert parsed[0]["TEST_CASE_ID"] == "case-001"
+    assert parsed[0]["STATUS"] == "PASS"
+    assert parsed[0]["COMMENT_INDEX"] == "0"
+
+
+def test_parse_manual_test_results_multiple_comments() -> None:
+    comment_a = VALID_BLOCK.replace("case-001", "case-001a")
+    comment_b = VALID_BLOCK.replace("case-001", "case-001b").replace("STATUS: pass", "STATUS: FAIL")
+
+    parsed = MODULE.parse_manual_test_results([comment_a, comment_b])
+
+    assert [entry["TEST_CASE_ID"] for entry in parsed] == ["case-001a", "case-001b"]
+    assert [entry["STATUS"] for entry in parsed] == ["PASS", "FAIL"]
+    assert [entry["COMMENT_INDEX"] for entry in parsed] == ["0", "1"]
+
+
+def test_parse_manual_test_results_ignores_non_template_text() -> None:
+    parsed = MODULE.parse_manual_test_results(["plain comment with no result block"])
+    assert parsed == []
+
+
+def test_parse_manual_test_results_rejects_missing_fields() -> None:
+    bad_block = VALID_BLOCK.replace("EVIDENCE: screenshot.png\n", "")
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        MODULE.parse_manual_test_results([bad_block])
+
+
+def test_parse_manual_test_results_rejects_invalid_status() -> None:
+    bad_block = VALID_BLOCK.replace("STATUS: pass", "STATUS: MAYBE")
+
+    with pytest.raises(ValueError, match="Invalid STATUS value"):
+        MODULE.parse_manual_test_results([bad_block])


### PR DESCRIPTION
## Summary
Closes #312.

Standardizes manual test issue authoring and result reporting with a parser-friendly checklist/result schema while keeping instructions readable for non-technical testers.

## Changes
- Added dedicated manual test issue template:
  - .github/ISSUE_TEMPLATE/manual_testing_checklist.yaml
- Added parser utility for result comments:
  - .github/scripts/manual_test_checklist_parser.py
- Added parser tests:
  - worlds/kirbyam/test/test_manual_test_checklist_parser.py
- Updated docs for machine-checkable result blocks:
  - worlds/kirbyam/docs/BIZHAWK_TESTING_GUIDE.md
  - worlds/kirbyam/docs/notes.md
  - worlds/kirbyam/CHANGELOG.md

## Result block contract
- Delimiters:
  - <!-- MANUAL_TEST_RESULT:START -->
  - <!-- MANUAL_TEST_RESULT:END -->
- Required fields:
  - RESULT_SCHEMA_VERSION
  - TEST_CASE_ID
  - STATUS (PASS | FAIL | BLOCKED)
  - BUILD_REF
  - PLATFORM
  - BIZHAWK_VERSION
  - ROM_REGION
  - EXPECTED_RESULT
  - OBSERVED_RESULT
  - EVIDENCE
  - NOTES

## Validation
- pytest worlds/kirbyam/test/test_manual_test_checklist_parser.py -v
- Result: 5 passed
