### PR TITLE
Fix build.py prompts for missing required inputs

### DIFF
--- a/.github/workflows/kirbyam-apworld.yml
+++ b/.github/workflows/kirbyam-apworld.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build kirbyam.apworld from source
         run: |
-          python worlds/kirbyam/build.py --skip-patch --skip-install
+          python worlds/kirbyam/build.py --skip-patch --skip-install --non-interactive
           if [ ! -f worlds/kirbyam/kirbyam.apworld ]; then
             echo "kirbyam.apworld was not created" >&2
             exit 1

--- a/.github/workflows/kirbyam-rom-patch-smoke.yml
+++ b/.github/workflows/kirbyam-rom-patch-smoke.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build payload and generate ROM patch
         run: |
-          python worlds/kirbyam/build.py --source-type arg --rom "$PWD/worlds/kirbyam/kirby_ap_payload/kirby.gba" --skip-install
+          python worlds/kirbyam/build.py --source-type arg --rom "$PWD/worlds/kirbyam/kirby_ap_payload/kirby.gba" --skip-install --non-interactive
 
       - name: Validate expected outputs exist
         run: |

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improve `worlds/kirbyam/build.py` usability for non-author machines by prompting for missing required patch inputs in interactive runs (including missing `--rom` when `--source-type arg` is selected), adding `--source-type file` fallback guidance when `rom_path.tmp` is invalid, and introducing `--non-interactive` fail-fast behavior for automation/CI (Issue #607).
 - Add 15 decomp-aligned world-map big-switch AP checks (`HUB_SWITCH_*`) with a dedicated ROM transport register (`hub_switch_flags` at `0x0203B04C`), BizHawk resend/dedupe polling, payload hook integration at the world-map unlock dispatcher callsite (`sub_08039ED4`), protocol/address contract updates, and regression coverage for data/polling/patch offsets/region binding (Issue #481).
 - Expand tracker integration surface by exporting all locations, all rooms (including those outside Room Sanity), and all received unique items via expanded KirbyAM `slot_data` for use in tracker templates and generic player/multiworld trackers (Issue #114).
 - Expose all configured KirbyAM seed options in `slot_data` (including `start_with_all_maps` and `enable_debug_logging`) so tracker surfaces can render the exact seed configuration from slot data without inferring from partial fields (Issue #114).

--- a/worlds/kirbyam/build.py
+++ b/worlds/kirbyam/build.py
@@ -254,7 +254,109 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip copying the built .apworld into the Archipelago custom_worlds directory.",
     )
+    p.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Disable interactive prompts; fail fast when required inputs are missing.",
+    )
     return p.parse_args()
+
+
+def _can_prompt(non_interactive: bool) -> bool:
+    if non_interactive:
+        return False
+
+    stdin = getattr(sys, "stdin", None)
+    stdout = getattr(sys, "stdout", None)
+    return bool(
+        stdin is not None
+        and stdout is not None
+        and stdin.isatty()
+        and stdout.isatty()
+    )
+
+
+def _prompt_yes_no(prompt: str, *, default: bool) -> bool:
+    suffix = " [Y/n]: " if default else " [y/N]: "
+    while True:
+        raw = input(prompt + suffix).strip().lower()
+        if not raw:
+            return default
+        if raw in {"y", "yes"}:
+            return True
+        if raw in {"n", "no"}:
+            return False
+        print("Please enter 'y' or 'n'.")
+
+
+def _prompt_existing_file(prompt: str) -> str:
+    while True:
+        raw = input(prompt).strip().strip('"')
+        if not raw:
+            print("A file path is required.")
+            continue
+
+        candidate = Path(raw).expanduser()
+        if candidate.is_file():
+            return str(candidate.resolve())
+
+        print(f"File not found: {candidate}")
+
+
+def _prepare_args_for_patch(args: argparse.Namespace, world_root: Path) -> argparse.Namespace:
+    can_prompt = _can_prompt(bool(args.non_interactive))
+
+    if args.source_type == "arg":
+        if args.rom:
+            rom_candidate = Path(args.rom).expanduser()
+            if not rom_candidate.is_file():
+                if not can_prompt:
+                    raise SystemExit(
+                        "--rom must point to an existing base ROM file when using --source-type arg."
+                    )
+                print(f"Provided ROM path does not exist: {rom_candidate}")
+                args.rom = _prompt_existing_file("Enter path to the base ROM (.gba): ")
+            else:
+                args.rom = str(rom_candidate.resolve())
+        else:
+            if not can_prompt:
+                raise SystemExit(
+                    "You selected --source-type arg but did not provide --rom <path>. "
+                    "Run interactively to be prompted, or pass --rom explicitly."
+                )
+            print("--source-type arg requires a base ROM path.")
+            args.rom = _prompt_existing_file("Enter path to the base ROM (.gba): ")
+
+    elif not args.skip_patch and args.source_type == "file":
+        rom_path_tmp = world_root / "kirby_ap_payload" / "rom_path.tmp"
+        rom_path_text = ""
+        if rom_path_tmp.exists():
+            try:
+                rom_path_text = rom_path_tmp.read_text(encoding="utf-8").strip().strip('"')
+            except OSError:
+                rom_path_text = ""
+
+        rom_path_ok = bool(rom_path_text) and Path(rom_path_text).expanduser().is_file()
+        if not rom_path_ok:
+            guidance = (
+                "--source-type file requires kirby_ap_payload/rom_path.tmp to contain a valid ROM path. "
+                "Use --source-type arg --rom <path> instead."
+            )
+            if not can_prompt:
+                # Keep existing non-interactive behavior for automation and tests:
+                # patch_rom.py remains the source of truth for file-source failures.
+                return args
+
+            print(
+                "Could not find a valid ROM path in kirby_ap_payload/rom_path.tmp."
+            )
+            if _prompt_yes_no("Switch to --source-type arg and enter a ROM path now?", default=True):
+                args.source_type = "arg"
+                args.rom = _prompt_existing_file("Enter path to the base ROM (.gba): ")
+            else:
+                print(guidance)
+
+    return args
 
 
 def main() -> None:
@@ -265,6 +367,7 @@ def main() -> None:
         raise SystemExit("World name must be lowercase.")
 
     world_root = Path(__file__).resolve().parent
+    args = _prepare_args_for_patch(args, world_root)
 
     if Path.cwd().resolve() != world_root:
         print(f"Using world root from script location: {world_root}")

--- a/worlds/kirbyam/build.py
+++ b/worlds/kirbyam/build.py
@@ -291,7 +291,7 @@ def _prompt_yes_no(prompt: str, *, default: bool) -> bool:
 
 def _prompt_existing_file(prompt: str) -> str:
     while True:
-        raw = input(prompt).strip().strip('"')
+        raw = input(prompt).strip().strip("'\"")
         if not raw:
             print("A file path is required.")
             continue

--- a/worlds/kirbyam/build.py
+++ b/worlds/kirbyam/build.py
@@ -304,6 +304,9 @@ def _prompt_existing_file(prompt: str) -> str:
 
 
 def _prepare_args_for_patch(args: argparse.Namespace, world_root: Path) -> argparse.Namespace:
+    if args.skip_patch:
+        return args
+
     can_prompt = _can_prompt(bool(args.non_interactive))
 
     if args.source_type == "arg":
@@ -332,11 +335,17 @@ def _prepare_args_for_patch(args: argparse.Namespace, world_root: Path) -> argpa
         rom_path_text = ""
         if rom_path_tmp.exists():
             try:
-                rom_path_text = rom_path_tmp.read_text(encoding="utf-8").strip().strip('"')
+                rom_path_text = rom_path_tmp.read_text(encoding="utf-8").strip().strip("'\"")
             except OSError:
                 rom_path_text = ""
 
-        rom_path_ok = bool(rom_path_text) and Path(rom_path_text).expanduser().is_file()
+        rom_path_ok = False
+        if rom_path_text:
+            rom_candidate = Path(rom_path_text).expanduser()
+            if not rom_candidate.is_absolute():
+                rom_candidate = rom_path_tmp.parent / rom_candidate
+            rom_path_ok = rom_candidate.is_file()
+
         if not rom_path_ok:
             guidance = (
                 "--source-type file requires kirby_ap_payload/rom_path.tmp to contain a valid ROM path. "

--- a/worlds/kirbyam/build.py
+++ b/worlds/kirbyam/build.py
@@ -330,7 +330,7 @@ def _prepare_args_for_patch(args: argparse.Namespace, world_root: Path) -> argpa
             print("--source-type arg requires a base ROM path.")
             args.rom = _prompt_existing_file("Enter path to the base ROM (.gba): ")
 
-    elif not args.skip_patch and args.source_type == "file":
+    elif args.source_type == "file":
         rom_path_tmp = world_root / "kirby_ap_payload" / "rom_path.tmp"
         rom_path_text = ""
         if rom_path_tmp.exists():

--- a/worlds/kirbyam/docs/dev-docs/kirbyam-world-architecture-notes.md
+++ b/worlds/kirbyam/docs/dev-docs/kirbyam-world-architecture-notes.md
@@ -601,6 +601,8 @@ Important details:
 - it can skip patch rebuild with `--skip-patch`
 - it installs the `.apworld` into Archipelago's custom worlds directory by default on Windows
 - it packages the world in place without a staging directory
+- when required patch inputs are missing, it prompts interactively (for example, missing `--rom` with `--source-type arg`)
+- automation can disable prompts with `--non-interactive` so CI fails fast with actionable messages
 
 So the world's distributable artifact is the `.apworld`, while the player's actual game artifact is the `.apkirbyam` patch generated from world output.
 

--- a/worlds/kirbyam/test/test_build_tooling_negative.py
+++ b/worlds/kirbyam/test/test_build_tooling_negative.py
@@ -247,3 +247,37 @@ def test_prepare_args_file_source_prompts_for_arg_fallback(tmp_path: Path, monke
     prepared = build_mod._prepare_args_for_patch(args, tmp_path)
     assert prepared.source_type == "arg"
     assert prepared.rom == str(rom_path)
+
+
+def test_prepare_args_skip_patch_does_not_require_rom(tmp_path: Path) -> None:
+    args = build_mod.argparse.Namespace(
+        source_type="arg",
+        rom=None,
+        skip_patch=True,
+        non_interactive=True,
+    )
+
+    prepared = build_mod._prepare_args_for_patch(args, tmp_path)
+    assert prepared.rom is None
+
+
+def test_prepare_args_file_source_accepts_relative_rom_path_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload_dir = tmp_path / "kirby_ap_payload"
+    payload_dir.mkdir()
+    rom_path = payload_dir / "base.gba"
+    rom_path.write_bytes(b"rom")
+    (payload_dir / "rom_path.tmp").write_text("'base.gba'\n", encoding="utf-8")
+
+    args = build_mod.argparse.Namespace(
+        source_type="file",
+        rom=None,
+        skip_patch=False,
+        non_interactive=True,
+    )
+
+    # Non-interactive mode should accept valid rom_path.tmp without prompting/fallback.
+    monkeypatch.setattr(build_mod, "_can_prompt", lambda _non_interactive: False)
+
+    prepared = build_mod._prepare_args_for_patch(args, tmp_path)
+    assert prepared.source_type == "file"
+    assert prepared.rom is None

--- a/worlds/kirbyam/test/test_build_tooling_negative.py
+++ b/worlds/kirbyam/test/test_build_tooling_negative.py
@@ -226,6 +226,37 @@ def test_prepare_args_non_interactive_missing_rom_fails(tmp_path: Path) -> None:
     assert "did not provide --rom" in str(exc_info.value)
 
 
+def test_prepare_args_non_interactive_invalid_rom_fails(tmp_path: Path) -> None:
+    args = build_mod.argparse.Namespace(
+        source_type="arg",
+        rom=str(tmp_path / "missing.gba"),
+        skip_patch=False,
+        non_interactive=True,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod._prepare_args_for_patch(args, tmp_path)
+    assert "must point to an existing base ROM file" in str(exc_info.value)
+
+
+def test_prepare_args_interactive_invalid_rom_repompts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    valid_rom = tmp_path / "valid.gba"
+    valid_rom.write_bytes(b"rom")
+
+    args = build_mod.argparse.Namespace(
+        source_type="arg",
+        rom=str(tmp_path / "missing.gba"),
+        skip_patch=False,
+        non_interactive=False,
+    )
+
+    monkeypatch.setattr(build_mod, "_can_prompt", lambda _non_interactive: True)
+    monkeypatch.setattr(build_mod, "_prompt_existing_file", lambda _prompt: str(valid_rom))
+
+    prepared = build_mod._prepare_args_for_patch(args, tmp_path)
+    assert prepared.rom == str(valid_rom)
+
+
 def test_prepare_args_file_source_prompts_for_arg_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     payload_dir = tmp_path / "kirby_ap_payload"
     payload_dir.mkdir()

--- a/worlds/kirbyam/test/test_build_tooling_negative.py
+++ b/worlds/kirbyam/test/test_build_tooling_negative.py
@@ -191,3 +191,59 @@ def test_build_main_still_fails_when_make_missing_and_no_existing_patch(tmp_path
         build_mod.__file__ = orig_file
         os.chdir(orig_cwd)
         sys.argv = orig_argv
+
+
+# ── interactive argument preparation ─────────────────────────────────────────
+
+def test_prepare_args_prompts_for_missing_rom_when_source_type_arg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    rom_path = tmp_path / "base.gba"
+    rom_path.write_bytes(b"rom")
+
+    args = build_mod.argparse.Namespace(
+        source_type="arg",
+        rom=None,
+        skip_patch=False,
+        non_interactive=False,
+    )
+
+    monkeypatch.setattr(build_mod, "_can_prompt", lambda _non_interactive: True)
+    monkeypatch.setattr(build_mod, "_prompt_existing_file", lambda _prompt: str(rom_path))
+
+    prepared = build_mod._prepare_args_for_patch(args, tmp_path)
+    assert prepared.rom == str(rom_path)
+
+
+def test_prepare_args_non_interactive_missing_rom_fails(tmp_path: Path) -> None:
+    args = build_mod.argparse.Namespace(
+        source_type="arg",
+        rom=None,
+        skip_patch=False,
+        non_interactive=True,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_mod._prepare_args_for_patch(args, tmp_path)
+    assert "did not provide --rom" in str(exc_info.value)
+
+
+def test_prepare_args_file_source_prompts_for_arg_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload_dir = tmp_path / "kirby_ap_payload"
+    payload_dir.mkdir()
+
+    rom_path = tmp_path / "fallback.gba"
+    rom_path.write_bytes(b"rom")
+
+    args = build_mod.argparse.Namespace(
+        source_type="file",
+        rom=None,
+        skip_patch=False,
+        non_interactive=False,
+    )
+
+    monkeypatch.setattr(build_mod, "_can_prompt", lambda _non_interactive: True)
+    monkeypatch.setattr(build_mod, "_prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(build_mod, "_prompt_existing_file", lambda _prompt: str(rom_path))
+
+    prepared = build_mod._prepare_args_for_patch(args, tmp_path)
+    assert prepared.source_type == "arg"
+    assert prepared.rom == str(rom_path)


### PR DESCRIPTION
## Summary
- add interactive prompting for missing required patch inputs in worlds/kirbyam/build.py
- add --non-interactive to fail fast in automation when required args are missing
- add fallback guidance when --source-type file cannot resolve a valid om_path.tmp
- add/extend negative-path tests for interactive argument preparation
- document behavior in KirbyAM dev docs and changelog

## Testing
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_build_tooling_negative.py -q

Fixes #607