### PR TITLE
Fix missing warp room-sanity checks

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -23,8 +23,10 @@ Contract for `## Unreleased` and all post-public `## v...` sections:
 
 ### Bug Fixes
 
+- Restore room-sanity coverage for designed warp rooms by re-enabling their `room_sanity` metadata mappings (Issue #605).
 - Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).
-- Prevent skipped in-game item delivery when stale `debug_item_counter` values jump ahead of the client cursor by only trusting forward counter reconciliation for pending mailbox ACKs (`incoming_item_flag == 0` while a delivery is pending), while keeping rewind recovery for true counter rollback. Also ensure delivery diagnostics gated by `enable_debug_logging` are still written to log files and only hidden from the live client stream via `NoStream` (Issue #601).
+- Prevent skipped in-game item delivery when stale `debug_item_counter` values jump ahead of the client cursor by only trusting forward counter reconciliation for pending mailbox ACKs (`incoming_item_flag == 0` while a delivery is pending), while keeping rewind recovery for true counter rollback.
+- Ensure delivery diagnostics gated by `enable_debug_logging` are still written to log files and only hidden from the live client stream via `NoStream` (Issue #601).
 - Harden vitality delivery against transition/reset replay by clamping native vitality counter grants to the shipped AP vitality item cardinality (4), and in `one_hit_mode=exclude_vitality_counters` scrub native vitality back to `0` during gameplay so vitality receipts cannot persist in that mode (Issue #571).
 - Fix missing boss-defeat LocationChecks when the matching shard is already owned by adding a conservative client fallback: rising-edge bits from `boss_mirror_table_native` byte 0 (bits 0-7) now backfill boss checks when `boss_defeat_flags` is absent for that fight (Issue #573).
 - Hide additional KirbyAM reconnect/resend diagnostics from the live client output unless `Enable Debug Logging` is enabled, while still writing those diagnostics to log files unconditionally (`NoStream`-filtered stream suppression only); includes watcher transport reconnect messages and resend diagnostics for boss/major/vitality/sound-player LocationChecks polling (Issue #582).

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -172,7 +172,7 @@ Server → Client: ConnectionRefused | Connected
 - `ability_randomization_minny` (bool): include/exclude Minny from enemy copy-ability randomization.
 - `ability_randomization_passive_enemies` (bool): when true, enemies that natively grant no ability participate in copy-ability randomization. Default: `true`.
 - `ability_randomization_no_ability_weight` (int): percentage chance from `0` to `100` that an included randomized enemy grant resolves to no ability instead of a copy ability. Default: `55`.
-- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 257 checks).
+- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 263 checks).
 - `enable_debug_logging` (bool): enables/disables debug-level client diagnostics.
 - `enemy_copy_ability_whitelist` (list[str]): validated ability pool (must exclude `Wait`).
 - `enemy_copy_ability_policy` (dict): deterministic policy payload used by runtime hooks.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -145,7 +145,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_MOONLIGHT .. HUB_SWITCH_CANDY | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 |
-| ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-YY`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
+| ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 
 ## Client Protocol

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -145,7 +145,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_MOONLIGHT .. HUB_SWITCH_CANDY | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 |
-| ROOM_SANITY_1_01 .. ROOM_SANITY_9_27 | 3961000+ | Room visit checks (`Room X-YY`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15 |
+| ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-YY`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 
 ## Client Protocol
@@ -172,7 +172,7 @@ Server → Client: ConnectionRefused | Connected
 - `ability_randomization_minny` (bool): include/exclude Minny from enemy copy-ability randomization.
 - `ability_randomization_passive_enemies` (bool): when true, enemies that natively grant no ability participate in copy-ability randomization. Default: `true`.
 - `ability_randomization_no_ability_weight` (int): percentage chance from `0` to `100` that an included randomized enemy grant resolves to no ability instead of a copy ability. Default: `55`.
-- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 257 checks).
+- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 263 checks).
 - `enable_debug_logging` (bool): enables/disables debug-level client diagnostics.
 - `enemy_copy_ability_whitelist` (list[str]): validated ability pool (must exclude `Wait`).
 - `enemy_copy_ability_policy` (dict): deterministic policy payload used by runtime hooks.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -172,7 +172,7 @@ Server → Client: ConnectionRefused | Connected
 - `ability_randomization_minny` (bool): include/exclude Minny from enemy copy-ability randomization.
 - `ability_randomization_passive_enemies` (bool): when true, enemies that natively grant no ability participate in copy-ability randomization. Default: `true`.
 - `ability_randomization_no_ability_weight` (int): percentage chance from `0` to `100` that an included randomized enemy grant resolves to no ability instead of a copy ability. Default: `55`.
-- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 263 checks).
+- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 257 checks).
 - `enable_debug_logging` (bool): enables/disables debug-level client diagnostics.
 - `enemy_copy_ability_whitelist` (list[str]): validated ability pool (must exclude `Wait`).
 - `enemy_copy_ability_policy` (dict): deterministic policy payload used by runtime hooks.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -172,7 +172,7 @@ Server → Client: ConnectionRefused | Connected
 - `ability_randomization_minny` (bool): include/exclude Minny from enemy copy-ability randomization.
 - `ability_randomization_passive_enemies` (bool): when true, enemies that natively grant no ability participate in copy-ability randomization. Default: `true`.
 - `ability_randomization_no_ability_weight` (int): percentage chance from `0` to `100` that an included randomized enemy grant resolves to no ability instead of a copy ability. Default: `55`.
