### PR TITLE
Add negative-path tests for build.py and patch_rom.py tooling (#306)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix BizHawk handler detection by validating the KirbyAM USA GBA header and patched auth block instead of an unrelated ROM offset.
 - Fix the ROM mailbox hook to return without clobbering live game registers, preventing corrupted startup state such as Player 1 starting with 99 lives.
+- Add negative-path tests for build.py and patch_rom.py covering missing ROM paths, missing payload outputs, missing data directory, and invalid CLI argument combinations.
 
 ## v0.0.7
 

--- a/worlds/kirbyam/test/test_build_tooling_negative.py
+++ b/worlds/kirbyam/test/test_build_tooling_negative.py
@@ -1,0 +1,104 @@
+"""Negative-path tests for KirbyAM build tooling (build.py).
+
+Covers the key failure modes required by issue #306:
+- Missing/invalid manifest (archipelago.json).
+- Missing patch_rom.py script.
+- Missing data/ output directory.
+- Invalid CLI argument combinations (--source-type arg without --rom, uppercase world name).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+BUILD_PY_PATH = Path(__file__).resolve().parents[1] / "build.py"
+_build_spec = importlib.util.spec_from_file_location("kirbyam_build", BUILD_PY_PATH)
+if _build_spec is None or _build_spec.loader is None:
+    raise RuntimeError(f"Failed to load build module from {BUILD_PY_PATH}")
+build_mod = importlib.util.module_from_spec(_build_spec)
+_build_spec.loader.exec_module(build_mod)
+
+
+# ── load_json ─────────────────────────────────────────────────────────────────
+
+def test_load_json_missing_file(tmp_path: Path) -> None:
+    """Missing JSON file raises SystemExit with an actionable 'Missing manifest' message."""
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod.load_json(tmp_path / "archipelago.json")
+    assert "Missing manifest" in str(exc_info.value)
+
+
+def test_load_json_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON raises SystemExit with a descriptive message."""
+    bad_json = tmp_path / "archipelago.json"
+    bad_json.write_text("{ this is not valid json }", encoding="utf-8")
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod.load_json(bad_json)
+    assert "Invalid JSON" in str(exc_info.value)
+
+
+# ── run_patch_rom ─────────────────────────────────────────────────────────────
+
+def test_run_patch_rom_missing_patch_script(tmp_path: Path) -> None:
+    """Missing kirby_ap_payload/patch_rom.py raises SystemExit with an actionable message."""
+    (tmp_path / "data").mkdir()
+    # kirby_ap_payload/ dir does not exist → patch_rom.py cannot be found
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod.run_patch_rom(tmp_path, source_type="file", rom_arg=None)
+    assert "patch_rom.py not found" in str(exc_info.value)
+
+
+def test_run_patch_rom_missing_data_dir(tmp_path: Path) -> None:
+    """Missing data/ output directory raises SystemExit before any subprocess call."""
+    (tmp_path / "kirby_ap_payload").mkdir()
+    (tmp_path / "kirby_ap_payload" / "patch_rom.py").write_text("# placeholder")
+    # data/ is intentionally absent
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod.run_patch_rom(tmp_path, source_type="file", rom_arg=None)
+    assert "Missing data folder" in str(exc_info.value)
+
+
+def test_run_patch_rom_source_type_arg_without_rom(tmp_path: Path) -> None:
+    """--source-type arg without a ROM path raises SystemExit before any subprocess call."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "kirby_ap_payload").mkdir()
+    (tmp_path / "kirby_ap_payload" / "patch_rom.py").write_text("# placeholder")
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod.run_patch_rom(tmp_path, source_type="arg", rom_arg=None)
+    assert "did not provide --rom" in str(exc_info.value)
+
+
+# ── main() top-level guards ───────────────────────────────────────────────────
+
+def test_build_main_uppercase_world_name() -> None:
+    """Uppercase characters in --world raise SystemExit before any filesystem access."""
+    orig = sys.argv
+    sys.argv = ["build.py", "--world", "KirbyAM", "--skip-patch"]
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            build_mod.main()
+        assert "lowercase" in str(exc_info.value)
+    finally:
+        sys.argv = orig
+
+
+def test_build_main_missing_manifest(tmp_path: Path) -> None:
+    """Missing archipelago.json in the working directory raises SystemExit."""
+    orig_argv = sys.argv
+    orig_cwd = Path.cwd()
+    sys.argv = ["build.py", "--skip-patch"]
+    os.chdir(tmp_path)
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            build_mod.main()
+        assert "manifest" in str(exc_info.value).lower() or "archipelago.json" in str(exc_info.value)
+    finally:
+        os.chdir(orig_cwd)
+        sys.argv = orig_argv

--- a/worlds/kirbyam/test/test_patch_rom.py
+++ b/worlds/kirbyam/test/test_patch_rom.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import tempfile
 from pathlib import Path
+
+import pytest
 
 
 PATCH_ROM_PATH = Path(__file__).resolve().parents[1] / "kirby_ap_payload" / "patch_rom.py"
@@ -21,3 +25,45 @@ def test_patch_rom_accepts_expected_usa_rom_size() -> None:
 def test_patch_rom_warns_for_unexpected_rom_size() -> None:
     warning = patch_rom.get_rom_size_warning(0x400000)
     assert warning == "Warning: ROM size is 0x400000, expected 0x1000000. Proceeding anyway."
+
+
+# ── Negative-path tests: parse_args ──────────────────────────────────────────
+
+def test_parse_args_source_type_arg_missing_rom_positional() -> None:
+    """--source-type arg with no positional args should raise SystemExit."""
+    with pytest.raises(SystemExit, match="Usage with --source-type arg"):
+        patch_rom.parse_args(["patch_rom.py", "--source-type", "arg"])
+
+
+def test_parse_args_source_type_arg_too_many_positionals() -> None:
+    """--source-type arg with 3+ positionals should raise SystemExit."""
+    with pytest.raises(SystemExit, match="Usage with --source-type arg"):
+        patch_rom.parse_args(["patch_rom.py", "--source-type", "arg", "a.gba", "b.gba", "c.gba"])
+
+
+def test_parse_args_source_type_file_too_many_positionals() -> None:
+    """--source-type file with 2+ positionals should raise SystemExit."""
+    with pytest.raises(SystemExit, match="Usage"):
+        patch_rom.parse_args(["patch_rom.py", "--source-type", "file", "a.gba", "b.gba"])
+
+
+# ── Negative-path tests: read_rom_path_from_tmp ───────────────────────────────
+
+def test_read_rom_path_from_tmp_missing_file() -> None:
+    """Missing rom_path.tmp should raise SystemExit with an actionable message."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        missing = os.path.join(tmpdir, "rom_path.tmp")
+        with pytest.raises(SystemExit) as exc_info:
+            patch_rom.read_rom_path_from_tmp(missing)
+        assert "not found" in str(exc_info.value)
+
+
+def test_read_rom_path_from_tmp_empty_file() -> None:
+    """Empty rom_path.tmp (whitespace only) should raise SystemExit with an actionable message."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_file = os.path.join(tmpdir, "rom_path.tmp")
+        with open(tmp_file, "w") as f:
+            f.write("   \n\n")
+        with pytest.raises(SystemExit) as exc_info:
+            patch_rom.read_rom_path_from_tmp(tmp_file)
+        assert "no usable ROM path" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Closes #306 — Adds negative-path tests for KirbyAM build tooling to verify robust failure modes with actionable error messages.

## Tests added

### `worlds/kirbyam/test/test_patch_rom.py` — 5 new tests

**`parse_args` invalid CLI combinations:**
- `test_parse_args_source_type_arg_missing_rom_positional` — `--source-type arg` with no positional raises `SystemExit("Usage with --source-type arg:")`
- `test_parse_args_source_type_arg_too_many_positionals` — `--source-type arg` with 3+ positionals raises the same
- `test_parse_args_source_type_file_too_many_positionals` — `--source-type file` with 2+ positionals raises `SystemExit("Usage:")`

**`read_rom_path_from_tmp` file errors:**
- `test_read_rom_path_from_tmp_missing_file` — missing `rom_path.tmp` raises `SystemExit` with `"not found"` in message
- `test_read_rom_path_from_tmp_empty_file` — empty/whitespace-only `rom_path.tmp` raises `SystemExit` with `"no usable ROM path"`

### `worlds/kirbyam/test/test_build_tooling_negative.py` — 7 new tests (new file)

**`load_json` manifest errors:**
- `test_load_json_missing_file` — missing `archipelago.json` → `SystemExit("Missing manifest")`
- `test_load_json_invalid_json` — malformed JSON → `SystemExit("Invalid JSON")`

**`run_patch_rom` pre-subprocess guards:**
- `test_run_patch_rom_missing_patch_script` — missing `kirby_ap_payload/patch_rom.py` → `SystemExit("patch_rom.py not found")`
- `test_run_patch_rom_missing_data_dir` — missing `data/` directory → `SystemExit("Missing data folder")`
- `test_run_patch_rom_source_type_arg_without_rom` — `source_type="arg"` with `rom_arg=None` → `SystemExit("did not provide --rom")`

**`main()` argument guards:**
- `test_build_main_uppercase_world_name` — `--world KirbyAM` → `SystemExit("lowercase")`
- `test_build_main_missing_manifest` — cwd without `archipelago.json` → `SystemExit("Missing manifest")`

## Results

14 tests pass: `14 passed, 1 warning in 0.12s`