### PR TITLE
KirbyAM: Add One-Hit Mode option (Issue #549)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `One-Hit Mode` (`one_hit_mode`) to the `Make the game harder` option group. Selecting `exclude_vitality_counters` removes all four Vitality Counter items from the item pool (replaced by filler) and enforces a maximum HP of 1 throughout the run. Selecting `include_vitality_counters` keeps Vitality Counters in the pool but still starts Kirby at maximum 1 HP; each Vitality Counter item received raises the cap by 1 (up to 5 with all four). The BizHawk client enforces the cap every gameplay tick by clamping `kirby_max_hp_native` and `kirby_hp_native` (player 0) to `vitality_counter + 1`, with dead/negative HP states preserved (Issue #549).
+
 ## v0.0.17
 
 - Add a `Make the game harder` option group containing `No Extra Lives` (`no_extra_lives`) and `DeathLink`, pass `no_extra_lives` through slot data, exclude `1 Up` from filler generation when enabled, and clamp the native life counter to `0` during gameplay with debug-only enforcement logging (Issue #491).

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -177,7 +177,7 @@ DeathLink runtime behavior contract:
 - Any `no_extra_lives` runtime diagnostics must remain gated behind `debug.logging`.
 
 `one_hit_mode` runtime behavior contract:
-- Generation removes all four Vitality Counter items from the non-filler item pool (replaced by filler) when `one_hit_mode == exclude_vitality_counters` (1). Vitality Chest locations are kept and receive filler items.
+- Generation removes all four Vitality Counter items from the non-filler item pool (replaced by filler) when `one_hit_mode == exclude_vitality_counters` (1). Vitality Chest locations are kept, but this mode does not guarantee location-specific filler placement on those chests.
 - Generation leaves the item pool unchanged when `one_hit_mode == include_vitality_counters` (2).
 - During gameplay, when `one_hit_mode != vanilla`, the BizHawk client reads `kirby_vitality_counter_native` (`u16`) and enforces `desired_max_hp = vitality_counter + 1` (capped to `0x7F`) onto `kirby_max_hp_native` and `kirby_hp_native` for player 0's struct.
 - Dead/negative HP states (`current_hp <= 0`) are preserved; only alive Kirby's HP is clamped.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -76,7 +76,9 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x0203AD2C | 4B | AI_KIRBY_STATE          | Runtime phase classifier (Issue #56 gameplay gate) |
 | 0x0203AD10 | 4B | DEMO_PLAYBACK_FLAGS     | Native title-demo discriminator (`demo_playback_flags_native`; bit `0x10` indicates title-screen demo playback) |
 | 0x02020FE0 | 1B | KIRBY_HP                | Kirby HP (`s8`) used for DeathLink runtime receive/apply and local death transition detection |
+| 0x02020FE1 | 1B | KIRBY_MAX_HP            | Kirby max HP (`s8`) used for one-hit mode enforcement (player 0 struct) |
 | 0x02020FE2 | 1B | KIRBY_LIVES             | Native extra-life counter (`u8`) used for `no_extra_lives` enforcement |
+| 0x02038980 | 2B | KIRBY_VITALITY_COUNTER  | Native vitality counter (`u16`); incremented by ROM payload on Vitality Counter item delivery; read by one-hit mode enforcement |
 
 ## Item ID Ranges
 
@@ -143,6 +145,7 @@ Server → Client: ConnectionRefused | Connected
 - `goal` (int): selected goal option.
 - `shards` (int): shard randomization mode.
 - `no_extra_lives` (bool): when true, exclude `1 Up` filler generation and have the BizHawk client clamp the native life counter to `0` during gameplay.
+- `one_hit_mode` (int): one-hit mode selection (`0=vanilla`, `1=exclude_vitality_counters`, `2=include_vitality_counters`). When non-zero, Kirby's max HP is clamped to `vitality_counter + 1` during gameplay. In `exclude_vitality_counters` mode, Vitality Counter items are removed from the item pool (replaced by filler) so the cap stays at 1. In `include_vitality_counters` mode, Vitality Counter items remain in the pool and each one received raises the cap by 1.
 - `death_link` (bool): enables/disables AP DeathLink tag synchronization in the client.
 - `ability_randomization_mode` (int): enemy copy-ability mode (`0=vanilla`, `1=shuffled`, `2=completely_random`).
 - `ability_randomization_boss_spawns` (bool): include/exclude ability-granting boss-spawned objects.
@@ -172,6 +175,13 @@ DeathLink runtime behavior contract:
 - Generation removes `1 Up` from the active filler pool when the option is enabled.
 - During gameplay, the BizHawk client clamps `kirby_lives_native` to `0` so the player starts with zero extra lives and native/in-game life gains are overwritten.
 - Any `no_extra_lives` runtime diagnostics must remain gated behind `debug.logging`.
+
+`one_hit_mode` runtime behavior contract:
+- Generation removes all four Vitality Counter items from the non-filler item pool (replaced by filler) when `one_hit_mode == exclude_vitality_counters` (1). Vitality Chest locations are kept and receive filler items.
+- Generation leaves the item pool unchanged when `one_hit_mode == include_vitality_counters` (2).
+- During gameplay, when `one_hit_mode != vanilla`, the BizHawk client reads `kirby_vitality_counter_native` (`u16`) and enforces `desired_max_hp = vitality_counter + 1` (capped to `0x7F`) onto `kirby_max_hp_native` and `kirby_hp_native` for player 0's struct.
+- Dead/negative HP states (`current_hp <= 0`) are preserved; only alive Kirby's HP is clamped.
+- Any `one_hit_mode` runtime diagnostics must remain gated behind `debug.logging`.
 ```
 
 **Preconditions before gameplay watchers run:**

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -35,6 +35,7 @@ from .options import (
     AbilityRandomizationMode,
     Goal,
     KirbyAmOptions,
+    OneHitMode,
     RandomizeShards,
 )
 from .rom import KirbyAmProcedurePatch, write_tokens
@@ -168,6 +169,11 @@ class KirbyAmWorld(World):
         option = getattr(getattr(self, "options", None), "no_extra_lives", None)
         value = getattr(option, "value", option)
         return bool(value)
+
+    def _one_hit_mode_value(self) -> int:
+        option = getattr(getattr(self, "options", None), "one_hit_mode", None)
+        value = getattr(option, "value", option)
+        return int(value) if value is not None else 0
 
     def _active_filler_pool(self) -> tuple[str, ...]:
         if not self._no_extra_lives_enabled():
@@ -375,6 +381,24 @@ class KirbyAmWorld(World):
                         code for code in non_filler_item_codes if code not in shard_code_set
                     ]
 
+                if self._one_hit_mode_value() == OneHitMode.option_exclude_vitality_counters:
+                    vitality_code_set = {
+                        item.item_id
+                        for item in kirby_data.items.values()
+                        if "Vitality" in item.tags
+                    }
+                    excluded_vitality_count = sum(
+                        1 for code in non_filler_item_codes if code in vitality_code_set
+                    )
+                    non_filler_item_codes = [
+                        code for code in non_filler_item_codes if code not in vitality_code_set
+                    ]
+                    logger.info(
+                        "[P%s] One-hit mode (exclude_vitality_counters): removed %s vitality counter item(s) from non-filler pool",
+                        self.player,
+                        excluded_vitality_count,
+                    )
+
                 if len(non_filler_item_codes) > needed_pool_size:
                     raise ValueError(
                         "KirbyAM item pool mismatch: non-filler item count %d exceeds open physical locations %d"
@@ -511,6 +535,7 @@ class KirbyAmWorld(World):
             "goal",
             "shards",
             "no_extra_lives",
+            "one_hit_mode",
             "death_link",
             "ability_randomization_mode",
             "ability_randomization_boss_spawns",

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -889,6 +889,8 @@ class KirbyAmClient(BizHawkClient):
             await bizhawk.write(ctx.bizhawk_ctx, writes)
 
             if self._debug_logging_enabled:
+                from CommonClient import logger
+
                 logger.info(
                     "KirbyAM debug: one-hit mode clamped max_hp from %s to %s (vitality_count=%s)",
                     current_max_hp,

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -10,7 +10,7 @@ from worlds._bizhawk.client import BizHawkClient
 
 from .data import LocationCategory, data, load_json_data
 from .kirby_ap_payload.thumb_branch import is_thumb_bl_instruction
-from .options import Goal
+from .options import Goal, OneHitMode
 from .types import KirbyAmBizHawkClientContext
 
 if TYPE_CHECKING:
@@ -38,6 +38,10 @@ _DEMO_PLAYBACK_ACTIVE_FLAG = 0x10
 _DEMO_PLAYBACK_FLAGS_WIDTH = 4
 _KIRBY_HP_ADDR_KEY = "kirby_hp_native"
 _KIRBY_HP_READ_WIDTH = 1
+_KIRBY_MAX_HP_ADDR_KEY = "kirby_max_hp_native"
+_KIRBY_MAX_HP_READ_WIDTH = 1
+_KIRBY_VITALITY_COUNTER_ADDR_KEY = "kirby_vitality_counter_native"
+_KIRBY_VITALITY_COUNTER_READ_WIDTH = 2
 _ROOM_VISIT_FLAGS_ADDR_KEY = "room_visit_flags_native"
 _ROOM_VISIT_FLAGS_ENTRY_COUNT = 0x120
 _ROOM_VISIT_FLAGS_BIT_MASK = 0x8000
@@ -234,6 +238,16 @@ class KirbyAmClient(BizHawkClient):
         if not isinstance(slot_data, dict):
             return False
         return self._coerce_bool(slot_data.get("no_extra_lives", False), False)
+
+    def _one_hit_mode_value(self, ctx: "BizHawkClientContext") -> int:
+        slot_data = getattr(ctx, "slot_data", None)
+        if not isinstance(slot_data, dict):
+            return OneHitMode.option_vanilla
+        value = slot_data.get("one_hit_mode", OneHitMode.option_vanilla)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return OneHitMode.option_vanilla
 
     @staticmethod
     def _item_signature(item: object) -> tuple[int, int, int, int] | None:
@@ -741,6 +755,7 @@ class KirbyAmClient(BizHawkClient):
                 self._last_runtime_gate_reason = None
 
             await self._enforce_no_extra_lives(ctx)
+            await self._enforce_one_hit_mode(ctx)
             await self._apply_pending_death_link(ctx)
             await self._poll_and_send_local_death_link(ctx)
 
@@ -827,6 +842,59 @@ class KirbyAmClient(BizHawkClient):
                 "KirbyAM debug: no-extra-lives clamped native lives from %s to 0",
                 current_lives,
             )
+
+    async def _enforce_one_hit_mode(self, ctx: "BizHawkClientContext") -> None:
+        """Clamp Kirby's max HP (and current HP) to vitality_counter + 1 while one-hit mode is active.
+
+        Both exclude_vitality_counters and include_vitality_counters modes use a 1 HP base.
+        In exclude mode the vitality counter stays at 0 all game, giving a permanent max of 1.
+        In include mode each received Vitality Counter item raises the cap by 1.
+
+        Enforcement targets player 0's Kirby struct (consistent with DeathLink HP tracking).
+        """
+        if self._one_hit_mode_value(ctx) == OneHitMode.option_vanilla:
+            return
+
+        vitality_addr = data.native_ram_addresses.get(_KIRBY_VITALITY_COUNTER_ADDR_KEY)
+        hp_addr = data.native_ram_addresses.get(_KIRBY_HP_ADDR_KEY)
+        max_hp_addr = data.native_ram_addresses.get(_KIRBY_MAX_HP_ADDR_KEY)
+        if vitality_addr is None or hp_addr is None or max_hp_addr is None:
+            return
+
+        results = await bizhawk.read(ctx.bizhawk_ctx, [
+            (vitality_addr, _KIRBY_VITALITY_COUNTER_READ_WIDTH, "System Bus"),
+            (hp_addr, _KIRBY_HP_READ_WIDTH, "System Bus"),
+            (max_hp_addr, _KIRBY_MAX_HP_READ_WIDTH, "System Bus"),
+        ])
+        vitality_raw, hp_raw, max_hp_raw = results
+
+        vitality_count = int.from_bytes(vitality_raw[:2], "little", signed=False)
+        current_hp = self._s8(hp_raw)
+        current_max_hp = self._s8(max_hp_raw)
+
+        # One-hit base is 1; each Vitality Counter adds 1 to the cap.
+        desired_max_hp = min(vitality_count + 1, 0x7F)
+
+        if current_max_hp <= desired_max_hp and current_hp <= desired_max_hp:
+            return
+
+        writes: list[tuple[int, bytes, str]] = []
+        if current_max_hp > desired_max_hp:
+            writes.append((max_hp_addr, bytes([desired_max_hp & 0xFF]), "System Bus"))
+        # Clamp alive HP down to new max; preserve dead/negative states.
+        if current_hp > 0 and current_hp > desired_max_hp:
+            writes.append((hp_addr, bytes([desired_max_hp & 0xFF]), "System Bus"))
+
+        if writes:
+            await bizhawk.write(ctx.bizhawk_ctx, writes)
+
+            if self._debug_logging_enabled:
+                logger.info(
+                    "KirbyAM debug: one-hit mode clamped max_hp from %s to %s (vitality_count=%s)",
+                    current_max_hp,
+                    desired_max_hp,
+                    vitality_count,
+                )
 
     @staticmethod
     def _s8(value: bytes) -> int:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -898,11 +898,12 @@ class KirbyAmClient(BizHawkClient):
                     parts.append(f"max_hp {current_max_hp}->{desired_max_hp}")
                 if clamped_hp:
                     parts.append(f"hp {current_hp}->{desired_max_hp}")
-                logger.info(
-                    "KirbyAM debug: one-hit mode clamped %s (vitality_count=%s)",
-                    ", ".join(parts),
-                    vitality_count,
-                )
+                if parts:
+                    logger.info(
+                        "KirbyAM debug: one-hit mode clamped %s (vitality_count=%s)",
+                        ", ".join(parts),
+                        vitality_count,
+                    )
 
     @staticmethod
     def _s8(value: bytes) -> int:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -891,10 +891,16 @@ class KirbyAmClient(BizHawkClient):
             if self._debug_logging_enabled:
                 from CommonClient import logger
 
+                clamped_max_hp = current_max_hp > desired_max_hp
+                clamped_hp = current_hp > 0 and current_hp > desired_max_hp
+                parts = []
+                if clamped_max_hp:
+                    parts.append(f"max_hp {current_max_hp}->{desired_max_hp}")
+                if clamped_hp:
+                    parts.append(f"hp {current_hp}->{desired_max_hp}")
                 logger.info(
-                    "KirbyAM debug: one-hit mode clamped max_hp from %s to %s (vitality_count=%s)",
-                    current_max_hp,
-                    desired_max_hp,
+                    "KirbyAM debug: one-hit mode clamped %s (vitality_count=%s)",
+                    ", ".join(parts),
                     vitality_count,
                 )
 

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -30,8 +30,7 @@
       "kirby_hp_native": "0x02020FE0",
       "kirby_max_hp_native": "0x02020FE1",
       "kirby_lives_native": "0x02020FE2",
-      "kirby_vitality_counter_native": "0x02038980",
-      "kirby_current_player_native": "0x0203AD3C"
+      "kirby_vitality_counter_native": "0x02038980"
     }
   },
   "rom": {

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -28,7 +28,10 @@
       "ai_kirby_state_native": "0x0203AD2C",
       "demo_playback_flags_native": "0x0203AD10",
       "kirby_hp_native": "0x02020FE0",
-      "kirby_lives_native": "0x02020FE2"
+      "kirby_max_hp_native": "0x02020FE1",
+      "kirby_lives_native": "0x02020FE2",
+      "kirby_vitality_counter_native": "0x02038980",
+      "kirby_current_player_native": "0x0203AD3C"
     }
   },
   "rom": {

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -122,6 +122,23 @@ class NoExtraLives(Toggle):
     default = 0
 
 
+class OneHitMode(Choice):
+    """
+    Controls whether Kirby's maximum health is reduced to 1 HP at the start (one-hit mode).
+
+    - Vanilla: Kirby's maximum health is unmodified (native 6 HP base, plus 1 per Vitality Counter found).
+    - Exclude Vitality Counters: Kirby starts with a maximum of 1 HP. All four Vitality Counter items are
+        removed from the item pool and replaced with filler. Kirby's HP cap stays at 1 for the entire run.
+    - Include Vitality Counters: Kirby starts with a maximum of 1 HP. Vitality Counter items remain in the
+        pool; each one received increases Kirby's HP cap by 1 (up to 5 with all four).
+    """
+    display_name = "One-Hit Mode"
+    default = 0
+    option_vanilla = 0
+    option_exclude_vitality_counters = 1
+    option_include_vitality_counters = 2
+
+
 class RoomSanity(Toggle):
     """Adds room-visit checks (Room X-YY). Disabled by default because it adds 257 locations."""
     display_name = "Room Sanity"
@@ -139,6 +156,8 @@ class KirbyAmOptions(PerGameCommonOptions):
     shards: RandomizeShards
 
     no_extra_lives: NoExtraLives
+
+    one_hit_mode: OneHitMode
 
     ability_randomization_mode: AbilityRandomizationMode
 
@@ -160,6 +179,7 @@ class KirbyAmOptions(PerGameCommonOptions):
 OPTION_GROUPS = [
     OptionGroup("Make the game harder", [
         NoExtraLives,
+        OneHitMode,
         KirbyAmDeathLink,
     ]),
     OptionGroup("Ability Randomization", [

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -10,7 +10,7 @@ from .. import KirbyAmWorld
 from ..data import LocationCategory, data
 from ..items import get_item_classification
 from ..locations import KirbyAmLocation
-from ..options import RandomizeShards
+from ..options import OneHitMode, RandomizeShards
 
 
 class _DummyMultiWorld:
@@ -43,7 +43,10 @@ def _build_fill_locations() -> list[KirbyAmLocation]:
     return locations
 
 
-def _build_world_for_create_items(shard_mode: int) -> tuple[KirbyAmWorld, list[KirbyAmLocation]]:
+def _build_world_for_create_items(
+    shard_mode: int,
+    one_hit_mode: int = OneHitMode.option_vanilla,
+) -> tuple[KirbyAmWorld, list[KirbyAmLocation]]:
     locations = _build_fill_locations()
     world = KirbyAmWorld.__new__(KirbyAmWorld)
     world.player = 1
@@ -55,6 +58,7 @@ def _build_world_for_create_items(shard_mode: int) -> tuple[KirbyAmWorld, list[K
             RandomizeShards.option_completely_random: "completely_random",
         }[shard_mode]),
         no_extra_lives=SimpleNamespace(value=False),
+        one_hit_mode=SimpleNamespace(value=one_hit_mode),
     )
     return world, locations
 
@@ -383,3 +387,103 @@ def test_create_items_fails_when_non_filler_count_exceeds_open_locations() -> No
 
     with pytest.raises(ValueError, match="non-filler item count"):
         world.create_items()
+
+
+# ── One-Hit Mode item pool tests ────────────────────────────────────────────
+
+
+def _vitality_item_codes() -> set[int]:
+    return {item.item_id for item in data.items.values() if "Vitality" in item.tags}
+
+
+def test_one_hit_mode_vanilla_includes_all_vitality_items() -> None:
+    world, _locations = _build_world_for_create_items(
+        RandomizeShards.option_completely_random,
+        one_hit_mode=OneHitMode.option_vanilla,
+    )
+    world.create_items()
+
+    vitality_codes = _vitality_item_codes()
+    pool_codes = {item.code for item in world.multiworld.itempool if item.code is not None}
+    assert vitality_codes.issubset(pool_codes), (
+        "Vanilla one-hit mode should not remove vitality counter items from the pool"
+    )
+
+
+def test_one_hit_mode_include_vitality_counters_includes_all_vitality_items() -> None:
+    world, _locations = _build_world_for_create_items(
+        RandomizeShards.option_completely_random,
+        one_hit_mode=OneHitMode.option_include_vitality_counters,
+    )
+    world.create_items()
+
+    vitality_codes = _vitality_item_codes()
+    pool_codes = {item.code for item in world.multiworld.itempool if item.code is not None}
+    assert vitality_codes.issubset(pool_codes), (
+        "include_vitality_counters mode should keep all vitality counter items in the pool"
+    )
+
+
+def test_one_hit_mode_exclude_vitality_counters_removes_vitality_items() -> None:
+    world, _locations = _build_world_for_create_items(
+        RandomizeShards.option_completely_random,
+        one_hit_mode=OneHitMode.option_exclude_vitality_counters,
+    )
+    world.create_items()
+
+    vitality_codes = _vitality_item_codes()
+    pool_codes = {item.code for item in world.multiworld.itempool if item.code is not None}
+    assert vitality_codes.isdisjoint(pool_codes), (
+        "exclude_vitality_counters mode should have no vitality counter items in the pool"
+    )
+
+
+def test_one_hit_mode_exclude_vitality_counters_pool_size_unchanged() -> None:
+    """Total pool size should not change; filler fills the slots vacated by vitality items."""
+    world_vanilla, _locs_v = _build_world_for_create_items(
+        RandomizeShards.option_completely_random,
+        one_hit_mode=OneHitMode.option_vanilla,
+    )
+    world_vanilla.create_items()
+
+    world_exclude, _locs_e = _build_world_for_create_items(
+        RandomizeShards.option_completely_random,
+        one_hit_mode=OneHitMode.option_exclude_vitality_counters,
+    )
+    world_exclude.create_items()
+
+    assert len(world_exclude.multiworld.itempool) == len(world_vanilla.multiworld.itempool), (
+        "Pool size should be the same in exclude_vitality_counters mode as in vanilla"
+    )
+
+
+def test_one_hit_mode_exclude_vitality_counters_vitality_chest_locations_exist() -> None:
+    """Vitality Chest locations remain in the pool; pool has enough items to fill them (with filler)."""
+    world, locations = _build_world_for_create_items(
+        RandomizeShards.option_completely_random,
+        one_hit_mode=OneHitMode.option_exclude_vitality_counters,
+    )
+    world.create_items()
+
+    vitality_locs = [
+        loc for loc in locations
+        if data.locations[loc.key].category == LocationCategory.VITALITY_CHEST
+    ]
+    assert len(vitality_locs) == 4, "Expected 4 vitality chest locations"
+
+    # All vitality chest locations are open (no locked item); the pool covers them with filler.
+    for loc in vitality_locs:
+        assert loc.item is None, (
+            f"Vitality chest location {loc.name} should be open (no locked item) in exclude mode"
+        )
+
+    # The pool size equals the number of open locations, confirming filler fills the vitality slots.
+    open_count = sum(
+        1 for loc in locations
+        if data.locations.get(loc.key) is not None
+        and data.locations[loc.key].category != LocationCategory.GOAL
+        and loc.item is None
+    )
+    assert len(world.multiworld.itempool) == open_count, (
+        "Pool size should equal the number of open non-goal locations"
+    )

--- a/worlds/kirbyam/test/test_slot_data_contract.py
+++ b/worlds/kirbyam/test/test_slot_data_contract.py
@@ -39,6 +39,7 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
         "goal": 0,
         "shards": 2,
         "no_extra_lives": False,
+        "one_hit_mode": 0,
         "death_link": True,
         "ability_randomization_mode": 1,
         "ability_randomization_boss_spawns": True,


### PR DESCRIPTION
## What is this fixing or adding?

Adds `One-Hit Mode` (`one_hit_mode`) to the **Make the game harder** option group. This is a new `Choice` option with three values:

- **`vanilla` (0)** — Default. No change to Kirby's health.
- **`exclude_vitality_counters` (1)** — Kirby starts with max 1 HP. All four Vitality Counter items are removed from the non-filler item pool and replaced with filler. Vitality Chest locations remain but are not guaranteed to receive filler specifically at those locations. HP cap stays at 1 for the whole run.
- **`include_vitality_counters` (2)** — Kirby starts with max 1 HP. Vitality Counter items remain in the pool. Each one received raises the HP cap by 1 (`vitality_counter + 1`, up to 5 with all four).

### World generation
- `options.py`: Add `OneHitMode` Choice with `vanilla`, `exclude_vitality_counters`, `include_vitality_counters`. Added to `OPTION_GROUPS["Make the game harder"]`.
- `__init__.py`: Add `_one_hit_mode_value()` helper, exclude vitality items from non-filler pool in `exclude_vitality_counters` mode, emit `one_hit_mode` in `fill_slot_data()`.

### BizHawk client runtime enforcement
- `client.py`: New `_enforce_one_hit_mode()` async method reads `kirby_vitality_counter_native` (u16 at `0x02038980`) and enforces `desired_max_hp = vitality_counter + 1` onto `kirby_max_hp_native` (`0x02020FE1`) and `kirby_hp_native` (`0x02020FE0`) for player 0. Called each gameplay tick alongside `_enforce_no_extra_lives()`. Dead/negative HP states are preserved. Debug logging uses an inline `from CommonClient import logger` import and reports exactly which fields (`max_hp`, `hp`, or both) were clamped with before→after values (e.g. `"one-hit mode clamped max_hp 6->1, hp 3->1 (vitality_count=0)"`).

### Data / addresses
- `data/addresses.json`: Add `kirby_max_hp_native` (`0x02020FE1`) and `kirby_vitality_counter_native` (`0x02038980`) to native block.

### Documentation
- `PROTOCOL.md`: Document `one_hit_mode` slot_data key, native address entries, and runtime behavior contract (accurately reflecting that `exclude_vitality_counters` mode removes items from the pool but does not guarantee filler at specific vitality chest locations).
- `CHANGELOG.md`: Unreleased entry.

### Tests
- `test_item_pool.py`: Five new one-hit mode tests covering vanilla/include/exclude vitality item pool behavior and pool-size invariant.
- `test_slot_data_contract.py`: Add `one_hit_mode` to mock slot data so contract test stays in sync.

## How was this tested?

- 315 tests pass (excluding pre-existing `test_hosting_integration.py` failure and ROM-patching tests requiring the ROM file).
- Client enforcement is client-only (no C payload changes needed); the C payload's `ap_sync_active_kirby_health_from_vitality()` fires only on item delivery and will be briefly overwritten on the next tick in `include_vitality_counters` mode when a vitality counter is received. The transient effect is imperceptible.
- CI passes on the latest commit.

## If this makes graphical changes, please attach screenshots.

N/A