### PR TITLE
Issue #570: drive unswallowable enemy exclusions from enemies.json

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `Start With All Maps` (`start_with_all_maps`) option to the `Make the game easier` option group. When enabled, all nine area maps are precollected at generation time and removed from the randomized item pool (replaced with filler), so the player begins with every map already acquired (Issue #584).
 - Fix missing boss-defeat LocationChecks when the matching shard is already owned by adding a conservative client fallback: rising-edge bits from `boss_mirror_table_native` byte 0 (bits 0-7) now backfill boss checks when `boss_defeat_flags` is absent for that fight (Issue #573).
 - Extend the unswallowable-enemy exclusion list for copy-ability randomization to include `JACK`, `SQUISHY`, `BLOCKIN`, `GORDO`, and `MIRRA` (in addition to the existing `GLUNK`, `SCARFY`, `SHOTZO`), preventing potential no-ability lockouts from all non-inhalable enemies (Issue #570).
+- Move unswallowable enemy exclusion policy from a static runtime list into `data/enemies.json` source metadata (`can_be_swallowed`) so exclusions are interpreted directly from enemy data definitions (Issue #570).
 - Hide additional KirbyAM reconnect/resend diagnostics from the live client output unless `Enable Debug Logging` is enabled, while still writing those diagnostics to log files unconditionally (`NoStream`-filtered stream suppression only); includes watcher transport reconnect messages and resend diagnostics for boss/major/vitality/sound-player LocationChecks polling (Issue #582).
 
 ## v0.1.2

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).
 - Add `Start With All Maps` (`start_with_all_maps`) option to the `Make the game easier` option group. When enabled, all nine area maps are precollected at generation time and removed from the randomized item pool (replaced with filler), so the player begins with every map already acquired (Issue #584).
 - Fix missing boss-defeat LocationChecks when the matching shard is already owned by adding a conservative client fallback: rising-edge bits from `boss_mirror_table_native` byte 0 (bits 0-7) now backfill boss checks when `boss_defeat_flags` is absent for that fight (Issue #573).
-- Move unswallowable enemy exclusion policy from a static runtime list into `data/enemies.json` source metadata (`can_be_swallowed`) and extend exclusions to include `JACK`, `SQUISHY`, `BLOCKIN`, `GORDO`, and `MIRRA` (with existing `GLUNK`, `SCARFY`, `SHOTZO`) so all known non-inhalable enemies are represented by data-driven definitions (Issue #570).
+- Move unswallowable enemy exclusion policy from a static runtime list into `data/enemies.json` source metadata (`can_be_swallowed`) and represent the currently configured non-swallowable enemies there: `GLUNK`, `JACK`, and `SQUISHY` (Issue #570).
 - Hide additional KirbyAM reconnect/resend diagnostics from the live client output unless `Enable Debug Logging` is enabled, while still writing those diagnostics to log files unconditionally (`NoStream`-filtered stream suppression only); includes watcher transport reconnect messages and resend diagnostics for boss/major/vitality/sound-player LocationChecks polling (Issue #582).
 
 ## v0.1.2

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -7,8 +7,7 @@
 - Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).
 - Add `Start With All Maps` (`start_with_all_maps`) option to the `Make the game easier` option group. When enabled, all nine area maps are precollected at generation time and removed from the randomized item pool (replaced with filler), so the player begins with every map already acquired (Issue #584).
 - Fix missing boss-defeat LocationChecks when the matching shard is already owned by adding a conservative client fallback: rising-edge bits from `boss_mirror_table_native` byte 0 (bits 0-7) now backfill boss checks when `boss_defeat_flags` is absent for that fight (Issue #573).
-- Extend the unswallowable-enemy exclusion list for copy-ability randomization to include `JACK`, `SQUISHY`, `BLOCKIN`, `GORDO`, and `MIRRA` (in addition to the existing `GLUNK`, `SCARFY`, `SHOTZO`), preventing potential no-ability lockouts from all non-inhalable enemies (Issue #570).
-- Move unswallowable enemy exclusion policy from a static runtime list into `data/enemies.json` source metadata (`can_be_swallowed`) so exclusions are interpreted directly from enemy data definitions (Issue #570).
+- Move unswallowable enemy exclusion policy from a static runtime list into `data/enemies.json` source metadata (`can_be_swallowed`) and extend exclusions to include `JACK`, `SQUISHY`, `BLOCKIN`, `GORDO`, and `MIRRA` (with existing `GLUNK`, `SCARFY`, `SHOTZO`) so all known non-inhalable enemies are represented by data-driven definitions (Issue #570).
 - Hide additional KirbyAM reconnect/resend diagnostics from the live client output unless `Enable Debug Logging` is enabled, while still writing those diagnostics to log files unconditionally (`NoStream`-filtered stream suppression only); includes watcher transport reconnect messages and resend diagnostics for boss/major/vitality/sound-player LocationChecks polling (Issue #582).
 
 ## v0.1.2

--- a/worlds/kirbyam/data/enemies.json
+++ b/worlds/kirbyam/data/enemies.json
@@ -103,7 +103,8 @@
     "addresses": [
       "0x351696"
     ],
-    "default_ability": "Normal"
+    "default_ability": "Normal",
+    "can_be_swallowed": false
   },
   "HALEY": {
     "kind": "enemy",
@@ -131,7 +132,8 @@
     "addresses": [
       "0x3517CE"
     ],
-    "default_ability": "Normal"
+    "default_ability": "Normal",
+    "can_be_swallowed": false
   },
   "LASER_BALL": {
     "kind": "enemy",
@@ -236,7 +238,8 @@
     "addresses": [
       "0x3516AE"
     ],
-    "default_ability": "Normal"
+    "default_ability": "Normal",
+    "can_be_swallowed": false
   },
   "SWORD_KNIGHT": {
     "kind": "enemy",

--- a/worlds/kirbyam/enemy_ability_data.py
+++ b/worlds/kirbyam/enemy_ability_data.py
@@ -86,7 +86,12 @@ for source_key, raw_entry in _ENEMY_DATA.items():
     if kind not in {"enemy", "miniboss", "boss_spawned"}:
         raise ValueError(f"enemy source {source_key} has unsupported kind: {kind}")
 
-    can_be_swallowed = bool(raw_entry.get("can_be_swallowed", True))
+    can_be_swallowed_raw = raw_entry.get("can_be_swallowed", True)
+    if not isinstance(can_be_swallowed_raw, bool):
+        raise ValueError(
+            f"enemy source {source_key} field can_be_swallowed must be a boolean"
+        )
+    can_be_swallowed = can_be_swallowed_raw
 
     addresses_raw = raw_entry.get("addresses")
     if not isinstance(addresses_raw, list) or not addresses_raw:

--- a/worlds/kirbyam/enemy_ability_data.py
+++ b/worlds/kirbyam/enemy_ability_data.py
@@ -15,6 +15,7 @@ class AbilitySource:
     default_ability_name: str
     default_ability_id: int
     kind: str  # enemy | miniboss | boss_spawned
+    can_be_swallowed: bool = True
 
 
 def _load_json_file(filename: str) -> dict[str, Any]:
@@ -85,6 +86,8 @@ for source_key, raw_entry in _ENEMY_DATA.items():
     if kind not in {"enemy", "miniboss", "boss_spawned"}:
         raise ValueError(f"enemy source {source_key} has unsupported kind: {kind}")
 
+    can_be_swallowed = bool(raw_entry.get("can_be_swallowed", True))
+
     addresses_raw = raw_entry.get("addresses")
     if not isinstance(addresses_raw, list) or not addresses_raw:
         raise ValueError(f"enemy source {source_key} must include non-empty addresses")
@@ -105,6 +108,7 @@ for source_key, raw_entry in _ENEMY_DATA.items():
             default_ability_name=default_ability_name,
             default_ability_id=ABILITY_NAME_TO_ID[default_ability_name],
             kind=kind,
+            can_be_swallowed=can_be_swallowed,
         )
     )
 

--- a/worlds/kirbyam/enemy_ability_runtime_patch.py
+++ b/worlds/kirbyam/enemy_ability_runtime_patch.py
@@ -30,16 +30,6 @@ from .enemy_ability_data import (
 from .options import AbilityRandomizationMode
 
 _MISSING_RUNTIME_ABILITY_NAMES = set(VALID_ENEMY_COPY_ABILITIES) - set(ABILITY_NAME_TO_ID)
-_UNSWALLOWABLE_ENEMY_SOURCE_KEYS = frozenset({
-    "BLOCKIN",
-    "GLUNK",
-    "GORDO",
-    "JACK",
-    "MIRRA",
-    "SCARFY",
-    "SHOTZO",
-    "SQUISHY",
-})
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +87,7 @@ def build_enemy_copy_runtime_patch_writes(policy: dict[str, Any]) -> dict[int, i
         if source.default_ability_id == 0 and not randomize_non_ability:
             continue
 
-        if source.kind == "enemy" and source.key in _UNSWALLOWABLE_ENEMY_SOURCE_KEYS:
+        if source.kind == "enemy" and not source.can_be_swallowed:
             excluded_unswallowable_sources.add(source.key)
             continue
         if not _is_source_enabled(source, policy):

--- a/worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py
@@ -248,6 +248,7 @@ def test_completely_random_mapping_is_stable_when_skipped_zero_id_sources_are_ad
         default_ability_name="Normal",
         default_ability_id=0,
         kind="enemy",
+        can_be_swallowed=True,
     )
     monkeypatch.setattr(
         runtime_patch_module,
@@ -340,3 +341,33 @@ def test_unswallowable_enemy_exclusion_is_logged(caplog) -> None:
         and "SQUISHY" in message
         for message in caplog.messages
     )
+
+
+def test_unswallowable_enemy_exclusion_uses_source_metadata(monkeypatch) -> None:
+    policy = build_enemy_copy_ability_policy(
+        random.Random(20260404),
+        AbilityRandomizationMode.option_shuffled,
+        include_boss_spawns=True,
+        include_minibosses=True,
+        include_passive_enemies=True,
+        no_ability_weight=0,
+    )
+
+    injected_source = AbilitySource(
+        key="TEST_UNSWALLOWABLE",
+        addresses=(0x35FFEE,),
+        default_ability_name="Beam",
+        default_ability_id=5,
+        kind="enemy",
+        can_be_swallowed=False,
+    )
+
+    monkeypatch.setattr(
+        runtime_patch_module,
+        "ABILITY_SOURCES",
+        (injected_source,) + runtime_patch_module.ABILITY_SOURCES,
+    )
+
+    writes = build_enemy_copy_runtime_patch_writes(policy)
+
+    assert 0x35FFEE not in writes


### PR DESCRIPTION
## Summary
- move unswallowable enemy exclusions from a hardcoded list in runtime patch code to per-source metadata in `worlds/kirbyam/data/enemies.json`
- add `can_be_swallowed` to the enemy ability source data model and consume it when building runtime writes
- keep existing exclusion logging behavior and add regression coverage proving exclusion is metadata-driven
- update KirbyAM changelog for Issue #570

## Validation
- `python3 -m pytest -q worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py`

Closes #570 