### PR TITLE
Gate ROM delivery counter diagnostics behind debug logging

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Gate ROM delivery-counter reconciliation diagnostics behind `Enable Debug Logging` (`enable_debug_logging`) so non-debug sessions only show normal sent/received item notifications; counter-ahead/back-in-range/rewind/fallback progress messages are now suppressed unless debug logging is enabled (Issue #574).
+
 ## v0.1.1
 
 - Harden `One-Hit Mode` (`one_hit_mode`) `exclude_vitality_counters` behavior by removing health-restoring filler (`Small Food`, `Max Tomato`) from filler selection in that mode; when combined with `No Extra Lives`, `1 Up` is also excluded from the already-reduced filler pool.

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1755,8 +1755,8 @@ class KirbyAmClient(BizHawkClient):
         # or forward (reconnect after stale client state).
         if rom_received_count is not None:
             if rom_received_count > len(ctx.items_received):
-                if not self._delivery_counter_ahead_fallback_active:
-                    logger.warning(
+                if self._debug_logging_enabled and not self._delivery_counter_ahead_fallback_active:
+                    logger.info(
                         "KirbyAM: ROM delivery counter is ahead of received items (rom=%s, received=%s); "
                         "ignoring ROM counter and continuing mailbox delivery",
                         rom_received_count,
@@ -1764,7 +1764,7 @@ class KirbyAmClient(BizHawkClient):
                     )
                 self._delivery_counter_ahead_fallback_active = True
             else:
-                if self._delivery_counter_ahead_fallback_active:
+                if self._debug_logging_enabled and self._delivery_counter_ahead_fallback_active:
                     logger.info(
                         "KirbyAM: ROM delivery counter is back in range (rom=%s, received=%s); "
                         "restoring normal mailbox synchronization",
@@ -1775,11 +1775,12 @@ class KirbyAmClient(BizHawkClient):
                 self._delivery_counter_ahead_resume_logged = False
 
             if rom_received_count < self._delivered_item_index:
-                logger.info(
-                    "KirbyAM: ROM delivery counter moved backward from %s to %s; rewinding client delivery cursor",
-                    self._delivered_item_index,
-                    rom_received_count,
-                )
+                if self._debug_logging_enabled:
+                    logger.info(
+                        "KirbyAM: ROM delivery counter moved backward from %s to %s; rewinding client delivery cursor",
+                        self._delivered_item_index,
+                        rom_received_count,
+                    )
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
@@ -1952,13 +1953,14 @@ class KirbyAmClient(BizHawkClient):
             item_id, player_id = item_fields
 
             if self._delivery_counter_ahead_fallback_active and not self._delivery_counter_ahead_resume_logged:
-                logger.info(
-                    "KirbyAM: ROM counter fallback active; continuing mailbox delivery at item index %s "
-                    "(rom=%s, received=%s)",
-                    self._delivered_item_index,
-                    rom_received_count,
-                    len(ctx.items_received),
-                )
+                if self._debug_logging_enabled:
+                    logger.info(
+                        "KirbyAM: ROM counter fallback active; continuing mailbox delivery at item index %s "
+                        "(rom=%s, received=%s)",
+                        self._delivered_item_index,
+                        rom_received_count,
+                        len(ctx.items_received),
+                    )
                 self._delivery_counter_ahead_resume_logged = True
 
             if self._debug_logging_enabled:

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -517,6 +517,7 @@ async def test_deliver_items_continues_when_rom_counter_ahead_of_received_items(
     """A stale/high ROM counter should not permanently suppress mailbox writes."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
     client._delivered_item_index = 0
     client._delivery_pending = False
 
@@ -556,6 +557,7 @@ async def test_deliver_items_logs_when_rom_counter_returns_in_range(mock_bizhawk
     """Ahead-counter fallback should clear once ROM and server state are plausibly aligned again."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
     client._delivered_item_index = 0
     client._delivery_counter_ahead_fallback_active = True
     client._delivery_counter_ahead_resume_logged = True
@@ -574,6 +576,38 @@ async def test_deliver_items_logs_when_rom_counter_returns_in_range(mock_bizhawk
     assert client._delivery_counter_ahead_fallback_active is False
     assert client._delivery_counter_ahead_resume_logged is False
     assert "ROM delivery counter is back in range" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_deliver_items_rom_counter_logs_suppressed_when_debug_disabled(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._delivered_item_index = 0
+    client._delivery_pending = False
+
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860001, player=1),
+    ]
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock), \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (2).to_bytes(4, 'little'),
+            (333).to_bytes(4, 'little'),
+        ]
+
+        await client._deliver_items(mock_bizhawk_context)
+
+    assert not any(
+        call.args and isinstance(call.args[0], str) and "ROM delivery counter" in call.args[0]
+        for call in mock_logger.info.call_args_list
+    )
+    assert not any(
+        call.args and isinstance(call.args[0], str) and "ROM counter fallback active" in call.args[0]
+        for call in mock_logger.info.call_args_list
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- gate ROM delivery-counter reconciliation diagnostics behind nable_debug_logging
- keep normal sent/received mailbox notifications unchanged for non-debug sessions
- add regression coverage proving ROM counter/fallback logs are suppressed when debug is disabled

## Validation
- python -m pytest worlds/kirbyam/test/test_client.py -k "deliver_items and rom_counter"

Closes #574