-- `room_sanity` (bool): enables/disables room-visit locations (`Room X-YY`, 263 checks).
+- `room_sanity` (bool): enables/disables room-visit locations (`Room X-<room code>`, 263 checks).
 - `enable_debug_logging` (bool): enables/disables debug-level client diagnostics.
 - `enemy_copy_ability_whitelist` (list[str]): validated ability pool (must exclude `Wait`).
 - `enemy_copy_ability_policy` (dict): deterministic policy payload used by runtime hooks.

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -132,8 +132,8 @@
     ],
     "room_sanity": {
       "included": true,
-      "location_id": 3961008,
-      "bit_index": 17
+      "location_id": 3961257,
+      "bit_index": 30
     },
     "ability_gates": {}
   },
@@ -752,9 +752,9 @@
       "REGION_RAINBOW_ROUTE/ROOM_1_09"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961008,
+      "bit_index": 17
     },
     "ability_gates": {}
   },
@@ -857,8 +857,8 @@
     ],
     "room_sanity": {
       "included": true,
-      "location_id": 3961056,
-      "bit_index": 65
+      "location_id": 3961258,
+      "bit_index": 69
     },
     "ability_gates": {}
   },
@@ -1177,9 +1177,9 @@
       "REGION_OLIVE_OCEAN/ROOM_6_14"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961056,
+      "bit_index": 65
     },
     "ability_gates": {}
   },
@@ -1561,8 +1561,8 @@
     ],
     "room_sanity": {
       "included": true,
-      "location_id": 3961102,
-      "bit_index": 123
+      "location_id": 3961259,
+      "bit_index": 134
     },
     "ability_gates": {}
   },
@@ -1700,9 +1700,9 @@
       "REGION_MUSTARD_MOUNTAIN/ROOM_4_CHEST"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961102,
+      "bit_index": 123
     },
     "ability_gates": {}
   },
@@ -1924,8 +1924,8 @@
     ],
     "room_sanity": {
       "included": true,
-      "location_id": 3961125,
-      "bit_index": 252
+      "location_id": 3961260,
+      "bit_index": 269
     },
     "ability_gates": {}
   },
@@ -2016,9 +2016,9 @@
       "REGION_RAINBOW_ROUTE/ROOM_1_09"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961125,
+      "bit_index": 252
     },
     "ability_gates": {}
   },
@@ -2699,9 +2699,9 @@
       "REGION_PEPPERMINT_PALACE/ROOM_7_05"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961178,
+      "bit_index": 92
     },
     "ability_gates": {}
   },
@@ -2744,8 +2744,8 @@
     ],
     "room_sanity": {
       "included": true,
-      "location_id": 3961178,
-      "bit_index": 92
+      "location_id": 3961261,
+      "bit_index": 101
     },
     "ability_gates": {}
   },
@@ -3668,8 +3668,8 @@
     ],
     "room_sanity": {
       "included": true,
-      "location_id": 3961237,
-      "bit_index": 149
+      "location_id": 3961262,
+      "bit_index": 153
     },
     "ability_gates": {}
   },
@@ -3784,9 +3784,9 @@
       "REGION_CANDY_CONSTELLATION/ROOM_9_HUB"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961237,
+      "bit_index": 149
     },
     "ability_gates": {}
   },

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -752,9 +752,9 @@
       "REGION_RAINBOW_ROUTE/ROOM_1_09"
     ],
     "room_sanity": {
-      "included": true,
-      "location_id": 3961008,
-      "bit_index": 17
+      "included": false,
+      "location_id": null,
+      "bit_index": null
     },
     "ability_gates": {}
   },
@@ -1177,9 +1177,9 @@
       "REGION_OLIVE_OCEAN/ROOM_6_14"
     ],
     "room_sanity": {
-      "included": true,
-      "location_id": 3961056,
-      "bit_index": 65
+      "included": false,
+      "location_id": null,
+      "bit_index": null
     },
     "ability_gates": {}
   },
