### PR TITLE
Fix: Apply Copilot review finding on timeout recovery test

### DIFF
--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1276,7 +1276,7 @@ async def test_game_watcher_skips_when_server_is_none(mock_bizhawk_context):
 
 
 @pytest.mark.asyncio
-async def test_global_game_watcher_recovers_when_handler_tick_times_out(caplog):
+async def test_global_game_watcher_recovers_when_handler_tick_times_out():
     """A RequestFailedError in handler game_watcher should not crash the global watcher loop."""
     ctx = Mock()
     ctx.watcher_timeout = 0.01
@@ -1297,15 +1297,15 @@ async def test_global_game_watcher_recovers_when_handler_tick_times_out(caplog):
     ctx.client_handler.game_watcher = AsyncMock(side_effect=raise_timeout)
 
     with patch('worlds._bizhawk.context.ping', new_callable=AsyncMock) as mock_ping, \
-         patch('worlds._bizhawk.context.get_hash', new_callable=AsyncMock) as mock_get_hash:
+         patch('worlds._bizhawk.context.get_hash', new_callable=AsyncMock) as mock_get_hash, \
+         patch('worlds._bizhawk.context.logger') as mock_logger:
         mock_get_hash.return_value = "test_rom_hash"
 
-        with caplog.at_level(logging.INFO):
-            await asyncio.wait_for(_game_watcher(ctx), timeout=0.2)
+        await asyncio.wait_for(_game_watcher(ctx), timeout=0.2)
 
     mock_ping.assert_awaited_once_with(ctx.bizhawk_ctx)
     ctx.client_handler.game_watcher.assert_awaited_once_with(ctx)
-    assert "Lost connection to BizHawk: Connection timed out" in caplog.text
+    mock_logger.info.assert_called_with("Lost connection to BizHawk: Connection timed out")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Addresses Copilot review comment from PR #429. The test for timeout recovery was using \caplog\ to verify logging, but Copilot correctly noted that explicitly patching \worlds._bizhawk.context.logger\ is more reliable and maintainable.

## Changes
- Patch \worlds._bizhawk.context.logger\ directly instead of relying on caplog
- Change assertion to directly verify logger.info call with correct message
- More explicit testing that the logger mock properly intercepts logs from _game_watcher

## Related Issue
Copilot review comment on #429