### PR TITLE
Add option to keep Minny vanilla in enemy ability randomization

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `Ability Randomization: Minny` (`ability_randomization_minny`) so Minny can be excluded from enemy copy-ability randomization and kept at vanilla behavior while other enemy ability sources remain randomized (Issue #572).
+
 ## v0.1.1
 
 - Harden `One-Hit Mode` (`one_hit_mode`) `exclude_vitality_counters` behavior by removing health-restoring filler (`Small Food`, `Max Tomato`) from filler selection in that mode; when combined with `No Extra Lives`, `1 Up` is also excluded from the already-reduced filler pool.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -150,6 +150,7 @@ Server → Client: ConnectionRefused | Connected
 - `ability_randomization_mode` (int): enemy copy-ability mode (`0=off`, `1=shuffled`, `2=completely_random`).
 - `ability_randomization_boss_spawns` (bool): include/exclude ability-granting boss-spawned objects.
 - `ability_randomization_minibosses` (bool): include/exclude mini-boss ability grants.
+- `ability_randomization_minny` (bool): include/exclude Minny from enemy copy-ability randomization.
 - `ability_randomization_passive_enemies` (bool): when true, enemies that natively grant no ability participate in copy-ability randomization. Default: `true`.
 - `ability_randomization_no_ability_weight` (int): percentage chance from `0` to `100` that an included randomized enemy grant resolves to no ability instead of a copy ability. Default: `55`.
 - `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 257 checks).
@@ -160,7 +161,7 @@ Server → Client: ConnectionRefused | Connected
 
 Compatibility note (Issue #398 option-key reorganization):
 - Legacy keys `enemy_copy_ability_randomization`, `randomize_boss_spawned_ability_grants`, and `randomize_miniboss_ability_grants` are intentionally not emitted in `slot_data` during the pre-public (`< v0.1.0`) phase.
-- Canonical keys are `ability_randomization_mode`, `ability_randomization_boss_spawns`, `ability_randomization_minibosses`, `ability_randomization_passive_enemies`, and `ability_randomization_no_ability_weight`.
+- Canonical keys are `ability_randomization_mode`, `ability_randomization_boss_spawns`, `ability_randomization_minibosses`, `ability_randomization_minny`, `ability_randomization_passive_enemies`, and `ability_randomization_no_ability_weight`.
 - If compatibility aliases are needed after public release, this section will be updated with an explicit deprecation/removal timeline.
 
 DeathLink runtime behavior contract:

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -214,6 +214,7 @@ class KirbyAmWorld(World):
             mode = int(self.options.ability_randomization_mode.value)
             randomize_boss_spawned = bool(self.options.ability_randomization_boss_spawns.value)
             randomize_miniboss = bool(self.options.ability_randomization_minibosses.value)
+            randomize_minny = bool(self.options.ability_randomization_minny.value)
             randomize_non_ability = bool(self.options.ability_randomization_passive_enemies.value)
             no_ability_weight = int(self.options.ability_randomization_no_ability_weight.value)
             self._enemy_copy_ability_policy = build_enemy_copy_ability_policy(
@@ -221,31 +222,35 @@ class KirbyAmWorld(World):
                 mode,
                 randomize_boss_spawned,
                 randomize_miniboss,
+                include_minny=randomize_minny,
                 include_passive_enemies=randomize_non_ability,
                 no_ability_weight=no_ability_weight,
             )
             if mode == AbilityRandomizationMode.option_off:
                 logger.info(
-                    "[P%s] Enemy copy-ability randomization: off (%s whitelist entries, no_ability_weight=%s)",
+                    "[P%s] Enemy copy-ability randomization: off (%s whitelist entries, minny=%s, no_ability_weight=%s)",
                     self.player,
                     len(VALID_ENEMY_COPY_ABILITIES),
+                    randomize_minny,
                     no_ability_weight,
                 )
             elif mode == AbilityRandomizationMode.option_shuffled:
                 logger.info(
                     "[P%s] Enemy copy-ability randomization: shuffled "
-                    "(%s whitelist entries, passive_enemies=%s, no_ability_weight=%s)",
+                    "(%s whitelist entries, minny=%s, passive_enemies=%s, no_ability_weight=%s)",
                     self.player,
                     len(VALID_ENEMY_COPY_ABILITIES),
+                    randomize_minny,
                     randomize_non_ability,
                     no_ability_weight,
                 )
             else:
                 logger.info(
                     "[P%s] Enemy copy-ability randomization: completely_random "
-                    "(%s whitelist entries, passive_enemies=%s, no_ability_weight=%s)",
+                    "(%s whitelist entries, minny=%s, passive_enemies=%s, no_ability_weight=%s)",
                     self.player,
                     len(VALID_ENEMY_COPY_ABILITIES),
+                    randomize_minny,
                     randomize_non_ability,
                     no_ability_weight,
                 )
@@ -545,6 +550,7 @@ class KirbyAmWorld(World):
             "ability_randomization_mode",
             "ability_randomization_boss_spawns",
             "ability_randomization_minibosses",
+            "ability_randomization_minny",
             "ability_randomization_passive_enemies",
             "ability_randomization_no_ability_weight",
             "room_sanity",

--- a/worlds/kirbyam/ability_randomization.py
+++ b/worlds/kirbyam/ability_randomization.py
@@ -46,6 +46,7 @@ def build_enemy_copy_ability_policy(
     mode: int,
     include_boss_spawns: bool,
     include_minibosses: bool,
+    include_minny: bool = True,
     whitelist: Iterable[str] = VALID_ENEMY_COPY_ABILITIES,
     include_passive_enemies: bool = False,
     no_ability_weight: int = 0,
@@ -64,6 +65,7 @@ def build_enemy_copy_ability_policy(
         "allowed_abilities": ordered,
         "ability_randomization_boss_spawns": bool(include_boss_spawns),
         "ability_randomization_minibosses": bool(include_minibosses),
+        "ability_randomization_minny": bool(include_minny),
         "ability_randomization_passive_enemies": bool(include_passive_enemies),
         "ability_randomization_no_ability_weight": normalized_no_ability_weight,
     }

--- a/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
+++ b/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
@@ -18,6 +18,7 @@
 - Progression & useful items which the player would normally acquire throughout the game have been moved around. (Mirror Shards, Maps, Vitality, Sound Player)
 - Normal copy ability enemies can be randomized to give a different copy ability.
 - Enemies which typically do not give abilities can be randomized to give abilities.
+- Minny can be kept vanilla with the `ability_randomization_minny` toggle while still randomizing other enemy ability sources.
 - The chance for an enemy to not have a copy ability can be controlled via the `ability_randomization_no_ability_weight`
 
 

--- a/worlds/kirbyam/enemy_ability_runtime_patch.py
+++ b/worlds/kirbyam/enemy_ability_runtime_patch.py
@@ -46,6 +46,8 @@ def _ability_name_to_id(name: str) -> int:
 
 
 def _is_source_enabled(source: AbilitySource, policy: dict[str, Any]) -> bool:
+    if source.key == "MINNY" and not bool(policy.get("ability_randomization_minny", True)):
+        return False
     if source.kind == "miniboss" and not bool(policy.get("ability_randomization_minibosses", True)):
         return False
     if source.kind == "boss_spawned" and not bool(policy.get("ability_randomization_boss_spawns", True)):

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -83,6 +83,16 @@ class AbilityRandomizationMinibosses(Toggle):
     default = 1
 
 
+class AbilityRandomizationMinny(Toggle):
+        """
+        Include Minny in enemy copy-ability randomization.
+            Only applies when Ability Randomization Mode is not Off.
+            On by Default, but ability_randomization_mode is Off by Default.
+        """
+        display_name = "Ability Randomization: Minny"
+        default = 1
+
+
 class AbilityRandomizationPassiveEnemies(Toggle):
     """
     When enabled, enemies that normally do not grant a copy ability can receive a
@@ -190,6 +200,8 @@ class KirbyAmOptions(PerGameCommonOptions):
 
     ability_randomization_minibosses: AbilityRandomizationMinibosses
 
+    ability_randomization_minny: AbilityRandomizationMinny
+
     ability_randomization_passive_enemies: AbilityRandomizationPassiveEnemies
 
     ability_randomization_no_ability_weight: AbilityRandomizationNoAbilityWeight
@@ -214,6 +226,7 @@ OPTION_GROUPS = [
         AbilityRandomizationMode,
         AbilityRandomizationBossSpawns,
         AbilityRandomizationMinibosses,
+        AbilityRandomizationMinny,
         AbilityRandomizationPassiveEnemies,
         AbilityRandomizationNoAbilityWeight,
     ]),

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -84,13 +84,13 @@ class AbilityRandomizationMinibosses(Toggle):
 
 
 class AbilityRandomizationMinny(Toggle):
-        """
-        Include Minny in enemy copy-ability randomization.
-            Only applies when Ability Randomization Mode is not Off.
-            On by Default, but ability_randomization_mode is Off by Default.
-        """
-        display_name = "Ability Randomization: Minny"
-        default = 1
+    """
+    Include Minny in enemy copy-ability randomization.
+      Only applies when Ability Randomization Mode is not Off.
+      On by Default, but ability_randomization_mode is Off by Default.
+    """
+    display_name = "Ability Randomization: Minny"
+    default = 1
 
 
 class AbilityRandomizationPassiveEnemies(Toggle):

--- a/worlds/kirbyam/test/data/snapshots/enemy_mapping_seed_20260322.json
+++ b/worlds/kirbyam/test/data/snapshots/enemy_mapping_seed_20260322.json
@@ -29,6 +29,7 @@
   "random_policy": {
     "ability_randomization_boss_spawns": true,
     "ability_randomization_minibosses": true,
+    "ability_randomization_minny": true,
     "ability_randomization_no_ability_weight": 55,
     "ability_randomization_passive_enemies": false,
     "allowed_abilities": [
@@ -72,6 +73,7 @@
   "shuffled_policy": {
     "ability_randomization_boss_spawns": false,
     "ability_randomization_minibosses": false,
+    "ability_randomization_minny": true,
     "ability_randomization_no_ability_weight": 55,
     "ability_randomization_passive_enemies": false,
     "allowed_abilities": [

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -1,6 +1,7 @@
 {
   "ability_randomization_boss_spawns": true,
   "ability_randomization_minibosses": false,
+  "ability_randomization_minny": false,
   "ability_randomization_mode": 1,
   "ability_randomization_no_ability_weight": 55,
   "ability_randomization_passive_enemies": false,
@@ -11,6 +12,7 @@
   "enemy_copy_ability_policy": {
     "ability_randomization_boss_spawns": true,
     "ability_randomization_minibosses": false,
+    "ability_randomization_minny": false,
     "ability_randomization_no_ability_weight": 55,
     "ability_randomization_passive_enemies": false,
     "allowed_abilities": [

--- a/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_randomization.py
@@ -32,6 +32,7 @@ def test_off_mode_returns_identity_mapping_policy() -> None:
     assert policy_is_whitelist_preserving(policy, VALID_ENEMY_COPY_ABILITIES)
     assert policy["ability_randomization_boss_spawns"] is True
     assert policy["ability_randomization_minibosses"] is True
+    assert policy["ability_randomization_minny"] is True
     assert policy["ability_randomization_no_ability_weight"] == 55
 
 
@@ -51,6 +52,7 @@ def test_shuffled_mode_maps_enemy_type_consistently() -> None:
     assert other in VALID_ENEMY_COPY_ABILITIES
     assert policy["ability_randomization_boss_spawns"] is False
     assert policy["ability_randomization_minibosses"] is False
+    assert policy["ability_randomization_minny"] is True
 
 
 def test_completely_random_mode_varies_by_event() -> None:
@@ -153,6 +155,7 @@ def test_non_ability_enemies_flag_defaults_to_false_in_policy() -> None:
         include_minibosses=True,
     )
     assert policy["ability_randomization_passive_enemies"] is False
+    assert policy["ability_randomization_minny"] is True
     assert policy["ability_randomization_no_ability_weight"] == 0
 
 
@@ -166,6 +169,7 @@ def test_non_ability_enemies_flag_true_stored_in_policy() -> None:
         no_ability_weight=55,
     )
     assert policy["ability_randomization_passive_enemies"] is True
+    assert policy["ability_randomization_minny"] is True
     assert policy["ability_randomization_no_ability_weight"] == 55
 
 
@@ -179,7 +183,20 @@ def test_off_mode_stores_non_ability_flag_in_policy() -> None:
         no_ability_weight=55,
     )
     assert policy["ability_randomization_passive_enemies"] is True
+    assert policy["ability_randomization_minny"] is True
     assert policy["ability_randomization_no_ability_weight"] == 55
+
+
+def test_minny_flag_false_stored_in_policy() -> None:
+    policy = build_enemy_copy_ability_policy(
+        random.Random(1),
+        AbilityRandomizationMode.option_shuffled,
+        include_boss_spawns=True,
+        include_minibosses=True,
+        include_minny=False,
+        no_ability_weight=55,
+    )
+    assert policy["ability_randomization_minny"] is False
 
 
 def test_shuffled_mode_with_zero_no_ability_weight_never_returns_normal() -> None:

--- a/worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py
@@ -212,6 +212,25 @@ def test_non_ability_option_on_with_miniboss_toggle_on_includes_mini_waddle_dee(
     assert writes[0x351B76] != 0
 
 
+def test_minny_toggle_excludes_minny_runtime_writes_only() -> None:
+    policy = build_enemy_copy_ability_policy(
+        random.Random(123),
+        AbilityRandomizationMode.option_shuffled,
+        include_boss_spawns=True,
+        include_minibosses=True,
+        include_minny=False,
+        include_passive_enemies=False,
+        no_ability_weight=0,
+    )
+
+    writes = build_enemy_copy_runtime_patch_writes(policy)
+
+    # MINNY default ability source address.
+    assert 0x3519F6 not in writes
+    # A different normal enemy source should still be patched.
+    assert 0x3518BE in writes
+
+
 def test_completely_random_mapping_is_stable_when_skipped_zero_id_sources_are_added(monkeypatch) -> None:
     baseline_policy = build_enemy_copy_ability_policy(
         random.Random(20260324),

--- a/worlds/kirbyam/test/test_slot_data_contract.py
+++ b/worlds/kirbyam/test/test_slot_data_contract.py
@@ -44,6 +44,7 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
         "ability_randomization_mode": 1,
         "ability_randomization_boss_spawns": True,
         "ability_randomization_minibosses": False,
+        "ability_randomization_minny": False,
         "ability_randomization_passive_enemies": False,
         "ability_randomization_no_ability_weight": 55,
         "room_sanity": False,
@@ -56,6 +57,7 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
         "identity_map": {"Sword": "Beam", "Beam": "Burning", "Burning": "Sword"},
         "ability_randomization_boss_spawns": True,
         "ability_randomization_minibosses": False,
+        "ability_randomization_minny": False,
         "ability_randomization_passive_enemies": False,
         "ability_randomization_no_ability_weight": 55,
     }

--- a/worlds/kirbyam/test/test_snapshot_outputs.py
+++ b/worlds/kirbyam/test/test_snapshot_outputs.py
@@ -54,6 +54,7 @@ def _build_representative_slot_data() -> dict[str, object]:
         "ability_randomization_mode": 1,
         "ability_randomization_boss_spawns": True,
         "ability_randomization_minibosses": False,
+        "ability_randomization_minny": False,
         "ability_randomization_passive_enemies": False,
         "ability_randomization_no_ability_weight": 55,
         "room_sanity": False,
@@ -65,6 +66,7 @@ def _build_representative_slot_data() -> dict[str, object]:
         AbilityRandomizationMode.option_shuffled,
         include_boss_spawns=True,
         include_minibosses=False,
+        include_minny=False,
         no_ability_weight=55,
     )
     return KirbyAmWorld.fill_slot_data(world)


### PR DESCRIPTION
## Summary\n- add a new KirbyAM world option bility_randomization_minny (default on) to control whether Minny participates in enemy ability randomization\n- thread the new option through generation slot data and deterministic enemy randomization policy\n- skip runtime patch writes for Minny when the option is disabled so Minny keeps vanilla behavior\n- add regression coverage for policy/runtime behavior and update slot-data snapshots/contracts/docs/changelog\n\n## Testing\n- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_enemy_copy_ability_randomization.py worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py worlds/kirbyam/test/test_slot_data_contract.py worlds/kirbyam/test/test_snapshot_outputs.py\n\nCloses #572