### PR TITLE
Issue #308: Add critical-module coverage gates for KirbyAM tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -68,6 +68,13 @@ jobs:
     - name: Unittests
       run: |
         pytest worlds/kirbyam/test -n auto --dist worksteal
+    - name: KirbyAM critical-module coverage gates
+      if: matrix.os == 'ubuntu-latest' && matrix.python.version == '3.13'
+      run: |
+        pytest worlds/kirbyam/test -q --cov=worlds.kirbyam --cov-report=json:test-output/kirbyam/coverage.json
+        python worlds/kirbyam/test/critical_module_coverage_gate.py \
+          --coverage-json test-output/kirbyam/coverage.json \
+          --thresholds-json worlds/kirbyam/test/critical_module_coverage_thresholds.json
     - name: Upload KirbyAM test logs on failure
       if: failure()
       uses: actions/upload-artifact@v4

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,3 +1,4 @@
 pytest>=9.0.1,<10  # this includes subtests support
 pytest-xdist>=3.8.0
 pytest-asyncio>=0.23.0
+pytest-cov>=7.1.0

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add critical-module coverage gates for protocol/runtime-sensitive KirbyAM modules, enforced in CI with versioned per-module thresholds.
 - Add a repeat-run flaky-test detection mode for reconnect-sensitive KirbyAM tests, with CI workflow support and run-index failure reporting.
 ## v0.0.8
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -2,6 +2,35 @@
 
 ## Issue #290: Generation Failure from Global bit_index Collision Check
 
+## Issue #308: Critical-Module Coverage Gates
+
+### Problem
+Global test coverage can look healthy while coverage of protocol/runtime-critical
+KirbyAM modules regresses unnoticed.
+
+### Solution
+Added module-level coverage gates for critical files:
+
+- Threshold definitions (versioned):
+  `worlds/kirbyam/test/critical_module_coverage_thresholds.json`
+- Gate evaluator:
+  `worlds/kirbyam/test/critical_module_coverage_gate.py`
+- CI enforcement in `.github/workflows/unittests.yml`:
+  - Runs once on `ubuntu-latest` / Python `3.13`
+  - Generates coverage JSON from KirbyAM tests
+  - Fails CI if any critical module falls below its threshold
+
+Current gated modules:
+- `worlds/kirbyam/client.py`
+- `worlds/kirbyam/data.py`
+- `worlds/kirbyam/generation_logging.py`
+- `worlds/kirbyam/ability_randomization.py`
+- `worlds/kirbyam/rules.py`
+
+### Validation
+- Added `worlds/kirbyam/test/test_critical_module_coverage_gate.py`.
+- Tests cover pass/fail behavior for threshold misses and missing module entries.
+
 ### Problem
 KirbyAM generation failed in `stage_assert_generate` because `validate_regions()` treated
 all location `bit_index` values as one global namespace. That rule incorrectly rejected