@@ -1700,9 +1700,9 @@
       "REGION_MUSTARD_MOUNTAIN/ROOM_4_CHEST"
     ],
     "room_sanity": {
-      "included": true,
-      "location_id": 3961102,
-      "bit_index": 123
+      "included": false,
+      "location_id": null,
+      "bit_index": null
     },
     "ability_gates": {}
   },
@@ -2016,9 +2016,9 @@
       "REGION_RAINBOW_ROUTE/ROOM_1_09"
     ],
     "room_sanity": {
-      "included": true,
-      "location_id": 3961125,
-      "bit_index": 252
+      "included": false,
+      "location_id": null,
+      "bit_index": null
     },
     "ability_gates": {}
   },
@@ -2699,9 +2699,9 @@
       "REGION_PEPPERMINT_PALACE/ROOM_7_05"
     ],
     "room_sanity": {
-      "included": true,
-      "location_id": 3961178,
-      "bit_index": 92
+      "included": false,
+      "location_id": null,
+      "bit_index": null
     },
     "ability_gates": {}
   },
@@ -3784,9 +3784,9 @@
       "REGION_CANDY_CONSTELLATION/ROOM_9_HUB"
     ],
     "room_sanity": {
-      "included": true,
-      "location_id": 3961237,
-      "bit_index": 149
+      "included": false,
+      "location_id": null,
+      "bit_index": null
     },
     "ability_gates": {}
   },

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -131,9 +131,9 @@
       "REGION_RAINBOW_ROUTE/ROOM_1_13"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961008,
+      "bit_index": 17
     },
     "ability_gates": {}
   },
@@ -856,9 +856,9 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_HUB"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961056,
+      "bit_index": 65
     },
     "ability_gates": {}
   },
@@ -1560,9 +1560,9 @@
       "REGION_MUSTARD_MOUNTAIN/ROOM_4_CHEST"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961102,
+      "bit_index": 123
     },
     "ability_gates": {}
   },
@@ -1923,9 +1923,9 @@
       "REGION_CARROT_CASTLE/ROOM_5_13"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961125,
+      "bit_index": 252
     },
     "ability_gates": {}
   },
@@ -2743,9 +2743,9 @@
       "REGION_PEPPERMINT_PALACE/ROOM_7_04"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961178,
+      "bit_index": 92
     },
     "ability_gates": {}
   },
@@ -3667,9 +3667,9 @@
       "REGION_CANDY_CONSTELLATION/ROOM_9_GOAL_2"
     ],
     "room_sanity": {
-      "included": false,
-      "location_id": null,
-      "bit_index": null
+      "included": true,
+      "location_id": 3961237,
+      "bit_index": 149
     },
     "ability_gates": {}
   },

--- a/worlds/kirbyam/docs/dev-docs/kirbyam-game-notes.md
+++ b/worlds/kirbyam/docs/dev-docs/kirbyam-game-notes.md
@@ -398,7 +398,7 @@ Primary local evidence:
 
 Canonical totals from rooms.json:
 - Total room nodes represented: 287
-- Room-sanity included nodes: 257
+- Room-sanity included nodes: 263
 - Room-sanity excluded nodes: 30
 
 Room nodes by region prefix:

--- a/worlds/kirbyam/docs/dev-docs/kirbyam-game-notes.md
+++ b/worlds/kirbyam/docs/dev-docs/kirbyam-game-notes.md
@@ -398,8 +398,8 @@ Primary local evidence:
 
 Canonical totals from rooms.json:
 - Total room nodes represented: 287
-- Room-sanity included nodes: 257
-- Room-sanity excluded nodes: 30
+- Room-sanity included nodes: 263
+- Room-sanity excluded nodes: 24
 
 Room nodes by region prefix:
 - Rainbow Route: 51

--- a/worlds/kirbyam/docs/dev-docs/kirbyam-game-notes.md
+++ b/worlds/kirbyam/docs/dev-docs/kirbyam-game-notes.md
@@ -398,8 +398,8 @@ Primary local evidence:
 
 Canonical totals from rooms.json:
 - Total room nodes represented: 287
-- Room-sanity included nodes: 263
-- Room-sanity excluded nodes: 24
+- Room-sanity included nodes: 257
+- Room-sanity excluded nodes: 30
 
 Room nodes by region prefix:
 - Rainbow Route: 51

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -217,7 +217,7 @@ StartingKirbyColor = _build_starting_kirby_color_option()
 
 
 class RoomSanity(Toggle):
-    """Adds room-visit checks (Room X-YY). Off by default because it adds 263 locations."""
+    """Adds room-visit checks (for example, `Room X-*`). Off by default because it adds 263 locations."""
     display_name = "Room Sanity"
     default = 0
 

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -217,7 +217,7 @@ StartingKirbyColor = _build_starting_kirby_color_option()
 
 
 class RoomSanity(Toggle):
