### PR TITLE
KirbyAM: add decomp-backed hub switch checks

### DIFF
--- a/.github/workflows/kirbyam-rom-patch-smoke.yml
+++ b/.github/workflows/kirbyam-rom-patch-smoke.yml
@@ -48,7 +48,7 @@ jobs:
           rom_path.parent.mkdir(parents=True, exist_ok=True)
           rom = bytearray(0x200000)
           thumb_bl = bytes.fromhex("00 f0 00 f8")
-          for offset in (0x001D952, 0x0000B144, 0x0000B0CC, 0x0000B264):
+          for offset in (0x001D952, 0x0000B144, 0x0000B0CC, 0x0000B264, 0x00039EEE):
             rom[offset:offset + 4] = thumb_bl
           rom_path.write_bytes(rom)
           PY

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add 15 decomp-aligned world-map big-switch AP checks (`HUB_SWITCH_*`) with a dedicated ROM transport register (`hub_switch_flags` at `0x0203B04C`), BizHawk resend/dedupe polling, payload hook integration at the world-map unlock dispatcher callsite (`sub_08039ED4`), protocol/address contract updates, and regression coverage for data/polling/patch offsets/region binding (Issue #481).
 - Expand tracker integration surface by exporting all locations, all rooms (including those outside Room Sanity), and all received unique items via expanded KirbyAM `slot_data` for use in tracker templates and generic player/multiworld trackers (Issue #114).
 - Expose all configured KirbyAM seed options in `slot_data` (including `start_with_all_maps` and `enable_debug_logging`) so tracker surfaces can render the exact seed configuration from slot data without inferring from partial fields (Issue #114).
 - Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -32,11 +32,11 @@ EWRAM Layout (0x02000000 - 0x02040000):
   
     0x02000000 - 0x02040000   EWRAM Region (256 KB)
         ├─ 0x02000000 - 0x0202BFFF   Native game state
-        ├─ 0x0203B000 - 0x0203B04B   AP Mailbox (reserved, 76 bytes)
+        ├─ 0x0203B000 - 0x0203B04F   AP Mailbox (reserved, 80 bytes)
         └─ Remaining EWRAM (excluding AP mailbox block)
 ```
 
-### AP Mailbox Block (0x0203B000 - 0x0203B04B)
+### AP Mailbox Block (0x0203B000 - 0x0203B04F)
 
 **Transport Layer: Client ↔ ROM Communication**
 
@@ -62,8 +62,9 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x40   | 0x0203B040 | 4B | mailbox_init_cookie | u32 | ROM internal | Initialization cookie (`0x4B41504D`). If absent/mismatched, payload seeds `delivered_shard_bitfield` from native shard state, clears scrub delay + boss-defeat flags + boss temp shard mask, and stores the cookie to prevent stale EWRAM transport values from triggering scrub writes. |
 | 0x44   | 0x0203B044 | 4B | boss_temp_shard_bitfield | u32 | ROM internal | Bits 0-7 track shard bits temporarily written by boss-defeat hook for cutscene safety. On gameplay resume, payload scrubs only `boss_temp_shard_bitfield & ~delivered_shard_bitfield`, then clears this mask. |
 | 0x48   | 0x0203B048 | 4B | delivered_vitality_item_bits | u32 | ROM internal | Replay guard for vitality counter items. Bit N marks that `VITALITY_COUNTER_(N+1)` has already been applied, preventing duplicate vitality grants if an item is resent during reconnect/reset recovery. |
+| 0x4C   | 0x0203B04C | 4B | hub_switch_flags | u32 | ROM → Client | Bits 0–14 set when world-map big-switch door unlock callbacks fire (`WorldMapDoor` order: Moonlight, RR East, RR South, Cabbage Center, RR West, Carrot, RR North, Mustard, Cabbage West, Radish, Peppermint East, Peppermint West, Cabbage East, Olive, Candy). |
 
-**Total: 76 bytes (0x0203B000 - 0x0203B04B)**
+**Total: 80 bytes (0x0203B000 - 0x0203B04F)**
 
 ### Native Game State (Referenced but not Managed by AP)
 
@@ -130,8 +131,9 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_RADISH_RUINS | 3960302 | Radish Ruins 8-4 vitality big chest (transport vitality bit 2) |
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
+| HUB_SWITCH_MOONLIGHT .. HUB_SWITCH_CANDY | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 |
 | ROOM_SANITY_1_01 .. ROOM_SANITY_9_27 | 3961000+ | Room visit checks (`Room X-YY`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15 |
-| *Reserved*    | 3960305+ | Future location families |
+| *Reserved*    | 3960415+ | Future location families |
 
 ## Client Protocol
 
@@ -274,6 +276,12 @@ for bit in mapped_sound_player_chest_bits:
     if (sound_player_bits >> bit) & 1:
         mapped_checked.add(sound_player_chest_location_id_for_bit(bit))
 
+# Hub switch checks (transport hub_switch_flags)
+hub_switch_bits = RAM[0x0203B04C] as u32
+for bit in mapped_hub_switch_bits:
+    if (hub_switch_bits >> bit) & 1:
+        mapped_checked.add(hub_switch_location_id_for_bit(bit))
+
 # Room sanity checks (native gVisitedDoors)
 room_visits = RAM[0x02028CA0 : 0x02028CA0 + 0x240] as u16[0x120]
 for doors_idx in mapped_room_sanity_doors_indices:
@@ -289,7 +297,7 @@ if missing_on_server:
     send LocationChecks(missing_on_server)
 ```
 
-Mirror shard bitfields (`shard_bitfield_native` / `shard_bitfield`) are progression-state signals only. `delivered_shard_bitfield` is the authority used by scrub logic to enforce that `KIRBY_SHARD_FLAGS` (and therefore all `HasShard()` / `NumShardsCollected()` gate checks) reflects AP-owned shard state (Issue #478 / #505): it is seeded from native shard save state on mailbox init, then extended by AP `SHARD_N` item delivery. Boss defeats are reported through `boss_defeat_flags`, major chest openings are reported through `major_chest_flags`, vitality chest openings are reported through `vitality_chest_flags`, and Sound Player chest openings are reported through `sound_player_chest_flags`. Native boss shard / native big-chest map / native vitality grants are intercepted so progression, map ownership, and vitality growth come only from AP item delivery, and native Sound Player unlock is similarly intercepted so unlock ownership comes only from AP `SOUND_PLAYER` receipt.
+Mirror shard bitfields (`shard_bitfield_native` / `shard_bitfield`) are progression-state signals only. `delivered_shard_bitfield` is the authority used by scrub logic to enforce that `KIRBY_SHARD_FLAGS` (and therefore all `HasShard()` / `NumShardsCollected()` gate checks) reflects AP-owned shard state (Issue #478 / #505): it is seeded from native shard save state on mailbox init, then extended by AP `SHARD_N` item delivery. Boss defeats are reported through `boss_defeat_flags`, major chest openings are reported through `major_chest_flags`, vitality chest openings are reported through `vitality_chest_flags`, Sound Player chest openings are reported through `sound_player_chest_flags`, and world-map big switch unlocks are reported through `hub_switch_flags`. Native boss shard / native big-chest map / native vitality grants are intercepted so progression, map ownership, and vitality growth come only from AP item delivery, and native Sound Player unlock is similarly intercepted so unlock ownership comes only from AP `SOUND_PLAYER` receipt.
 
 Boss shard scrub timing contract (Issue #505):
 - Boss hook writes temporary native shard state for cutscene safety and marks `boss_temp_shard_bitfield`.
@@ -300,7 +308,7 @@ Boss shard scrub timing contract (Issue #505):
 - Detection is **level-based** (current bitfield state), not edge-based, to be reconnect-safe.
 - No checks are sent for bits already in `server_checked_locations`.
 - No checks are sent for reserved/unmapped bits even when set.
-- Boss-defeat, major-chest, vitality-chest, sound-player-chest, and room-sanity polling follow the same resend/dedupe diagnostic contract.
+- Boss-defeat, major-chest, vitality-chest, sound-player-chest, hub-switch, and room-sanity polling follow the same resend/dedupe diagnostic contract.
 - Diagnostics are transition-based to avoid per-tick log spam when mapped state is unchanged.
 
 ### 3. Item Delivery (Mailbox Protocol)

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -312,6 +312,7 @@ class KirbyAmWorld(World):
             major_chest_locations: list[KirbyAmLocation] = []
             vitality_chest_locations: list[KirbyAmLocation] = []
             sound_player_chest_locations: list[KirbyAmLocation] = []
+            hub_switch_locations: list[KirbyAmLocation] = []
             room_sanity_locations: list[KirbyAmLocation] = []
             location_by_key: dict[str, KirbyAmLocation] = {}
             for loc in fill_locations:
@@ -329,6 +330,8 @@ class KirbyAmWorld(World):
                     vitality_chest_locations.append(loc)
                 elif loc_meta.category == LocationCategory.SOUND_PLAYER_CHEST:
                     sound_player_chest_locations.append(loc)
+                elif loc_meta.category == LocationCategory.HUB_SWITCH:
+                    hub_switch_locations.append(loc)
                 elif loc_meta.category == LocationCategory.ROOM_SANITY:
                     room_sanity_locations.append(loc)
 
@@ -336,11 +339,12 @@ class KirbyAmWorld(World):
             major_chest_locations.sort(key=lambda loc: loc.key or "")
             vitality_chest_locations.sort(key=lambda loc: loc.key or "")
             sound_player_chest_locations.sort(key=lambda loc: loc.key or "")
+            hub_switch_locations.sort(key=lambda loc: loc.key or "")
             room_sanity_locations.sort(key=lambda loc: loc.key or "")
 
             locked_shard_count = 0
             randomized_item_codes: list[int] = []
-            if boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or room_sanity_locations:
+            if boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or room_sanity_locations:
                 shard_label_to_code = {
                     item.label: item.item_id
                     for item in kirby_data.items.values()
@@ -394,7 +398,7 @@ class KirbyAmWorld(World):
                     )
 
                 open_physical_locations = [
-                    loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations + room_sanity_locations
+                    loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations + hub_switch_locations + room_sanity_locations
                     if loc.item is None
                 ]
                 needed_pool_size = len(open_physical_locations)
@@ -525,10 +529,10 @@ class KirbyAmWorld(World):
                         self.player,
                     )
 
-            if (boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or room_sanity_locations) and not randomized_item_codes:
+            if (boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or room_sanity_locations) and not randomized_item_codes:
                 raise ValueError(
                     "KirbyAM item pool build failed: no randomized items were produced. "
-                    "This likely indicates a problem with boss/major/vitality or sound-player chest locations, "
+                    "This likely indicates a problem with boss/major/vitality/sound-player/hub-switch locations, "
                     "room-sanity locations, or region/location data."
                 )
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -130,6 +130,13 @@ class KirbyAmClient(BizHawkClient):
                 continue
             self._sound_player_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
 
+        # Hub switch bitfield → location IDs (HUB_SWITCH category).
+        self._hub_switch_location_ids_by_bit: dict[int, list[int]] = {}
+        for loc in data.locations.values():
+            if loc.bit_index is None or loc.category != LocationCategory.HUB_SWITCH:
+                continue
+            self._hub_switch_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+
         # Room-sanity bitfield index (doorsIdx) → location IDs.
         self._room_sanity_location_ids_by_bit: dict[int, list[int]] = {}
         for loc in data.locations.values():
@@ -163,6 +170,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_major_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_vitality_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_sound_player_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._last_hub_switch_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_room_sanity_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Notification pipeline state (Issue #83)
@@ -218,6 +226,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_major_chest_poll_log = None
         self._last_vitality_chest_poll_log = None
         self._last_sound_player_chest_poll_log = None
+        self._last_hub_switch_poll_log = None
         self._last_room_sanity_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
@@ -776,6 +785,9 @@ class KirbyAmClient(BizHawkClient):
 
             # Sound Player chest location polling via dedicated sound_player_chest_flags register
             await self._poll_sound_player_chest_locations(ctx)
+
+            # Hub switch location polling via dedicated hub_switch_flags register
+            await self._poll_hub_switch_locations(ctx)
 
             # Room-sanity location polling via native gVisitedDoors bit 15.
             await self._poll_room_sanity_locations(ctx)
@@ -1530,6 +1542,55 @@ class KirbyAmClient(BizHawkClient):
                 self._last_sound_player_chest_poll_log = chest_log_state
         else:
             self._last_sound_player_chest_poll_log = None
+
+    async def _poll_hub_switch_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Read transport hub_switch_flags and map set bits to hub-switch locations.
+
+        This register is written by the ROM payload when world-map big switches
+        trigger a hub-door unlock callback. Polling mirrors existing resend/dedupe
+        semantics used by other transport-backed location families.
+        """
+        switch_addr = self._transport_addr("hub_switch_flags")
+        if switch_addr is None:
+            return
+
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(switch_addr, 4, "System Bus")]))[0]
+        switch_bits = self._u32_le(raw)
+
+        mapped_checked_locations: set[int] = set()
+        for bit in sorted(self._hub_switch_location_ids_by_bit.keys()):
+            if (switch_bits >> bit) & 1:
+                mapped_checked_locations.update(self._hub_switch_location_ids_by_bit.get(bit, []))
+
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+        already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
+        if missing_on_server:
+            from CommonClient import logger
+
+            switch_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if switch_log_state != self._last_hub_switch_poll_log:
+                logger.info(
+                    "KirbyAM: resending hub-switch LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
+                self._last_hub_switch_poll_log = switch_log_state
+
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+        elif mapped_checked_locations:
+            from CommonClient import logger
+
+            switch_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if switch_log_state != self._last_hub_switch_poll_log:
+                logger.debug(
+                    "KirbyAM: dedupe suppressed hub-switch LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_hub_switch_poll_log = switch_log_state
+        else:
+            self._last_hub_switch_poll_log = None
 
     async def _poll_room_sanity_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -152,6 +152,7 @@ class LocationCategory(IntEnum):
     VITALITY_CHEST = 10
     SOUND_PLAYER_CHEST = 11
     ROOM_SANITY = 12
+    HUB_SWITCH = 13
 
 
 class ItemData(NamedTuple):

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -19,7 +19,8 @@
       "shard_scrub_delay_frames": "0x0203B03C",
       "mailbox_init_cookie": "0x0203B040",
       "boss_temp_shard_bitfield": "0x0203B044",
-      "delivered_vitality_item_bits": "0x0203B048"
+      "delivered_vitality_item_bits": "0x0203B048",
+      "hub_switch_flags": "0x0203B04C"
     },
     "native": {
       "shard_bitfield_native": "0x02038970",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -260,5 +260,170 @@
     "bit_index": 0,
     "category": "SOUND_PLAYER_CHEST",
     "location_id": 3960304
+  },
+  "HUB_SWITCH_MOONLIGHT": {
+    "label": "Moonlight Mansion - Big Switch",
+    "parent_region": "REGION_MOONLIGHT_MANSION/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_MOONLIGHT_MANSION"
+    ],
+    "bit_index": 0,
+    "category": "HUB_SWITCH",
+    "location_id": 3960400
+  },
+  "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
+    "label": "Rainbow Route East - Big Switch",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 1,
+    "category": "HUB_SWITCH",
+    "location_id": 3960401
+  },
+  "HUB_SWITCH_RAINBOW_ROUTE_SOUTH": {
+    "label": "Rainbow Route South - Big Switch",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 2,
+    "category": "HUB_SWITCH",
+    "location_id": 3960402
+  },
+  "HUB_SWITCH_CABBAGE_CAVERN_CENTER": {
+    "label": "Cabbage Cavern Center - Big Switch",
+    "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 3,
+    "category": "HUB_SWITCH",
+    "location_id": 3960403
+  },
+  "HUB_SWITCH_RAINBOW_ROUTE_WEST": {
+    "label": "Rainbow Route West - Big Switch",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 4,
+    "category": "HUB_SWITCH",
+    "location_id": 3960404
+  },
+  "HUB_SWITCH_CARROT": {
+    "label": "Carrot Castle - Big Switch",
+    "parent_region": "REGION_CARROT_CASTLE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_CARROT_CASTLE"
+    ],
+    "bit_index": 5,
+    "category": "HUB_SWITCH",
+    "location_id": 3960405
+  },
+  "HUB_SWITCH_RAINBOW_ROUTE_NORTH": {
+    "label": "Rainbow Route North - Big Switch",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 6,
+    "category": "HUB_SWITCH",
+    "location_id": 3960406
+  },
+  "HUB_SWITCH_MUSTARD": {
+    "label": "Mustard Mountain - Big Switch",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_MUSTARD_MOUNTAIN"
+    ],
+    "bit_index": 7,
+    "category": "HUB_SWITCH",
+    "location_id": 3960407
+  },
+  "HUB_SWITCH_CABBAGE_CAVERN_WEST": {
+    "label": "Cabbage Cavern West - Big Switch",
+    "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 8,
+    "category": "HUB_SWITCH",
+    "location_id": 3960408
+  },
+  "HUB_SWITCH_RADISH": {
+    "label": "Radish Ruins - Big Switch",
+    "parent_region": "REGION_RADISH_RUINS/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_RADISH_RUINS"
+    ],
+    "bit_index": 9,
+    "category": "HUB_SWITCH",
+    "location_id": 3960409
+  },
+  "HUB_SWITCH_PEPPERMINT_EAST": {
+    "label": "Peppermint Palace East - Big Switch",
+    "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_PEPPERMINT_PALACE"
+    ],
+    "bit_index": 10,
+    "category": "HUB_SWITCH",
+    "location_id": 3960410
+  },
+  "HUB_SWITCH_PEPPERMINT_WEST": {
+    "label": "Peppermint Palace West - Big Switch",
+    "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_PEPPERMINT_PALACE"
+    ],
+    "bit_index": 11,
+    "category": "HUB_SWITCH",
+    "location_id": 3960411
+  },
+  "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
+    "label": "Cabbage Cavern East - Big Switch",
+    "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 12,
+    "category": "HUB_SWITCH",
+    "location_id": 3960412
+  },
+  "HUB_SWITCH_OLIVE": {
+    "label": "Olive Ocean - Big Switch",
+    "parent_region": "REGION_OLIVE_OCEAN/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_OLIVE_OCEAN"
+    ],
+    "bit_index": 13,
+    "category": "HUB_SWITCH",
+    "location_id": 3960413
+  },
+  "HUB_SWITCH_CANDY": {
+    "label": "Candy Constellation - Big Switch",
+    "parent_region": "REGION_CANDY_CONSTELLATION/MAIN",
+    "tags": [
+      "HubSwitch",
+      "MAP_CANDY_CONSTELLATION"
+    ],
+    "bit_index": 14,
+    "category": "HUB_SWITCH",
+    "location_id": 3960414
   }
 }

--- a/worlds/kirbyam/data/regions/areas.json
+++ b/worlds/kirbyam/data/regions/areas.json
@@ -7,14 +7,18 @@
     ]
   },
   "REGION_MUSTARD_MOUNTAIN/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_MUSTARD"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/MAIN"
     ]
   },
   "REGION_MOONLIGHT_MANSION/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_MOONLIGHT"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/MAIN",
@@ -22,14 +26,18 @@
     ]
   },
   "REGION_CANDY_CONSTELLATION/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_CANDY"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/MAIN"
     ]
   },
   "REGION_OLIVE_OCEAN/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_OLIVE"
+    ],
     "events": [],
     "exits": [
       "REGION_CABBAGE_CAVERN/MAIN",
@@ -37,7 +45,10 @@
     ]
   },
   "REGION_PEPPERMINT_PALACE/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_PEPPERMINT_EAST",
+      "HUB_SWITCH_PEPPERMINT_WEST"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/MAIN",
@@ -45,7 +56,11 @@
     ]
   },
   "REGION_CABBAGE_CAVERN/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_CABBAGE_CAVERN_CENTER",
+      "HUB_SWITCH_CABBAGE_CAVERN_EAST",
+      "HUB_SWITCH_CABBAGE_CAVERN_WEST"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/MAIN",
@@ -54,7 +69,9 @@
     ]
   },
   "REGION_CARROT_CASTLE/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_CARROT"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/MAIN",
@@ -63,7 +80,9 @@
     ]
   },
   "REGION_RADISH_RUINS/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_RADISH"
+    ],
     "events": [],
     "exits": [
       "REGION_CABBAGE_CAVERN/MAIN",
@@ -71,7 +90,12 @@
     ]
   },
   "REGION_RAINBOW_ROUTE/MAIN": {
-    "locations": [],
+    "locations": [
+      "HUB_SWITCH_RAINBOW_ROUTE_EAST",
+      "HUB_SWITCH_RAINBOW_ROUTE_NORTH",
+      "HUB_SWITCH_RAINBOW_ROUTE_SOUTH",
+      "HUB_SWITCH_RAINBOW_ROUTE_WEST"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/ROOM_1_01",

--- a/worlds/kirbyam/groups.py
+++ b/worlds/kirbyam/groups.py
@@ -43,6 +43,7 @@ _LOCATION_GROUP_MAPS: dict[str, set[str]] = {
 
 _LOCATION_CATEGORY_TO_GROUP_NAME = {
     LocationCategory.MAJOR_CHEST: "Major Chests",
+    LocationCategory.HUB_SWITCH: "Hub Switches",
 }
 
 # Pre-create category groups and map/area groups so they are always present during build.

--- a/worlds/kirbyam/kirby_ap_payload/ap_payload.c
+++ b/worlds/kirbyam/kirby_ap_payload/ap_payload.c
@@ -47,6 +47,7 @@
 #define AP_MAJOR_CHEST_FLAGS    (*(volatile uint32_t*)(AP_BASE + 0x28u))
 #define AP_VITALITY_CHEST_FLAGS (*(volatile uint32_t*)(AP_BASE + 0x2Cu))
 #define AP_SOUND_PLAYER_CHEST_FLAGS (*(volatile uint32_t*)(AP_BASE + 0x30u))
+#define AP_HUB_SWITCH_FLAGS (*(volatile uint32_t*)(AP_BASE + 0x4Cu))
 #define KIRBY_SHARD_FLAGS_ADDR  0x02038970u
 #define KIRBY_SHARD_FLAGS       (*(volatile uint8_t*)(KIRBY_SHARD_FLAGS_ADDR))
 #define AI_KIRBY_STATE_ADDR     0x0203AD2Cu
@@ -149,6 +150,12 @@ static void ap_set_sound_player_chest_flag(uint32_t chest_index) {
     }
 }
 
+static void ap_set_hub_switch_flag(uint32_t door_index) {
+    if (door_index < 15u) {
+        AP_HUB_SWITCH_FLAGS |= (1u << door_index);
+    }
+}
+
 static void ap_set_vitality_chest_flag_for_room(uint16_t room_id) {
     switch (room_id) {
         case 739u: // Carrot Castle 5-23 Big Chest
@@ -233,6 +240,18 @@ __attribute__((used)) void ap_on_collect_sound_player_chest(uint32_t reward_inde
     }
 
     KIRBY_COLLECT_SOUND_PLAYER_FN(reward_index);
+}
+
+typedef void (*WorldMapUnlockFn)(void);
+
+// Hook target for the world-map unlock dispatcher call in sub_08039ED4.
+// r0 contains the selected unlock function pointer from gUnk_0834BD94 and r4
+// holds the task pointer whose +0x08 halfword stores the WorldMapDoor index.
+__attribute__((used)) void ap_on_world_map_unlock_call(WorldMapUnlockFn unlock_fn) {
+    register uint32_t task_ptr asm("r4");
+    uint16_t door_index = *(volatile uint16_t*)(task_ptr + 0x08u);
+    ap_set_hub_switch_flag((uint32_t)door_index);
+    unlock_fn();
 }
 
 static void ap_sync_active_kirby_health_from_vitality(void) {
@@ -427,6 +446,7 @@ void ap_poll_mailbox_c(void) {
         AP_BOSS_DEFEAT_FLAGS = 0u;
         AP_BOSS_TEMP_SHARD_BITFIELD = 0u;
         AP_DELIVERED_VITALITY_ITEM_BITS = 0u;
+        AP_HUB_SWITCH_FLAGS = 0u;
         AP_MAILBOX_INIT_COOKIE = AP_MAILBOX_INIT_COOKIE_VALUE;
     }
 

--- a/worlds/kirbyam/kirby_ap_payload/patch_rom.py
+++ b/worlds/kirbyam/kirby_ap_payload/patch_rom.py
@@ -44,6 +44,7 @@ BOSS_COLLECT_SHARD_CALL_OFFSET = 0x001D952
 BIG_CHEST_COLLECT_CALL_OFFSET = 0x0000B144
 VITALITY_CHEST_COLLECT_CALL_OFFSET = 0x0000B0CC
 SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET = 0x0000B264
+BIG_SWITCH_UNLOCK_CALL_OFFSET = 0x00039EEE
 
 
 ROM_PATH_TMP = "rom_path.tmp"
@@ -698,6 +699,7 @@ def main():
         big_chest_hook_target = resolve_elf_symbol_address(payload_elf_path, "ap_on_collect_big_chest")
         vitality_chest_hook_target = resolve_elf_symbol_address(payload_elf_path, "ap_on_collect_vitality_chest")
         sound_player_chest_hook_target = resolve_elf_symbol_address(payload_elf_path, "ap_on_collect_sound_player_chest")
+        hub_switch_hook_target = resolve_elf_symbol_address(payload_elf_path, "ap_on_world_map_unlock_call")
         # arm-none-eabi-nm may encode Thumb function symbols with bit 0 set.
         # Clear the Thumb state bit before passing to thumb_bl_bytes(), which
         # requires a halfword-aligned target address.
@@ -706,6 +708,7 @@ def main():
         big_chest_hook_target &= ~1
         vitality_chest_hook_target &= ~1
         sound_player_chest_hook_target &= ~1
+        hub_switch_hook_target &= ~1
         rom_base = 0x08000000
         payload_rom_start = rom_base + PAYLOAD_OFFSET
         payload_rom_end = payload_rom_start + len(payload)
@@ -744,11 +747,19 @@ def main():
                 f"[0x{payload_rom_start:08X}, 0x{payload_rom_end:08X}). "
                 "Check your payload.elf link address and PAYLOAD_OFFSET."
             )
+        if not (payload_rom_start <= hub_switch_hook_target < payload_rom_end):
+            raise SystemExit(
+                "Error: hub switch hook target address out of expected payload range.\n"
+                f"Resolved address: 0x{hub_switch_hook_target:08X}, expected within "
+                f"[0x{payload_rom_start:08X}, 0x{payload_rom_end:08X}). "
+                "Check your payload.elf link address and PAYLOAD_OFFSET."
+            )
         main_hook_bl_bytes = thumb_bl_bytes(rom_base + MAIN_HOOK_OFFSET, main_hook_target)
         boss_hook_bl_bytes = thumb_bl_bytes(rom_base + BOSS_COLLECT_SHARD_CALL_OFFSET, boss_hook_target)
         big_chest_hook_bl_bytes = thumb_bl_bytes(rom_base + BIG_CHEST_COLLECT_CALL_OFFSET, big_chest_hook_target)
         vitality_chest_hook_bl_bytes = thumb_bl_bytes(rom_base + VITALITY_CHEST_COLLECT_CALL_OFFSET, vitality_chest_hook_target)
         sound_player_chest_hook_bl_bytes = thumb_bl_bytes(rom_base + SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET, sound_player_chest_hook_target)
+        hub_switch_hook_bl_bytes = thumb_bl_bytes(rom_base + BIG_SWITCH_UNLOCK_CALL_OFFSET, hub_switch_hook_target)
 
         # 3) Load ROM
         try:
@@ -765,11 +776,13 @@ def main():
         original_big_chest_hook = validate_thumb_bl_callsite(rom, BIG_CHEST_COLLECT_CALL_OFFSET, "big chest")
         original_vitality_hook = validate_thumb_bl_callsite(rom, VITALITY_CHEST_COLLECT_CALL_OFFSET, "vitality chest")
         original_sound_player_hook = validate_thumb_bl_callsite(rom, SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET, "sound player chest")
+        original_hub_switch_hook = validate_thumb_bl_callsite(rom, BIG_SWITCH_UNLOCK_CALL_OFFSET, "hub switch unlock")
         print("Validated hook callsite instruction shape (Thumb BL):")
         print(f"  boss shard @ {BOSS_COLLECT_SHARD_CALL_OFFSET:#x}: {original_boss_hook.hex(' ')}")
         print(f"  big chest @ {BIG_CHEST_COLLECT_CALL_OFFSET:#x}: {original_big_chest_hook.hex(' ')}")
         print(f"  vitality chest @ {VITALITY_CHEST_COLLECT_CALL_OFFSET:#x}: {original_vitality_hook.hex(' ')}")
         print(f"  sound player chest @ {SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET:#x}: {original_sound_player_hook.hex(' ')}")
+        print(f"  hub switch unlock @ {BIG_SWITCH_UNLOCK_CALL_OFFSET:#x}: {original_hub_switch_hook.hex(' ')}")
 
         # 4) Insert payload
         rom[PAYLOAD_OFFSET:PAYLOAD_OFFSET + len(payload)] = payload
@@ -780,6 +793,7 @@ def main():
         rom[BIG_CHEST_COLLECT_CALL_OFFSET:BIG_CHEST_COLLECT_CALL_OFFSET + 4] = big_chest_hook_bl_bytes
         rom[VITALITY_CHEST_COLLECT_CALL_OFFSET:VITALITY_CHEST_COLLECT_CALL_OFFSET + 4] = vitality_chest_hook_bl_bytes
         rom[SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET:SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET + 4] = sound_player_chest_hook_bl_bytes
+        rom[BIG_SWITCH_UNLOCK_CALL_OFFSET:BIG_SWITCH_UNLOCK_CALL_OFFSET + 4] = hub_switch_hook_bl_bytes
 
         # 6) Write the intermediary patched ROM
         with open(INTERMEDIARY_ROM, "wb") as f:
@@ -840,6 +854,14 @@ def main():
             sound_player_chest_hook_bl_bytes.hex(" "),
             "target=",
             hex(sound_player_chest_hook_target),
+        )
+        print(
+            "Hub switch unlock call patched at file offset:",
+            hex(BIG_SWITCH_UNLOCK_CALL_OFFSET),
+            "with bytes:",
+            hub_switch_hook_bl_bytes.hex(" "),
+            "target=",
+            hex(hub_switch_hook_target),
         )
 
         # 7) Generate base_patch.bsdiff4: clean base -> intermediary patched ROM

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -148,6 +148,141 @@
         "MAP_DIMENSION_MIRROR"
       ]
     },
+    "HUB_SWITCH_CABBAGE_CAVERN_CENTER": {
+      "category": "HUB_SWITCH",
+      "label": "Cabbage Cavern Center - Big Switch",
+      "location_id": 3960403,
+      "tags": [
+        "HubSwitch",
+        "MAP_CABBAGE_CAVERN"
+      ]
+    },
+    "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
+      "category": "HUB_SWITCH",
+      "label": "Cabbage Cavern East - Big Switch",
+      "location_id": 3960412,
+      "tags": [
+        "HubSwitch",
+        "MAP_CABBAGE_CAVERN"
+      ]
+    },
+    "HUB_SWITCH_CABBAGE_CAVERN_WEST": {
+      "category": "HUB_SWITCH",
+      "label": "Cabbage Cavern West - Big Switch",
+      "location_id": 3960408,
+      "tags": [
+        "HubSwitch",
+        "MAP_CABBAGE_CAVERN"
+      ]
+    },
+    "HUB_SWITCH_CANDY": {
+      "category": "HUB_SWITCH",
+      "label": "Candy Constellation - Big Switch",
+      "location_id": 3960414,
+      "tags": [
+        "HubSwitch",
+        "MAP_CANDY_CONSTELLATION"
+      ]
+    },
+    "HUB_SWITCH_CARROT": {
+      "category": "HUB_SWITCH",
+      "label": "Carrot Castle - Big Switch",
+      "location_id": 3960405,
+      "tags": [
+        "HubSwitch",
+        "MAP_CARROT_CASTLE"
+      ]
+    },
+    "HUB_SWITCH_MOONLIGHT": {
+      "category": "HUB_SWITCH",
+      "label": "Moonlight Mansion - Big Switch",
+      "location_id": 3960400,
+      "tags": [
+        "HubSwitch",
+        "MAP_MOONLIGHT_MANSION"
+      ]
+    },
+    "HUB_SWITCH_MUSTARD": {
+      "category": "HUB_SWITCH",
+      "label": "Mustard Mountain - Big Switch",
+      "location_id": 3960407,
+      "tags": [
+        "HubSwitch",
+        "MAP_MUSTARD_MOUNTAIN"
+      ]
+    },
+    "HUB_SWITCH_OLIVE": {
+      "category": "HUB_SWITCH",
+      "label": "Olive Ocean - Big Switch",
+      "location_id": 3960413,
+      "tags": [
+        "HubSwitch",
+        "MAP_OLIVE_OCEAN"
+      ]
+    },
+    "HUB_SWITCH_PEPPERMINT_EAST": {
+      "category": "HUB_SWITCH",
+      "label": "Peppermint Palace East - Big Switch",
+      "location_id": 3960410,
+      "tags": [
+        "HubSwitch",
+        "MAP_PEPPERMINT_PALACE"
+      ]
+    },
+    "HUB_SWITCH_PEPPERMINT_WEST": {
+      "category": "HUB_SWITCH",
+      "label": "Peppermint Palace West - Big Switch",
+      "location_id": 3960411,
+      "tags": [
+        "HubSwitch",
+        "MAP_PEPPERMINT_PALACE"
+      ]
+    },
+    "HUB_SWITCH_RADISH": {
+      "category": "HUB_SWITCH",
+      "label": "Radish Ruins - Big Switch",
+      "location_id": 3960409,
+      "tags": [
+        "HubSwitch",
+        "MAP_RADISH_RUINS"
+      ]
+    },
+    "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
+      "category": "HUB_SWITCH",
+      "label": "Rainbow Route East - Big Switch",
+      "location_id": 3960401,
+      "tags": [
+        "HubSwitch",
+        "MAP_RAINBOW_ROUTE"
+      ]
+    },
+    "HUB_SWITCH_RAINBOW_ROUTE_NORTH": {
+      "category": "HUB_SWITCH",
+      "label": "Rainbow Route North - Big Switch",
+      "location_id": 3960406,
+      "tags": [
+        "HubSwitch",
+        "MAP_RAINBOW_ROUTE"
+      ]
+    },
+    "HUB_SWITCH_RAINBOW_ROUTE_SOUTH": {
+      "category": "HUB_SWITCH",
+      "label": "Rainbow Route South - Big Switch",
+      "location_id": 3960402,
+      "tags": [
+        "HubSwitch",
+        "MAP_RAINBOW_ROUTE"
+      ]
+    },
+    "HUB_SWITCH_RAINBOW_ROUTE_WEST": {
+      "category": "HUB_SWITCH",
+      "label": "Rainbow Route West - Big Switch",
+      "location_id": 3960404,
+      "tags": [
+        "HubSwitch",
+        "MAP_RAINBOW_ROUTE"
+      ]
+    },
     "MAJOR_CHEST_CABBAGE_CAVERN": {
       "category": "MAJOR_CHEST",
       "label": "Cabbage Cavern 3-7 - Big Chest",

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -389,6 +389,71 @@ async def test_poll_sound_player_chest_skips_when_address_missing(mock_bizhawk_c
     mock_send.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_context):
+    """Set transport hub-switch bits should map to hub-switch LocationChecks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    moonlight = data.locations["HUB_SWITCH_MOONLIGHT"].location_id
+    rainbow_east = data.locations["HUB_SWITCH_RAINBOW_ROUTE_EAST"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        # Bits 0 and 1 set => Moonlight and Rainbow Route East hub switch checks.
+        mock_read.return_value = [((1 << 0) | (1 << 1)).to_bytes(4, 'little')]
+
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [moonlight, rainbow_east]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_poll_hub_switch_skips_already_server_acknowledged(mock_bizhawk_context):
+    """No hub-switch resend when server already acknowledges all mapped transport checks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    moonlight = data.locations["HUB_SWITCH_MOONLIGHT"].location_id
+    mock_bizhawk_context.checked_locations = {moonlight}
+
+    with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.return_value = [((1 << 0)).to_bytes(4, 'little')]
+
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
+    assert mock_logger.debug.called
+    assert "dedupe suppressed hub-switch LocationChecks" in mock_logger.debug.call_args.args[0]
+    assert mock_logger.debug.call_args.args[1] == [moonlight]
+
+
+@pytest.mark.asyncio
+async def test_poll_hub_switch_skips_when_address_missing(mock_bizhawk_context):
+    """Missing transport hub-switch address should no-op safely."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    transport_without_hub_switch = {k: v for k, v in data.transport_ram_addresses.items() if k != "hub_switch_flags"}
+    ram_without_hub_switch = {k: v for k, v in data.ram_addresses.items() if k != "hub_switch_flags"}
+
+    with patch.dict(data.transport_ram_addresses, transport_without_hub_switch, clear=True), \
+         patch.dict(data.ram_addresses, ram_without_hub_switch, clear=True), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+    mock_read.assert_not_awaited()
+    mock_send.assert_not_awaited()
+
+
 def test_major_chest_data_sanity():
     """Major-chest entries should have explicit unique IDs and unique mapped bits."""
     major_chests = [
@@ -437,6 +502,24 @@ def test_sound_player_chest_data_sanity():
     sound_player = sound_player_chests[0]
     assert sound_player.location_id is not None
     assert sound_player.bit_index == 0
+
+
+def test_hub_switch_data_sanity():
+    """Hub-switch entries should have explicit unique IDs and unique mapped bits."""
+    hub_switches = [
+        loc for loc in data.locations.values()
+        if loc.category.name == "HUB_SWITCH"
+    ]
+
+    assert len(hub_switches) == 15
+
+    ids = [loc.location_id for loc in hub_switches]
+    assert all(loc_id is not None for loc_id in ids)
+    assert len(ids) == len(set(ids))
+
+    bits = [loc.bit_index for loc in hub_switches]
+    assert all(bit is not None for bit in bits)
+    assert len(bits) == len(set(bits))
 
 
 def test_client_initialization():
@@ -2397,6 +2480,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock) as mock_poll_major, \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality, \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player, \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switch, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe_boss, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
          patch.object(client, '_deliver_items', new_callable=AsyncMock) as mock_deliver, \
@@ -2413,6 +2497,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
     mock_poll_major.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_vitality.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_sound_player.assert_awaited_once_with(mock_bizhawk_context)
+    mock_poll_hub_switch.assert_awaited_once_with(mock_bizhawk_context)
     mock_probe_boss.assert_awaited_once_with(mock_bizhawk_context)
     mock_probe_unsafe.assert_awaited_once_with(mock_bizhawk_context)
     mock_deliver.assert_awaited_once_with(mock_bizhawk_context)
@@ -2505,6 +2590,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
     client._last_major_chest_poll_log = ("resend", (3,), ())
     client._last_vitality_chest_poll_log = ("resend", (4,), ())
     client._last_sound_player_chest_poll_log = ("resend", (5,), ())
+    client._last_hub_switch_poll_log = ("resend", (6,), ())
     client._last_boss_probe_snapshot = bytes(32)
     client._boss_probe_stream_marker = object()
     client._unsafe_delivery_probe_stream_marker = object()
@@ -2519,6 +2605,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
             patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock) as mock_poll_major_chests, \
             patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality_chests, \
             patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player_chests, \
+                patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switches, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
          patch.object(client, '_deliver_items', new_callable=AsyncMock) as mock_deliver, \
@@ -2534,6 +2621,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         assert client._last_major_chest_poll_log is None
         assert client._last_vitality_chest_poll_log is None
         assert client._last_sound_player_chest_poll_log is None
+        assert client._last_hub_switch_poll_log is None
         assert client._last_boss_probe_snapshot is None
         assert client._boss_probe_stream_marker is None
         assert client._unsafe_delivery_probe_stream_marker is None
@@ -2545,6 +2633,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         mock_poll_major_chests.assert_awaited_once()
         mock_poll_vitality_chests.assert_awaited_once()
         mock_poll_sound_player_chests.assert_awaited_once()
+        mock_poll_hub_switches.assert_awaited_once()
         mock_probe.assert_awaited_once()
         mock_probe_unsafe.assert_awaited_once()
         mock_deliver.assert_awaited_once_with(mock_bizhawk_context)
@@ -2570,6 +2659,7 @@ async def test_game_watcher_reconnect_entry_suppresses_session_ready_log_when_de
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
@@ -2777,6 +2867,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \
@@ -2832,6 +2923,7 @@ async def test_game_watcher_emits_runtime_gate_logs_when_debug_enabled(mock_bizh
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
@@ -2873,6 +2965,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \
@@ -2899,6 +2992,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \
@@ -3203,3 +3297,25 @@ def test_vitality_chest_locations_defined_in_regions():
     for key in vitality_chest_keys:
         assert key in all_region_locations, \
             f"VITALITY_CHEST location '{key}' defined in locations.json but not registered in any region in areas.json"
+
+
+def test_hub_switch_locations_defined_in_regions():
+    """Regression test: all HUB_SWITCH locations must be registered in their regions."""
+    location_category_enum = getattr(data, "LocationCategory", None)
+    hub_switch_category = getattr(location_category_enum, "HUB_SWITCH", None) if location_category_enum else None
+    hub_switch_keys = {
+        key
+        for key, loc in data.locations.items()
+        if key.startswith("HUB_SWITCH_")
+        or (hub_switch_category is not None and getattr(loc, "category", None) == hub_switch_category)
+    }
+
+    assert hub_switch_keys, "No HUB_SWITCH locations found in locations.json"
+
+    all_region_locations = set()
+    for region_data in data.regions.values():
+        all_region_locations.update(region_data.locations)
+
+    for key in hub_switch_keys:
+        assert key in all_region_locations, \
+            f"HUB_SWITCH location '{key}' defined in locations.json but not registered in any region in areas.json"

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -341,8 +341,9 @@ def test_vanilla_shards_are_locked_to_boss_defeats() -> None:
     _major_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MAJOR_CHEST)
     _vitality_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.VITALITY_CHEST)
     _sound_player_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.SOUND_PLAYER_CHEST)
+    _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
-    _expected_pool_size = _major_chest_count + _vitality_chest_count + _sound_player_chest_count + _room_sanity_count
+    _expected_pool_size = _major_chest_count + _vitality_chest_count + _sound_player_chest_count + _hub_switch_count + _room_sanity_count
     assert len(world.multiworld.itempool) == _expected_pool_size
     assert all("Mirror Shard" not in item.name for item in world.multiworld.itempool)
 
@@ -360,6 +361,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
     _major_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MAJOR_CHEST)
     _vitality_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.VITALITY_CHEST)
     _sound_player_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.SOUND_PLAYER_CHEST)
+    _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
     _shard_item_count = len(KirbyAmWorld._SHARD_ITEM_LABEL_ORDER)
     _open_non_goal_location_count = (
@@ -367,6 +369,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
         + _major_chest_count
         + _vitality_chest_count
         + _sound_player_chest_count
+        + _hub_switch_count
         + _room_sanity_count
     )
     _expected_pool_size = _open_non_goal_location_count

--- a/worlds/kirbyam/test/test_patch_rom.py
+++ b/worlds/kirbyam/test/test_patch_rom.py
@@ -94,6 +94,10 @@ def test_sound_player_chest_collect_call_offset_matches_verified_hook_site() -> 
     assert patch_rom.SOUND_PLAYER_CHEST_COLLECT_CALL_OFFSET == 0x0000B264
 
 
+def test_big_switch_unlock_call_offset_matches_verified_hook_site() -> None:
+    assert patch_rom.BIG_SWITCH_UNLOCK_CALL_OFFSET == 0x00039EEE
+
+
 # ── Negative-path tests: parse_args ──────────────────────────────────────────
 
 def test_parse_args_source_type_arg_missing_rom_positional() -> None:

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -132,6 +132,7 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_reset_safe_shards.py
+++ b/worlds/kirbyam/test/test_reset_safe_shards.py
@@ -110,6 +110,19 @@ def test_payload_tracks_sound_player_chest_checks_and_ap_unlock_apply():
     assert "KIRBY_ITEM_ID_BASE_OFFSET + 25u" in content, "Sound Player AP item ID should be handled"
 
 
+def test_payload_tracks_hub_switch_checks_from_world_map_unlocks() -> None:
+    """Verify world-map big-switch unlock callbacks set dedicated AP hub-switch check flags."""
+    payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")
+
+    with open(payload_path, 'r') as f:
+        content = f.read()
+
+    assert "AP_HUB_SWITCH_FLAGS" in content, "Hub switch transport register should be defined"
+    assert "ap_set_hub_switch_flag" in content, "Hub switch flag helper should exist"
+    assert "ap_on_world_map_unlock_call" in content, "World-map unlock hook target should exist"
+    assert "door_index" in content, "World-map unlock hook should read the unlock door index"
+
+
 def test_sram_checksum_fields_updated():
     """Verify that checksum fields are updated alongside shard persistence."""
     payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")


### PR DESCRIPTION
## Summary
- add `HUB_SWITCH` location family with 15 decomp-aligned world-map big switch checks
- add dedicated mailbox transport register `hub_switch_flags` at `0x0203B04C`
- hook world-map unlock dispatcher callsite in payload/patch tooling and mirror bits to client polling
- update protocol/changelog and item-pool/location-group wiring
- add regression coverage for polling, data sanity, region binding, payload symbols, and patch offset

## Validation
- `/Users/harrisonsherwin/Archipelago-kirbyam/.venv/bin/python -m pytest -q worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_reconnect_chaos.py worlds/kirbyam/test/test_item_pool.py worlds/kirbyam/test/test_patch_rom.py worlds/kirbyam/test/test_reset_safe_shards.py`
- result: `197 passed, 1 warning`

Closes #481 