### PR TITLE
Fix server crash on KirbyAM BizHawk connect auth

### DIFF
--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -428,12 +428,10 @@ class KirbyAmWorld(World):
             raise
 
     def modify_multidata(self, multidata: dict[str, Any]) -> None:
-        # Register auth token -> player name mapping for BizHawk
+        # Register auth token using the same (team, slot) tuple shape as player names.
         key = base64.b64encode(self.auth).decode("ascii")
-        connect_names = multidata.setdefault("connect_names", {})
-        # connect_names is used as an auth-token to player-name mapping.
-        # The player's name should always be the value.
-        connect_names[key] = self.player_name
+        connect_names = multidata["connect_names"]
+        connect_names[key] = connect_names[self.player_name]
 
     # Helper method to fill slot data
     def fill_slot_data(self) -> dict[str, Any]:

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -764,6 +764,24 @@ enough for reliable parsing/reporting.
 ### Validation
 - Targeted pytest on the new parser test module.
 
+## Issue #373: Fix BizHawk Connect Crash from connect_names Value Shape
+
+### Problem
+KirbyAM registered BizHawk auth tokens in `connect_names` as player-name
+strings. The server expects every `connect_names` value to be a `(team, slot)`
+tuple, so connection attempts could crash with a tuple-unpack `ValueError`.
+
+### Solution
+- Updated `KirbyAmWorld.modify_multidata` to copy the existing `(team, slot)`
+  tuple from the player-name entry instead of storing the player name string.
+- Added regression test module
+  `worlds/kirbyam/test/test_multidata_connect_names.py` to assert auth token
+  registration preserves tuple shape.
+
+### Validation
+- `pytest worlds/kirbyam/test/test_multidata_connect_names.py`
+- `pytest worlds/kirbyam/test/test_hosting_integration.py`
+
 ## Issue #311: Golden Snapshot Tests for slot_data and Generated Artifacts
 
 ### Problem

--- a/worlds/kirbyam/test/test_multidata_connect_names.py
+++ b/worlds/kirbyam/test/test_multidata_connect_names.py
@@ -1,0 +1,29 @@
+"""Regression tests for KirbyAM connect_names token registration (Issue #373)."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import Mock
+
+from .. import KirbyAmWorld
+
+
+def test_modify_multidata_registers_auth_token_with_team_slot_tuple() -> None:
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+    world.auth = bytes(range(16))
+    world.player = 1
+    world.multiworld = Mock()
+    world.multiworld.get_player_name.return_value = "KirbyAM Test"
+
+    multidata = {
+        "connect_names": {
+            "KirbyAM Test": (0, 1),
+        }
+    }
+
+    KirbyAmWorld.modify_multidata(world, multidata)
+
+    auth_key = base64.b64encode(world.auth).decode("ascii")
+    assert multidata["connect_names"][auth_key] == (0, 1)
+    assert isinstance(multidata["connect_names"][auth_key], tuple)
+    assert len(multidata["connect_names"][auth_key]) == 2


### PR DESCRIPTION
## Summary
- fix KirbyAmWorld.modify_multidata to register BizHawk auth token keys in connect_names with the expected (team, slot) tuple
- add regression test covering auth-token registration shape
- document the issue and validation in KirbyAM notes

## Validation
- python -m pytest worlds/kirbyam/test/test_multidata_connect_names.py worlds/kirbyam/test/test_hosting_integration.py -q

Closes #373