### PR TITLE
Fix #479: enforce item pool non-filler uniqueness

### DIFF
--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -324,39 +324,46 @@ class KirbyAmWorld(World):
                         self.options.shards.current_key,
                     )
 
-                # Build default items for all still-open physical locations.
-                base_non_shard_codes: list[int] = []
-                base_non_shard_locations = [
-                    loc
-                    for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations
-                    if loc.item is None
-                ]
-
-                for loc in base_non_shard_locations:
-                    if loc.default_item_code is None:
-                        raise ValueError(f"KirbyAM location '{loc.name}' is missing a default item code")
-                    base_non_shard_codes.append(loc.default_item_code)
-
-                if self.options.shards.value == RandomizeShards.option_completely_random:
-                    if len(shard_item_codes) > len(base_non_shard_codes):
-                        raise ValueError(
-                            "KirbyAM shard pool mismatch: shard item count %d exceeds open physical locations %d"
-                            % (len(shard_item_codes), len(base_non_shard_codes))
-                        )
-                    codes_for_open_locations = list(base_non_shard_codes)
-                    replacement_indices = list(range(len(codes_for_open_locations)))
-                    self.random.shuffle(replacement_indices)
-                    for replacement_index, shard_code in zip(replacement_indices, shard_item_codes):
-                        codes_for_open_locations[replacement_index] = shard_code
-                    randomized_item_codes.extend(codes_for_open_locations)
-                else:
-                    randomized_item_codes.extend(base_non_shard_codes)
-
                 open_physical_locations = [
                     loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations
                     if loc.item is None
                 ]
                 needed_pool_size = len(open_physical_locations)
+
+                non_filler_item_codes = [
+                    item.item_id
+                    for item in kirby_data.items.values()
+                    if item.classification != ItemClassification.filler
+                ]
+                if self.options.shards.value == RandomizeShards.option_vanilla:
+                    shard_code_set = set(shard_item_codes)
+                    non_filler_item_codes = [
+                        code for code in non_filler_item_codes if code not in shard_code_set
+                    ]
+
+                if len(non_filler_item_codes) > needed_pool_size:
+                    raise ValueError(
+                        "KirbyAM item pool mismatch: non-filler item count %d exceeds open physical locations %d"
+                        % (len(non_filler_item_codes), needed_pool_size)
+                    )
+
+                filler_needed = needed_pool_size - len(non_filler_item_codes)
+                randomized_item_codes.extend(non_filler_item_codes)
+                randomized_item_codes.extend(
+                    self.item_name_to_id[self.get_filler_item_name()]
+                    for _ in range(filler_needed)
+                )
+                self.random.shuffle(randomized_item_codes)
+
+                non_filler_pool_codes = [
+                    code
+                    for code in randomized_item_codes
+                    if get_item_classification(code) != ItemClassification.filler
+                ]
+                if sorted(non_filler_pool_codes) != sorted(non_filler_item_codes):
+                    raise ValueError(
+                        "KirbyAM item pool invariant failed: randomized non-filler item set does not match expected set"
+                    )
 
                 if len(randomized_item_codes) != needed_pool_size:
                     raise ValueError(

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -2,10 +2,13 @@ import random
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from BaseClasses import ItemClassification
 
 from .. import KirbyAmWorld
 from ..data import LocationCategory, data
+from ..items import get_item_classification
 from ..locations import KirbyAmLocation
 from ..options import RandomizeShards
 
@@ -235,3 +238,69 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
     _expected_pool_size = _open_non_goal_location_count
     assert len(world.multiworld.itempool) == _expected_pool_size
     assert len(shard_items) == _shard_item_count
+
+
+def test_completely_random_pool_contains_each_non_filler_item_exactly_once() -> None:
+    world, _locations = _build_world_for_create_items(RandomizeShards.option_completely_random)
+
+    world.create_items()
+
+    expected_non_filler_codes = {
+        item.item_id for item in data.items.values() if item.classification != ItemClassification.filler
+    }
+    pool_codes = [item.code for item in world.multiworld.itempool if item.code is not None]
+    pool_non_filler_codes = [code for code in pool_codes if get_item_classification(code) != ItemClassification.filler]
+
+    assert set(pool_non_filler_codes) == expected_non_filler_codes
+    assert len(pool_non_filler_codes) == len(expected_non_filler_codes)
+    assert len(pool_codes) >= len(expected_non_filler_codes)
+
+
+def test_vanilla_pool_contains_each_non_shard_non_filler_item_exactly_once() -> None:
+    world, _locations = _build_world_for_create_items(RandomizeShards.option_vanilla)
+
+    world.create_items()
+
+    shard_codes = {
+        item.item_id for item in data.items.values() if "Shards" in item.tags
+    }
+    expected_non_filler_codes = {
+        item.item_id
+        for item in data.items.values()
+        if item.classification != ItemClassification.filler and item.item_id not in shard_codes
+    }
+    pool_codes = [item.code for item in world.multiworld.itempool if item.code is not None]
+    pool_non_filler_codes = [code for code in pool_codes if get_item_classification(code) != ItemClassification.filler]
+
+    assert set(pool_non_filler_codes) == expected_non_filler_codes
+    assert len(pool_non_filler_codes) == len(expected_non_filler_codes)
+    assert shard_codes.isdisjoint(set(pool_codes)), "Vanilla shard mode should not randomize shard items"
+
+
+def test_create_items_fails_when_non_filler_count_exceeds_open_locations() -> None:
+    boss_only_locations = [
+        KirbyAmLocation(
+            1,
+            meta.label,
+            meta.location_id,
+            None,
+            key=key,
+            default_item_code=meta.default_item,
+        )
+        for key, meta in data.locations.items()
+        if meta.category == LocationCategory.BOSS_DEFEAT
+    ]
+
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+    world.player = 1
+    world.random = random.Random(7)
+    world.multiworld = _DummyMultiWorld(boss_only_locations)
+    world.options = SimpleNamespace(
+        shards=SimpleNamespace(
+            value=RandomizeShards.option_completely_random,
+            current_key="completely_random",
+        )
+    )
+
+    with pytest.raises(ValueError, match="non-filler item count"):
+        world.create_items()


### PR DESCRIPTION
## Summary
Fixes #479 by rebuilding the randomized item pool from item-catalog invariants instead of replacing arbitrary default-location items with shards.

## What changed
- Updated create_items to:
  - build pool from all non-filler items exactly once,
  - exclude shard items from randomized pool in vanilla shard mode (since those are locked to bosses),
  - fill remaining open slots only with filler picks,
  - hard-fail when non-filler count exceeds open locations,
  - assert non-filler pool invariant after assembly.
- Added regression tests for:
  - completely_random: all non-filler items appear exactly once,
  - vanilla: all non-shard non-filler items appear exactly once and shards are not randomized,
  - hard-fail when open locations are fewer than required non-filler items.

## Evidence trail
- Claim: item pool must include each non-filler exactly once and only duplicate fillers when needed.
- Source: Issue #479 acceptance criteria and bug report notes.
- Adaptation: replaced shard replacement logic with catalog-driven non-filler construction plus filler padding.
- Validation:
  - python -m pytest worlds/kirbyam/test/test_item_pool.py -q (15 passed)
  - Build payload step attempted with make, but this clone has no Makefile (No targets specified and no makefile found).