--- a/worlds/kirbyam/test/critical_module_coverage_gate.py
+++ b/worlds/kirbyam/test/critical_module_coverage_gate.py
@@ -1,0 +1,81 @@
+"""Enforce per-module coverage thresholds for critical KirbyAM modules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise SystemExit(f"Missing JSON file: {path}") from e
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"Invalid JSON file: {path}\n{e}") from e
+
+
+def _normalize_path(path_str: str) -> str:
+    return path_str.replace("\\", "/")
+
+
+def enforce_thresholds(coverage_json: Path, thresholds_json: Path) -> tuple[bool, list[str]]:
+    coverage = _load_json(coverage_json)
+    thresholds_raw = _load_json(thresholds_json)
+
+    files = coverage.get("files")
+    if not isinstance(files, dict):
+        raise SystemExit(f"Coverage JSON does not contain 'files' object: {coverage_json}")
+
+    threshold_items: dict[str, float] = {}
+    for module_path, threshold in thresholds_raw.items():
+        if not isinstance(module_path, str):
+            raise SystemExit("Threshold keys must be module path strings")
+        if not isinstance(threshold, (int, float)):
+            raise SystemExit(f"Threshold for {module_path} must be numeric")
+        threshold_items[_normalize_path(module_path)] = float(threshold)
+
+    covered_by_norm_path: dict[str, float] = {}
+    for raw_path, payload in files.items():
+        normalized = _normalize_path(raw_path)
+        summary = payload.get("summary", {}) if isinstance(payload, dict) else {}
+        percent = summary.get("percent_covered")
+        if isinstance(percent, (int, float)):
+            covered_by_norm_path[normalized] = float(percent)
+
+    failures: list[str] = []
+    details: list[str] = []
+
+    for module_path, threshold in threshold_items.items():
+        actual = covered_by_norm_path.get(module_path)
+        if actual is None:
+            failures.append(f"{module_path}: missing from coverage report (required >= {threshold:.1f}%)")
+            continue
+
+        details.append(f"{module_path}: {actual:.1f}% (required >= {threshold:.1f}%)")
+        if actual + 1e-9 < threshold:
+            failures.append(f"{module_path}: {actual:.1f}% < {threshold:.1f}%")
+
+    if failures:
+        return False, details + ["", "Coverage gate failures:", *failures]
+    return True, details + ["", "All critical module coverage thresholds passed."]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate critical-module coverage thresholds.")
+    parser.add_argument("--coverage-json", required=True, help="Path to coverage JSON report.")
+    parser.add_argument("--thresholds-json", required=True, help="Path to thresholds JSON file.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ok, lines = enforce_thresholds(Path(args.coverage_json), Path(args.thresholds_json))
+    for line in lines:
+        print(line)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worlds/kirbyam/test/critical_module_coverage_thresholds.json
+++ b/worlds/kirbyam/test/critical_module_coverage_thresholds.json
@@ -1,0 +1,7 @@
+{
+  "worlds/kirbyam/client.py": 88.0,
+  "worlds/kirbyam/data.py": 70.0,
+  "worlds/kirbyam/generation_logging.py": 70.0,
+  "worlds/kirbyam/ability_randomization.py": 72.0,
+  "worlds/kirbyam/rules.py": 90.0
+}

--- a/worlds/kirbyam/test/test_critical_module_coverage_gate.py
+++ b/worlds/kirbyam/test/test_critical_module_coverage_gate.py
@@ -1,0 +1,76 @@
+"""Tests for critical-module coverage gate enforcement (Issue #308)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+GATE_PATH = Path(__file__).resolve().parent / "critical_module_coverage_gate.py"
+GATE_SPEC = importlib.util.spec_from_file_location("kirbyam_cov_gate", GATE_PATH)
+if GATE_SPEC is None or GATE_SPEC.loader is None:
+    raise RuntimeError(f"Failed to load coverage gate module from {GATE_PATH}")
+gate = importlib.util.module_from_spec(GATE_SPEC)
+GATE_SPEC.loader.exec_module(gate)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_enforce_thresholds_passes_when_all_modules_meet_target(tmp_path: Path) -> None:
+    cov = tmp_path / "coverage.json"
+    thr = tmp_path / "thresholds.json"
+
+    _write_json(
+        cov,
+        {
+            "files": {
+                "worlds/kirbyam/client.py": {"summary": {"percent_covered": 90.0}},
+                "worlds/kirbyam/rules.py": {"summary": {"percent_covered": 95.0}},
+            }
+        },
+    )
+    _write_json(
+        thr,
+        {
+            "worlds/kirbyam/client.py": 88.0,
+            "worlds/kirbyam/rules.py": 90.0,
+        },
+    )
+
+    ok, lines = gate.enforce_thresholds(cov, thr)
+    assert ok
+    assert any("All critical module coverage thresholds passed." in line for line in lines)
+
+
+def test_enforce_thresholds_fails_for_low_coverage(tmp_path: Path) -> None:
+    cov = tmp_path / "coverage.json"
+    thr = tmp_path / "thresholds.json"
+
+    _write_json(
+        cov,
+        {
+            "files": {
+                "worlds/kirbyam/client.py": {"summary": {"percent_covered": 80.0}},
+            }
+        },
+    )
+    _write_json(thr, {"worlds/kirbyam/client.py": 88.0})
+
+    ok, lines = gate.enforce_thresholds(cov, thr)
+    assert not ok
+    assert any("80.0% < 88.0%" in line for line in lines)
+
+
+def test_enforce_thresholds_fails_when_required_module_missing(tmp_path: Path) -> None:
+    cov = tmp_path / "coverage.json"
+    thr = tmp_path / "thresholds.json"
+
+    _write_json(cov, {"files": {}})
+    _write_json(thr, {"worlds/kirbyam/client.py": 88.0})
+
+    ok, lines = gate.enforce_thresholds(cov, thr)
+    assert not ok
+    assert any("missing from coverage report" in line for line in lines)


### PR DESCRIPTION
## Summary\n- add a scriptable critical-module coverage gate that reads coverage.py JSON output\n- add versioned threshold definitions for high-value KirbyAM modules\n- enforce the gate in CI on the canonical ubuntu/python3.13 unit-test lane\n- document local and CI usage in KirbyAM notes\n\n## Validation\n- .venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_critical_module_coverage_gate.py -q\n- .venv/Scripts/python.exe -m pytest worlds/kirbyam/test -q --cov=worlds.kirbyam --cov-report=json:test-output/kirbyam/coverage.308.json\n- .venv/Scripts/python.exe worlds/kirbyam/test/critical_module_coverage_gate.py --coverage-json test-output/kirbyam/coverage.308.json --thresholds-json worlds/kirbyam/test/critical_module_coverage_thresholds.json\n\nCloses #308