-    """Adds room-visit checks (Room X-YY). Off by default because it adds 257 locations."""
+    """Adds room-visit checks (Room X-YY). Off by default because it adds 263 locations."""
     display_name = "Room Sanity"
     default = 0
 

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -217,7 +217,7 @@ StartingKirbyColor = _build_starting_kirby_color_option()
 
 
 class RoomSanity(Toggle):
-    """Adds room-visit checks (Room X-YY). Off by default because it adds 263 locations."""
+    """Adds room-visit checks (Room X-YY). Off by default because it adds 257 locations."""
     display_name = "Room Sanity"
     default = 0
 

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -759,7 +759,7 @@
     "ROOM_SANITY_1_WARP": {
       "category": "ROOM_SANITY",
       "label": "Room 1-WARP",
-      "location_id": 3961008,
+      "location_id": 3961257,
       "tags": [
         "RoomSanity"
       ]
@@ -959,7 +959,7 @@
     "ROOM_SANITY_2_WARP": {
       "category": "ROOM_SANITY",
       "label": "Room 2-WARP",
-      "location_id": 3961056,
+      "location_id": 3961258,
       "tags": [
         "RoomSanity"
       ]
@@ -1319,7 +1319,7 @@
     "ROOM_SANITY_4_WARP": {
       "category": "ROOM_SANITY",
       "label": "Room 4-WARP",
-      "location_id": 3961102,
+      "location_id": 3961259,
       "tags": [
         "RoomSanity"
       ]
@@ -1495,7 +1495,7 @@
     "ROOM_SANITY_5_WARP": {
       "category": "ROOM_SANITY",
       "label": "Room 5-WARP",
-      "location_id": 3961125,
+      "location_id": 3961260,
       "tags": [
         "RoomSanity"
       ]
@@ -1967,7 +1967,7 @@
     "ROOM_SANITY_7_WARP": {
       "category": "ROOM_SANITY",
       "label": "Room 7-WARP",
-      "location_id": 3961178,
+      "location_id": 3961261,
       "tags": [
         "RoomSanity"
       ]
@@ -2415,7 +2415,7 @@
     "ROOM_SANITY_9_WARP": {
       "category": "ROOM_SANITY",
       "label": "Room 9-WARP",
-      "location_id": 3961237,
+      "location_id": 3961262,
       "tags": [
         "RoomSanity"
       ]
@@ -2943,7 +2943,7 @@
       ],
       "label": "REGION_CANDY_CONSTELLATION/ROOM_9_WARP",
       "parent_region": "REGION_CANDY_CONSTELLATION",
-      "room_sanity_location_id": 3961237
+      "room_sanity_location_id": 3961262
     },
     "REGION_CARROT_CASTLE/ROOM_5_01": {
       "exits": [
@@ -3178,7 +3178,7 @@
       ],
       "label": "REGION_CARROT_CASTLE/ROOM_5_WARP",
       "parent_region": "REGION_CARROT_CASTLE",
-      "room_sanity_location_id": 3961125
+      "room_sanity_location_id": 3961260
     },
     "REGION_DIMENSION_MIRROR/ROOM_10_01": {
       "exits": [
@@ -3598,7 +3598,7 @@
       ],
       "label": "REGION_MOONLIGHT_MANSION/ROOM_2_WARP",
       "parent_region": "REGION_MOONLIGHT_MANSION",
-      "room_sanity_location_id": 3961056
+      "room_sanity_location_id": 3961258
     },
     "REGION_MUSTARD_MOUNTAIN/ROOM_4_01": {
       "exits": [
@@ -3845,7 +3845,7 @@
       ],
       "label": "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP",
       "parent_region": "REGION_MUSTARD_MOUNTAIN",
-      "room_sanity_location_id": 3961102
+      "room_sanity_location_id": 3961259
     },
     "REGION_OLIVE_OCEAN/ROOM_6_01": {
       "exits": [
@@ -4432,7 +4432,7 @@
       ],
       "label": "REGION_PEPPERMINT_PALACE/ROOM_7_WARP",
       "parent_region": "REGION_PEPPERMINT_PALACE",
-      "room_sanity_location_id": 3961178
+      "room_sanity_location_id": 3961261
     },
     "REGION_RADISH_RUINS/ROOM_8_01": {
       "exits": [
@@ -5256,7 +5256,7 @@
       ],
       "label": "REGION_RAINBOW_ROUTE/ROOM_1_WARP",
       "parent_region": "REGION_RAINBOW_ROUTE",
-      "room_sanity_location_id": 3961008
+      "room_sanity_location_id": 3961257
     },
     "REGION_TUTORIAL/ROOM_0_01": {
       "exits": [

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -676,6 +676,14 @@
         "RoomSanity"
       ]
     },
+    "ROOM_SANITY_1_40": {
+      "category": "ROOM_SANITY",
+      "label": "Room 1-40",
+      "location_id": 3961008,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
     "ROOM_SANITY_1_41": {
       "category": "ROOM_SANITY",
       "label": "Room 1-41",
@@ -912,6 +920,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 2-19",
       "location_id": 3961054,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_2_20": {
+      "category": "ROOM_SANITY",
+      "label": "Room 2-20",
+      "location_id": 3961056,
       "tags": [
         "RoomSanity"
       ]
@@ -1188,6 +1204,14 @@
         "RoomSanity"
       ]
     },
+    "ROOM_SANITY_4_08": {
+      "category": "ROOM_SANITY",
+      "label": "Room 4-08",
+      "location_id": 3961102,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
     "ROOM_SANITY_4_09": {
       "category": "ROOM_SANITY",
       "label": "Room 4-09",
@@ -1352,6 +1376,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 5-04",
       "location_id": 3961121,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_5_05": {
+      "category": "ROOM_SANITY",
+      "label": "Room 5-05",
+      "location_id": 3961125,
       "tags": [
         "RoomSanity"
       ]
@@ -1932,6 +1964,14 @@
         "RoomSanity"
       ]
     },
+    "ROOM_SANITY_7_CHEST": {
+      "category": "ROOM_SANITY",
+      "label": "Room 7-CHEST",
+      "location_id": 3961178,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
     "ROOM_SANITY_7_GOAL_1": {
       "category": "ROOM_SANITY",
       "label": "Room 7-GOAL_1",
@@ -2248,6 +2288,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 9-06",
       "location_id": 3961231,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_9_07": {
+      "category": "ROOM_SANITY",
+      "label": "Room 9-07",
+      "location_id": 3961237,
       "tags": [
         "RoomSanity"
       ]
@@ -2740,7 +2788,7 @@
       ],
       "label": "REGION_CANDY_CONSTELLATION/ROOM_9_07",
       "parent_region": "REGION_CANDY_CONSTELLATION",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961237
     },
     "REGION_CANDY_CONSTELLATION/ROOM_9_08": {
       "exits": [
@@ -2993,7 +3041,7 @@
       ],
       "label": "REGION_CARROT_CASTLE/ROOM_5_05",
       "parent_region": "REGION_CARROT_CASTLE",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961125
     },
     "REGION_CARROT_CASTLE/ROOM_5_06": {
       "exits": [
@@ -3542,7 +3590,7 @@
       ],
       "label": "REGION_MOONLIGHT_MANSION/ROOM_2_20",
       "parent_region": "REGION_MOONLIGHT_MANSION",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961056
     },
     "REGION_MOONLIGHT_MANSION/ROOM_2_BOSS": {
       "exits": [
@@ -3680,7 +3728,7 @@
       ],
       "label": "REGION_MUSTARD_MOUNTAIN/ROOM_4_08",
       "parent_region": "REGION_MUSTARD_MOUNTAIN",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961102
     },
     "REGION_MUSTARD_MOUNTAIN/ROOM_4_09": {
       "exits": [
@@ -4384,7 +4432,7 @@
       ],
       "label": "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST",
       "parent_region": "REGION_PEPPERMINT_PALACE",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961178
     },
     "REGION_PEPPERMINT_PALACE/ROOM_7_GOAL_1": {
       "exits": [
@@ -5142,7 +5190,7 @@
       ],
       "label": "REGION_RAINBOW_ROUTE/ROOM_1_40",
       "parent_region": "REGION_RAINBOW_ROUTE",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961008
     },
     "REGION_RAINBOW_ROUTE/ROOM_1_41": {
       "exits": [

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -676,14 +676,6 @@
         "RoomSanity"
       ]
     },
-    "ROOM_SANITY_1_40": {
-      "category": "ROOM_SANITY",
-      "label": "Room 1-40",
-      "location_id": 3961008,
-      "tags": [
-        "RoomSanity"
-      ]
-    },
     "ROOM_SANITY_1_41": {
       "category": "ROOM_SANITY",
       "label": "Room 1-41",
@@ -760,6 +752,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 1-HUB_4",
       "location_id": 3961011,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_1_WARP": {
+      "category": "ROOM_SANITY",
+      "label": "Room 1-WARP",
+      "location_id": 3961008,
       "tags": [
         "RoomSanity"
       ]
@@ -916,14 +916,6 @@
         "RoomSanity"
       ]
     },
-    "ROOM_SANITY_2_20": {
-      "category": "ROOM_SANITY",
-      "label": "Room 2-20",
-      "location_id": 3961056,
-      "tags": [
-        "RoomSanity"
-      ]
-    },
     "ROOM_SANITY_2_BOSS": {
       "category": "ROOM_SANITY",
       "label": "Room 2-BOSS",
@@ -960,6 +952,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 2-HUB",
       "location_id": 3961070,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_2_WARP": {
+      "category": "ROOM_SANITY",
+      "label": "Room 2-WARP",
+      "location_id": 3961056,
       "tags": [
         "RoomSanity"
       ]
@@ -1188,14 +1188,6 @@
         "RoomSanity"
       ]
     },
-    "ROOM_SANITY_4_08": {
-      "category": "ROOM_SANITY",
-      "label": "Room 4-08",
-      "location_id": 3961102,
-      "tags": [
-        "RoomSanity"
-      ]
-    },
     "ROOM_SANITY_4_09": {
       "category": "ROOM_SANITY",
       "label": "Room 4-09",
@@ -1324,6 +1316,14 @@
         "RoomSanity"
       ]
     },
+    "ROOM_SANITY_4_WARP": {
+      "category": "ROOM_SANITY",
+      "label": "Room 4-WARP",
+      "location_id": 3961102,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
     "ROOM_SANITY_5_01": {
       "category": "ROOM_SANITY",
       "label": "Room 5-01",
@@ -1352,14 +1352,6 @@
       "category": "ROOM_SANITY",
       "label": "Room 5-04",
       "location_id": 3961121,
-      "tags": [
-        "RoomSanity"
-      ]
-    },
-    "ROOM_SANITY_5_05": {
-      "category": "ROOM_SANITY",
-      "label": "Room 5-05",
-      "location_id": 3961125,
       "tags": [
         "RoomSanity"
       ]
@@ -1496,6 +1488,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 5-HUB",
       "location_id": 3961126,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_5_WARP": {
+      "category": "ROOM_SANITY",
+      "label": "Room 5-WARP",
+      "location_id": 3961125,
       "tags": [
         "RoomSanity"
       ]
@@ -1932,14 +1932,6 @@
         "RoomSanity"
       ]
     },
-    "ROOM_SANITY_7_CHEST": {
-      "category": "ROOM_SANITY",
-      "label": "Room 7-CHEST",
-      "location_id": 3961178,
-      "tags": [
-        "RoomSanity"
-      ]
-    },
     "ROOM_SANITY_7_GOAL_1": {
       "category": "ROOM_SANITY",
       "label": "Room 7-GOAL_1",
@@ -1968,6 +1960,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 7-HUB_2",
       "location_id": 3961200,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_7_WARP": {
+      "category": "ROOM_SANITY",
+      "label": "Room 7-WARP",
+      "location_id": 3961178,
       "tags": [
         "RoomSanity"
       ]
@@ -2252,14 +2252,6 @@
         "RoomSanity"
       ]
     },
