### PR TITLE
Release sync: v0.0.16 changelog and world_version

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.0.16
+
 - Fix boss shard AP-ownership semantics by keeping temporary native shard writes only during post-boss cutscene safety windows, then scrubbing non-AP-owned boss-temp shard bits on gameplay resume (instead of relying solely on fixed-frame delay), while preserving already AP-owned shard bits and adding debug-only per-frame post-boss shard telemetry gated by `enable_debug_logging` (Issue #505).
 
 ## v0.0.15

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.0.15",
+  "world_version": "0.0.16",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- cut 0.0.16 from Unreleased in KirbyAM changelog
- bump world_version in worlds/kirbyam/archipelago.json to 