### PR TITLE
Harden KirbyAM hook context preservation to prevent startup-state corruption

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Hide KirbyAM goal/event-style objective checks from datapackage location exports so `/locations` no longer lists them as normal AP locations.
+- Harden ROM hook context preservation at startup by explicitly saving/restoring low+high register state around `ap_poll_mailbox_c`, reducing startup-state corruption risk (99-lives symptom).
 
 ## v0.0.10
 

--- a/worlds/kirbyam/docs/notes.md
+++ b/worlds/kirbyam/docs/notes.md
@@ -991,6 +991,29 @@ reconnect behavior easier to debug.
 - Added tests that assert resend logging and dedupe suppression logging.
 - Full client test file passes after update.
 
+## Issue #337: Startup 99-Lives Follow-up Hook Hardening
+
+### Problem
+Startup-state corruption could still appear as a 99-lives symptom despite the
+earlier fix that removed an explicit `r4` temporary restore pattern.
+
+The remaining risk was the hook boundary itself: calling `ap_poll_mailbox_c`
+from a sensitive site while preserving only part of the live register context.
+
+### Solution
+Hardened `ap_hook_entry` in `ap_hook.s` to preserve a stronger context envelope:
+- save/restore `r0-r7` and `lr`
+- explicitly mirror and restore `r8-r11` through `r0-r3` around the C call
+- keep replayed overwritten instructions (`mov r7, r9` / `mov r6, r8`) intact
+
+This reduces the chance of hook-boundary context drift affecting startup state.
+
+### Validation
+- Updated `test_reset_safe_shards.py` hook regression to assert:
+  - low-register + LR preservation (`push/pop {r0-r7, lr}` / `{r0-r7}`)
+  - explicit high-register mirror/restore (`r8-r11` via `r0-r3`)
+  - no `r4`-based LR reconstruction pattern
+
 ## Issue #223: In-Gameplay Unsafe-State Delivery Policy (Research-First Mode)
 
 ### Problem

--- a/worlds/kirbyam/kirby_ap_payload/ap_hook.s
+++ b/worlds/kirbyam/kirby_ap_payload/ap_hook.s
@@ -6,14 +6,29 @@
 .extern ap_poll_mailbox_c
 
 ap_hook_entry:
-    // Save r0-r3 and LR.
-    push {r0-r3, lr}
+    // Preserve full low-register context plus LR.
+    push {r0-r7, lr}
+
+    // Explicitly preserve high registers used by the overwritten stream.
+    // Save r8-r11 via low registers so C call effects cannot leak here.
+    mov r0, r8
+    mov r1, r9
+    mov r2, r10
+    mov r3, r11
+    push {r0-r3}
 
     bl ap_poll_mailbox_c
 
-    // Restore r0-r3 and leave the saved LR on the stack until return.
-    // Using r4 as a temporary here corrupts live game state at the hook site.
+    // Restore preserved high registers first.
     pop  {r0-r3}
+    mov r8, r0
+    mov r9, r1
+    mov r10, r2
+    mov r11, r3
+
+    // Restore full low-register context and leave saved LR on stack until return.
+    // Using r4 as a temporary here can corrupt live game state at this hook site.
+    pop  {r0-r7}
 
     // Re-run overwritten instructions from 0x08152696/0x08152698:
     mov r7, r9

--- a/worlds/kirbyam/test/test_reset_safe_shards.py
+++ b/worlds/kirbyam/test/test_reset_safe_shards.py
@@ -84,8 +84,8 @@ def test_issue_109_addresses_documented():
     assert "0x1C" in content or "28" in content, "SRAM offset 0x1C should be defined"
 
 
-def test_ap_hook_returns_without_clobbering_r4():
-    """Verify the payload hook keeps LR on the stack instead of using r4 as a temp."""
+def test_ap_hook_preserves_register_context_without_r4_temp_restore():
+    """Verify the hook preserves full context and does not rebuild LR through r4."""
     hook_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_hook.s")
     assert os.path.exists(hook_path), "ap_hook.s should exist in kirby_ap_payload"
 
@@ -97,10 +97,22 @@ def test_ap_hook_returns_without_clobbering_r4():
     # Normalize runs of spaces/tabs to a single space.
     normalized = re.sub(r'[ \t]+', ' ', code_only)
 
-    assert re.search(r'\bpush\s*\{r0-r3,\s*lr\}', normalized), \
-        "Hook should save r0-r3 and lr"
+    assert re.search(r'\bpush\s*\{r0-r7,\s*lr\}', normalized), \
+        "Hook should save r0-r7 and lr"
+    assert re.search(r'\bpush\s*\{r0-r3\}', normalized), \
+        "Hook should save high-register mirrors through r0-r3"
     assert re.search(r'\bpop\s*\{r0-r3\}', normalized), \
-        "Hook should restore r0-r3 before replaying instructions"
+        "Hook should restore high-register mirrors before low-register restore"
+    assert re.search(r'\bmov\s+r8\s*,\s*r0\b', normalized), \
+        "Hook should restore r8 from mirrored low register"
+    assert re.search(r'\bmov\s+r9\s*,\s*r1\b', normalized), \
+        "Hook should restore r9 from mirrored low register"
+    assert re.search(r'\bmov\s+r10\s*,\s*r2\b', normalized), \
+        "Hook should restore r10 from mirrored low register"
+    assert re.search(r'\bmov\s+r11\s*,\s*r3\b', normalized), \
+        "Hook should restore r11 from mirrored low register"
+    assert re.search(r'\bpop\s*\{r0-r7\}', normalized), \
+        "Hook should restore r0-r7 before replaying overwritten instructions"
     assert re.search(r'\bpop\s*\{pc\}', normalized), \
         "Hook should return by popping the saved lr into pc"
     assert not re.search(r'\bpop\s*\{[^}]*\br4\b[^}]*\}', normalized, re.IGNORECASE), \


### PR DESCRIPTION
## Summary
- harden the ROM hook boundary to preserve full low-register context and explicit high-register mirrors across p_poll_mailbox_c
- keep replayed overwritten instructions unchanged while reducing startup-state corruption risk
- strengthen hook regression coverage to assert the expanded register-preservation contract
- document Issue #337 follow-up rationale and behavior changes in notes/changelog

## Validation
- python -m pytest worlds/kirbyam/test/test_reset_safe_shards.py -q
- python -m pytest worlds/kirbyam/test/test_patch_rom.py -q

Closes #337