-    "ROOM_SANITY_9_07": {
-      "category": "ROOM_SANITY",
-      "label": "Room 9-07",
-      "location_id": 3961237,
-      "tags": [
-        "RoomSanity"
-      ]
-    },
     "ROOM_SANITY_9_08": {
       "category": "ROOM_SANITY",
       "label": "Room 9-08",
@@ -2416,6 +2408,14 @@
       "category": "ROOM_SANITY",
       "label": "Room 9-HUB",
       "location_id": 3961256,
+      "tags": [
+        "RoomSanity"
+      ]
+    },
+    "ROOM_SANITY_9_WARP": {
+      "category": "ROOM_SANITY",
+      "label": "Room 9-WARP",
+      "location_id": 3961237,
       "tags": [
         "RoomSanity"
       ]
@@ -2740,7 +2740,7 @@
       ],
       "label": "REGION_CANDY_CONSTELLATION/ROOM_9_07",
       "parent_region": "REGION_CANDY_CONSTELLATION",
-      "room_sanity_location_id": 3961237
+      "room_sanity_location_id": null
     },
     "REGION_CANDY_CONSTELLATION/ROOM_9_08": {
       "exits": [
@@ -2943,7 +2943,7 @@
       ],
       "label": "REGION_CANDY_CONSTELLATION/ROOM_9_WARP",
       "parent_region": "REGION_CANDY_CONSTELLATION",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961237
     },
     "REGION_CARROT_CASTLE/ROOM_5_01": {
       "exits": [
@@ -2993,7 +2993,7 @@
       ],
       "label": "REGION_CARROT_CASTLE/ROOM_5_05",
       "parent_region": "REGION_CARROT_CASTLE",
-      "room_sanity_location_id": 3961125
+      "room_sanity_location_id": null
     },
     "REGION_CARROT_CASTLE/ROOM_5_06": {
       "exits": [
@@ -3178,7 +3178,7 @@
       ],
       "label": "REGION_CARROT_CASTLE/ROOM_5_WARP",
       "parent_region": "REGION_CARROT_CASTLE",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961125
     },
     "REGION_DIMENSION_MIRROR/ROOM_10_01": {
       "exits": [
@@ -3542,7 +3542,7 @@
       ],
       "label": "REGION_MOONLIGHT_MANSION/ROOM_2_20",
       "parent_region": "REGION_MOONLIGHT_MANSION",
-      "room_sanity_location_id": 3961056
+      "room_sanity_location_id": null
     },
     "REGION_MOONLIGHT_MANSION/ROOM_2_BOSS": {
       "exits": [
@@ -3598,7 +3598,7 @@
       ],
       "label": "REGION_MOONLIGHT_MANSION/ROOM_2_WARP",
       "parent_region": "REGION_MOONLIGHT_MANSION",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961056
     },
     "REGION_MUSTARD_MOUNTAIN/ROOM_4_01": {
       "exits": [
@@ -3680,7 +3680,7 @@
       ],
       "label": "REGION_MUSTARD_MOUNTAIN/ROOM_4_08",
       "parent_region": "REGION_MUSTARD_MOUNTAIN",
-      "room_sanity_location_id": 3961102
+      "room_sanity_location_id": null
     },
     "REGION_MUSTARD_MOUNTAIN/ROOM_4_09": {
       "exits": [
@@ -3845,7 +3845,7 @@
       ],
       "label": "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP",
       "parent_region": "REGION_MUSTARD_MOUNTAIN",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961102
     },
     "REGION_OLIVE_OCEAN/ROOM_6_01": {
       "exits": [
@@ -4384,7 +4384,7 @@
       ],
       "label": "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST",
       "parent_region": "REGION_PEPPERMINT_PALACE",
-      "room_sanity_location_id": 3961178
+      "room_sanity_location_id": null
     },
     "REGION_PEPPERMINT_PALACE/ROOM_7_GOAL_1": {
       "exits": [
@@ -4432,7 +4432,7 @@
       ],
       "label": "REGION_PEPPERMINT_PALACE/ROOM_7_WARP",
       "parent_region": "REGION_PEPPERMINT_PALACE",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961178
     },
     "REGION_RADISH_RUINS/ROOM_8_01": {
       "exits": [
@@ -5142,7 +5142,7 @@
       ],
       "label": "REGION_RAINBOW_ROUTE/ROOM_1_40",
       "parent_region": "REGION_RAINBOW_ROUTE",
-      "room_sanity_location_id": 3961008
+      "room_sanity_location_id": null
     },
     "REGION_RAINBOW_ROUTE/ROOM_1_41": {
       "exits": [
@@ -5256,7 +5256,7 @@
       ],
       "label": "REGION_RAINBOW_ROUTE/ROOM_1_WARP",
       "parent_region": "REGION_RAINBOW_ROUTE",
-      "room_sanity_location_id": null
+      "room_sanity_location_id": 3961008
     },
     "REGION_TUTORIAL/ROOM_0_01": {
       "exits": [

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -172,7 +172,20 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
         region.get("room_sanity", {}).get("included", False)
         for region in room_regions.values()
     ]
-    assert sum(1 for included in included_room_sanity if included) == 257
+    assert sum(1 for included in included_room_sanity if included) == 263
+
+    included_room_sanity_ids = [
+        region["room_sanity"]["location_id"]
+        for region in room_regions.values()
+        if region.get("room_sanity", {}).get("included", False)
+    ]
+    included_room_sanity_bits = [
+        region["room_sanity"]["bit_index"]
+        for region in room_regions.values()
+        if region.get("room_sanity", {}).get("included", False)
+    ]
+    assert len(included_room_sanity_ids) == len(set(included_room_sanity_ids))
+    assert len(included_room_sanity_bits) == len(set(included_room_sanity_bits))
 
     expected_warp_room_sanity = {
         "REGION_RAINBOW_ROUTE/ROOM_1_WARP",
@@ -188,20 +201,6 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
         assert isinstance(room_meta["location_id"], int)
         assert isinstance(room_meta["bit_index"], int)
 
-    expected_legacy_room_sanity_disabled = {
-        "REGION_RAINBOW_ROUTE/ROOM_1_40",
-        "REGION_MOONLIGHT_MANSION/ROOM_2_20",
-        "REGION_MUSTARD_MOUNTAIN/ROOM_4_08",
-        "REGION_CARROT_CASTLE/ROOM_5_05",
-        "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST",
-        "REGION_CANDY_CONSTELLATION/ROOM_9_07",
-    }
-    for region_key in expected_legacy_room_sanity_disabled:
-        room_meta = room_regions[region_key]["room_sanity"]
-        assert room_meta["included"] is False
-        assert room_meta["location_id"] is None
-        assert room_meta["bit_index"] is None
-    
     # Rooms may carry location data where the actual in-game pickup occurs.
     # Exactly the rooms with boss defeats and big chests should have locations;
     # all other rooms remain topology-only with empty lists.

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -172,7 +172,7 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
         region.get("room_sanity", {}).get("included", False)
         for region in room_regions.values()
     ]
-    assert sum(1 for included in included_room_sanity if included) == 263
+    assert sum(1 for included in included_room_sanity if included) == 257
 
     expected_warp_room_sanity = {
         "REGION_RAINBOW_ROUTE/ROOM_1_WARP",
@@ -187,6 +187,20 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
         assert room_meta["included"] is True
         assert isinstance(room_meta["location_id"], int)
         assert isinstance(room_meta["bit_index"], int)
+
+    expected_legacy_room_sanity_disabled = {
+        "REGION_RAINBOW_ROUTE/ROOM_1_40",
+        "REGION_MOONLIGHT_MANSION/ROOM_2_20",
+        "REGION_MUSTARD_MOUNTAIN/ROOM_4_08",
+        "REGION_CARROT_CASTLE/ROOM_5_05",
+        "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST",
+        "REGION_CANDY_CONSTELLATION/ROOM_9_07",
+    }
+    for region_key in expected_legacy_room_sanity_disabled:
+        room_meta = room_regions[region_key]["room_sanity"]
+        assert room_meta["included"] is False
+        assert room_meta["location_id"] is None
+        assert room_meta["bit_index"] is None
     
     # Rooms may carry location data where the actual in-game pickup occurs.
     # Exactly the rooms with boss defeats and big chests should have locations;

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -172,7 +172,21 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
         region.get("room_sanity", {}).get("included", False)
         for region in room_regions.values()
     ]
-    assert sum(1 for included in included_room_sanity if included) == 257
+    assert sum(1 for included in included_room_sanity if included) == 263
+
+    expected_warp_room_sanity = {
+        "REGION_RAINBOW_ROUTE/ROOM_1_WARP",
+        "REGION_MOONLIGHT_MANSION/ROOM_2_WARP",
+        "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP",
+        "REGION_CARROT_CASTLE/ROOM_5_WARP",
+        "REGION_PEPPERMINT_PALACE/ROOM_7_WARP",
+        "REGION_CANDY_CONSTELLATION/ROOM_9_WARP",
+    }
+    for region_key in expected_warp_room_sanity:
+        room_meta = room_regions[region_key]["room_sanity"]
+        assert room_meta["included"] is True
+        assert isinstance(room_meta["location_id"], int)
+        assert isinstance(room_meta["bit_index"], int)
     
     # Rooms may carry location data where the actual in-game pickup occurs.
     # Exactly the rooms with boss defeats and big chests should have locations;
@@ -244,6 +258,12 @@ def test_room_sanity_binding_optional() -> None:
     
     _bind_room_sanity_locations(room_regions, enable_room_sanity=True)
     assert "ROOM_SANITY_1_CENTRAL_CIRCLE" in room_regions["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]["locations"]
+    assert "ROOM_SANITY_1_WARP" in room_regions["REGION_RAINBOW_ROUTE/ROOM_1_WARP"]["locations"]
+    assert "ROOM_SANITY_2_WARP" in room_regions["REGION_MOONLIGHT_MANSION/ROOM_2_WARP"]["locations"]
+    assert "ROOM_SANITY_4_WARP" in room_regions["REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP"]["locations"]
+    assert "ROOM_SANITY_5_WARP" in room_regions["REGION_CARROT_CASTLE/ROOM_5_WARP"]["locations"]
+    assert "ROOM_SANITY_7_WARP" in room_regions["REGION_PEPPERMINT_PALACE/ROOM_7_WARP"]["locations"]
+    assert "ROOM_SANITY_9_WARP" in room_regions["REGION_CANDY_CONSTELLATION/ROOM_9_WARP"]["locations"]
     assert "ROOM_SANITY_10_01" not in room_regions["REGION_DIMENSION_MIRROR/ROOM_10_01"]["locations"]
     assert "ROOM_SANITY_0_01" not in room_regions["REGION_TUTORIAL/ROOM_0_01"]["locations"]
 


### PR DESCRIPTION
## Summary
- re-enable room-sanity metadata for all designed warp rooms in `rooms.json`
- restore their canonical `location_id` + `bit_index` mappings used by `gVisitedDoors`
- add regression assertions for warp-room inclusion and room-sanity binding
- update room-sanity count/docs/changelog references

## Testing
- `python -m pytest worlds/kirbyam/test/test_rules.py worlds/kirbyam/test/test_room_sanity_polling.py`

Closes #605