### PR TITLE
Fix host upload TypeError by converting goal checks to addressless events

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix host upload crash (`TypeError: an integer is required`) by converting goal locations to addressless runtime events during item generation.
 - Add a structured manual-testing issue template and parser-backed machine-checkable result block format for issue comments.
 - Add golden snapshot tests for deterministic slot_data and enemy randomization mapping outputs, with committed JSON fixtures and an explicit snapshot update workflow.
 - Remove `worlds/kirbyam/kirbyam.apworld` from source control; add `*.apworld` to `.gitignore` to prevent re-committing the build artifact.

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -261,6 +261,10 @@ class KirbyAmWorld(World):
                 if loc_meta and loc_meta.category == LocationCategory.GOAL:
                     loc.place_locked_item(self.create_event(loc.name))
                     loc.progress_type = LocationProgressType.DEFAULT
+                    # Goal checks are runtime events, not host-fillable AP locations.
+                    # Keep address=None so multidata does not serialize a None item
+                    # for a numeric location entry (host LocationStore requires ints).
+                    loc.address = None
                     goal_event_count += 1
 
             # Log item creation (pool size as total; shards counted separately)

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -546,6 +546,28 @@ Implemented full runtime DeathLink flow in `worlds/kirbyam/client.py`:
   - local alive->dead send exactly once
   - incoming-apply echo suppression
 
+## Issue #333: Host Upload Crash (`TypeError: an integer is required`)
+
+### Problem
+Uploading KirbyAM seeds to `archipelago.gg` failed while loading room multidata:
+`_speedups.LocationStore.init` raised `TypeError: an integer is required`.
+
+### Root cause
+Goal locations were converted to locked event items (`item.code is None`) in
+`create_items()`, but their AP location address remained numeric. During host
+load, `LocationStore` attempted to deserialize these numeric location entries
+with a non-integer item value, causing the crash.
+
+### Solution
+- When converting goal locations to runtime events, set `loc.address = None`.
+  This keeps goal checks as event-only (non-host-fillable) locations and avoids
+  serializing `None` item codes into numeric location entries.
+- Added regression test in `test_item_pool.py` ensuring goal locations become
+  addressless events.
+
+### Validation
+- Targeted pytest for `test_item_pool.py`, including the new regression test.
+
 ## Issue #312: Standardize Manual Test Templates into Machine-Checkable Checklists
 
 ### Problem

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -1,10 +1,13 @@
 import random
 from pathlib import Path
+from types import SimpleNamespace
 
 from BaseClasses import ItemClassification
 
 from .. import KirbyAmWorld
 from ..data import LocationCategory, data
+from ..locations import KirbyAmLocation
+from ..options import RandomizeShards
 
 
 def test_useful_item_catalog_includes_map_and_vitality() -> None:
@@ -68,3 +71,41 @@ def test_payload_supports_weighted_life_fillers() -> None:
     assert "KIRBY_ITEM_ID_BASE_OFFSET + 23u" in payload
     assert "ap_grant_lives(2u)" in payload
     assert "ap_grant_lives(3u)" in payload
+
+
+def test_goal_locations_are_converted_to_addressless_events() -> None:
+    goal_key, goal_meta = next(
+        (key, meta) for key, meta in data.locations.items() if meta.category == LocationCategory.GOAL
+    )
+    goal_location = KirbyAmLocation(
+        1,
+        goal_meta.label,
+        goal_meta.location_id,
+        None,
+        key=goal_key,
+        default_item_code=goal_meta.default_item,
+    )
+
+    class _DummyMultiWorld:
+        def __init__(self, locations):
+            self._locations = locations
+            self.itempool = []
+
+        def get_locations(self, player):
+            return self._locations
+
+        def get_player_name(self, player):
+            return "KirbyAM-Test"
+
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+    world.player = 1
+    world.multiworld = _DummyMultiWorld([goal_location])
+    world.options = SimpleNamespace(
+        shards=SimpleNamespace(value=RandomizeShards.option_completely_random)
+    )
+
+    world.create_items()
+
+    assert goal_location.item is not None
+    assert goal_location.item.code is None
+    assert goal_location.address is None


### PR DESCRIPTION
## Summary
Closes #333.

Fixes archipelago.gg host-load failure (`TypeError: an integer is required`) by ensuring goal checks are serialized as runtime events instead of numeric host-fillable locations with null item codes.

## Root cause
`create_items()` converted GOAL locations to locked events (`item.code is None`) but left their numeric AP address intact. During host load, `_speedups.LocationStore` expects integer item values for numeric location entries and crashed on `None`.

## Changes
- `worlds/kirbyam/__init__.py`
  - When converting GOAL locations to events, now sets `loc.address = None`.
- `worlds/kirbyam/test/test_item_pool.py`
  - Added regression test `test_goal_locations_are_converted_to_addressless_events`.
- `worlds/kirbyam/CHANGELOG.md`
- `worlds/kirbyam/docs/notes.md`

## Validation
- `pytest worlds/kirbyam/test/test_item_pool.py -q`
- Result: 6 passed

## Note on local patch artifact validation
A local `patch_rom.py` run was interrupted repeatedly and left `worlds/kirbyam/data/base_patch.bsdiff4` locked/zero-length in this local workspace only.
This issue changes world generation serialization (Python) and does not modify payload/ROM patch logic.
No patch artifact was included in this commit/PR.
