### PR TITLE
KirbyAM: fix boss-defeat checks when shard already owned

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `Start With All Maps` (`start_with_all_maps`) option to the `Make the game easier` option group. When enabled, all nine area maps are precollected at generation time and removed from the randomized item pool (replaced with filler), so the player begins with every map already acquired (Issue #584).
+- Fix missing boss-defeat LocationChecks when the matching shard is already owned by adding a conservative client fallback: rising-edge bits from `boss_mirror_table_native` byte 0 (bits 0-7) now backfill boss checks when `boss_defeat_flags` is absent for that fight (Issue #573).
 
 ## v0.1.2
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1624,6 +1624,7 @@ class KirbyAmClient(BizHawkClient):
         elif stream_marker is not self._boss_probe_stream_marker:
             self._boss_probe_stream_marker = stream_marker
             self._last_boss_probe_snapshot = None
+            self._boss_probe_fallback_bits.clear()
 
         raw = (await bizhawk.read(
             ctx.bizhawk_ctx,

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -149,6 +149,7 @@ class KirbyAmClient(BizHawkClient):
         # Boss candidate probing state
         self._last_boss_probe_snapshot: bytes | None = None
         self._boss_probe_stream_marker: object = None
+        self._boss_probe_fallback_bits: set[int] = set()
 
         # Runtime gameplay-state gate tracking
         self._last_runtime_gate_reason: str | None = None
@@ -220,6 +221,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_room_sanity_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
+        self._boss_probe_fallback_bits.clear()
         self._unsafe_delivery_probe_stream_marker = None
         self._last_unsafe_delivery_counter_values = {}
         self._incoming_death_link_pending = False
@@ -1337,6 +1339,12 @@ class KirbyAmClient(BizHawkClient):
             if (boss_bits >> bit) & 1:
                 mapped_checked_locations.update(self._boss_location_ids_by_bit.get(bit, []))
 
+        # Fallback source for Issue #573: if boss_defeat_flags does not rise because
+        # native CollectShard() was skipped (already-owned shard), use rising-edge
+        # observations from boss_mirror_table_native collected by probe polling.
+        for bit in sorted(self._boss_probe_fallback_bits):
+            mapped_checked_locations.update(self._boss_location_ids_by_bit.get(bit, []))
+
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
@@ -1646,6 +1654,25 @@ class KirbyAmClient(BizHawkClient):
                 "KirbyAM: boss candidate probe rising bits: %s",
                 ", ".join(rising_edges),
             )
+
+        # Conservative fallback mapping: only byte 0 bits 0-7 are considered,
+        # and only when observed as rising edges. This preserves probe behavior
+        # while providing a low-risk backup for boss check signaling.
+        supported_bits = set(self._boss_location_ids_by_bit.keys())
+        if not supported_bits:
+            return
+
+        prev_byte0 = old[0] if old else 0
+        new_byte0 = raw[0] if raw else 0
+        rising_mask = (~prev_byte0 & 0xFF) & new_byte0
+        if rising_mask == 0:
+            return
+
+        for bit in supported_bits:
+            if bit < 0 or bit > 7:
+                continue
+            if (rising_mask >> bit) & 1:
+                self._boss_probe_fallback_bits.add(bit)
 
     async def _probe_unsafe_delivery_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -3111,6 +3111,41 @@ async def test_poll_boss_defeat_skips_already_server_acknowledged(mock_bizhawk_c
 
 
 @pytest.mark.asyncio
+async def test_poll_boss_defeat_uses_probe_fallback_when_transport_bit_missing(mock_bizhawk_context):
+    """Issue #573: probe-observed native boss bit should backfill missing transport signal."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(
+        data.transport_ram_addresses,
+        {"boss_defeat_flags": 0x0203B024},
+        clear=False,
+    ), patch.dict(
+        data.native_ram_addresses,
+        {"boss_mirror_table_native": 0x02028C14},
+        clear=False,
+    ), patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        # Probe baseline then rising edge for bit 0 (boss 1), then poll transport=0.
+        mock_read.side_effect = [
+            [bytes(32)],
+            [bytes([0x01]) + bytes(31)],
+            [(0x00).to_bytes(4, 'little')],
+        ]
+
+        await client._probe_boss_defeat_candidates(mock_bizhawk_context)
+        await client._probe_boss_defeat_candidates(mock_bizhawk_context)
+        await client._poll_boss_defeat_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [boss1_loc]}
+    ])
+
+
+@pytest.mark.asyncio
 async def test_poll_boss_defeat_skips_when_address_missing(mock_bizhawk_context):
     """When boss_defeat_flags address is not in addresses.json the method should no-op."""
     client = KirbyAmClient()


### PR DESCRIPTION
## What is this fixing or adding?

Fixes issue #573 where defeating an area boss could fail to send the boss-defeat LocationCheck if the corresponding mirror shard was already owned.

This PR adds a conservative client fallback:
- keeps existing transport polling via `boss_defeat_flags`
- also records rising-edge observations from `boss_mirror_table_native` byte 0 bits 0-7
- backfills boss-defeat check mapping from those observed bits when transport signaling is missing
- clears `_boss_probe_fallback_bits` alongside `_last_boss_probe_snapshot` on stream rebaseline, preventing stale fallback bits from a previous stream/session from being used after BizHawk reconnects

Also includes:
- regression test coverage for the fallback behavior
- changelog update under Unreleased
- merge-conflict resolution with latest `main`

## How was this tested?

- `python3 -m pytest -q worlds/kirbyam/test/test_client.py -k "boss_defeat or probe_boss_candidates or slot_data"`
- Result: 13 passed, 111 deselected

## If this makes graphical changes, please attach screenshots.

No graphical changes.

Closes #573 