### PR TITLE
Release v0.0.17 pre-tag metadata sync

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.0.17
+
 - Add a `Make the game harder` option group containing `No Extra Lives` (`no_extra_lives`) and `DeathLink`, pass `no_extra_lives` through slot data, exclude `1 Up` from filler generation when enabled, and clamp the native life counter to `0` during gameplay with debug-only enforcement logging (Issue #491).
 - Add `Ability Randomization: No Ability Weight` (`ability_randomization_no_ability_weight`), a 0-100 weighted no-ability outcome for included randomized enemy grants. A value of `0` preserves all included grants as copy abilities, `100` forces all included grants to resolve to no ability, and intermediate values are deterministic per shuffled enemy type or per completely-random grant event with a separately salted no-ability roll. The shipped default is `55` based on a USA-ROM scan of vanilla regular-enemy placements (`827 / 1510 = 54.77%`). Existing boss-spawn, miniboss, and passive-enemy toggles still control which sources participate (Issue #399).
 - Unhide KirbyAM common item/location options in generated templates and option surface (`local_items`, `non_local_items`, `start_inventory`, `start_hints`, `start_location_hints`, `exclude_locations`, `priority_locations`, `item_links`, `plando_items`), and document standard Archipelago usage in world docs (Issue #546).

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.0.16",
+  "world_version": "0.0.17",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- cut worlds/kirbyam/CHANGELOG.md Unreleased entries into v0.0.17
- bump worlds/kirbyam/archipelago.json world_version to 0.0.17

## Purpose
Implements the pre-tag sync step so manifest version and release tag can match exactly when tagging main.

## Validation
- verified updated files are in the same commit
- version values align: changelog v0.0.17 and manifest 0.0.17