### PR TITLE
Hide non-shipping KirbyAM template goal choices

### DIFF
--- a/data/options.yaml
+++ b/data/options.yaml
@@ -76,8 +76,11 @@ requires:
     {{- range_option(option, option_val) -}}
 
     {%- elif option.options -%}
+    {%- set excluded_choices = option.template_excluded_choices if option.template_excluded_choices is defined else [] -%}
     {%- for suboption_option_id, sub_option_name in option.name_lookup.items() %}
+    {%- if sub_option_name not in excluded_choices and suboption_option_id not in excluded_choices %}
     {{ yaml_dump(sub_option_name) }}: {% if suboption_option_id == option_val or sub_option_name == option_val %}50{% else %}0{% endif %}
+    {%- endif -%}
     {%- endfor -%}
   
     {%- if option.name_lookup[option_val] not in option.options and option_val not in option.options %}

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix KirbyAM Open Patch preflight to revalidate configured base ROM for `.apkirbyam` and reprompt in GUI mode when hash/path checks fail.
 - Reduce BizHawk client log spam by suppressing duplicate "patch metadata missing" validation errors during repeated retries.
 - Remove debug-only KirbyAM event locations from normal world generation/spoiler output and add regression coverage to prevent `EVENT_DEBUG_` leaks.
+- Hide non-shipping KirbyAM goal choices (`100`, `debug`) from generated player YAML templates and add regression coverage.
 
 ## v0.0.9
 

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -11,14 +11,15 @@ class Goal(Choice):
     Determines what your goal is to consider the game beaten.
 
     - Dark Mind: Defeat Dark Mind and beat the game
-    - 100% Save File: NOT READY --- Achieve 100% completion of the save file
-    - DEBUG: A goal for testing purposes
+    - 100% Save File: Reserved for future player-template exposure
+    - DEBUG: Testing-only goal
     """
     display_name = "Goal"
     default = 0
     option_dark_mind = 0
     option_100 = 1
     option_debug = 2
+    template_excluded_choices = frozenset({"100", "debug"})
 
 
 class RandomizeShards(Choice):

--- a/worlds/kirbyam/test/test_template_options.py
+++ b/worlds/kirbyam/test/test_template_options.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from Utils import parse_yaml
+
+
+def test_kirbyam_template_hides_non_shipping_goal_choices() -> None:
+    import worlds.AutoWorld
+    from Options import generate_yaml_templates
+    from worlds.AutoWorld import AutoWorldRegister
+    from worlds.kirbyam import KirbyAmWorld
+
+    old_world_types = AutoWorldRegister.world_types
+    try:
+        AutoWorldRegister.world_types = {KirbyAmWorld.game: KirbyAmWorld}
+
+        with TemporaryDirectory("archipelago_kirbyam_template") as temp_dir:
+            generate_yaml_templates(temp_dir)
+
+            generated_file = Path(temp_dir) / "Kirby & The Amazing Mirror.yaml"
+            assert generated_file.exists()
+
+            with generated_file.open(encoding="utf-8") as f:
+                content = f.read()
+                data = parse_yaml(content)
+
+            game_block = data["Kirby & The Amazing Mirror"]
+            goal_weights = game_block["goal"]
+
+            assert "dark_mind" in goal_weights
+            assert "100" not in goal_weights
+            assert "debug" not in goal_weights
+    finally:
+        worlds.AutoWorld.AutoWorldRegister.world_types = old_world_types


### PR DESCRIPTION
## Summary
- add template-level choice filtering support for Choice options via `template_excluded_choices`
- hide KirbyAM `goal` choices `100` and `debug` from generated player YAML
- keep runtime option IDs unchanged for compatibility
- add regression coverage for generated KirbyAM template content
- update KirbyAM changelog

## Validation
- pytest worlds/kirbyam/test/test_template_options.py test/options/test_generate_templates.py
- Build payload task

Closes #359