### PR TITLE
KirbyAM: fix start_with_all_maps runtime reconciliation

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -23,7 +23,6 @@ Contract for `## Unreleased` and all post-public `## v...` sections:
 
 ### Bug Fixes
 
-- Make `start_with_all_maps` reliable in gameplay by having the BizHawk client reassert AP-owned native map bits from `slot_data` and confirmed delivered map items, so all starting maps survive reconnect/save-state drift and later map receipts restore correctly (Issue #650).
 - Restore room-sanity coverage for designed warp rooms by re-enabling their `room_sanity` metadata mappings (Issue #605).
 - Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).
 - Prevent skipped in-game item delivery when stale `debug_item_counter` values jump ahead of the client cursor by only trusting forward counter reconciliation for pending mailbox ACKs (`incoming_item_flag == 0` while a delivery is pending), while keeping rewind recovery for true counter rollback.

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -23,6 +23,7 @@ Contract for `## Unreleased` and all post-public `## v...` sections:
 
 ### Bug Fixes
 
+- Make `start_with_all_maps` reliable in gameplay by having the BizHawk client reassert AP-owned native map bits from `slot_data` and confirmed delivered map items, so all starting maps survive reconnect/save-state drift and later map receipts restore correctly (Issue #650).
 - Restore room-sanity coverage for designed warp rooms by re-enabling their `room_sanity` metadata mappings (Issue #605).
 - Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).
 - Prevent skipped in-game item delivery when stale `debug_item_counter` values jump ahead of the client cursor by only trusting forward counter reconciliation for pending mailbox ACKs (`incoming_item_flag == 0` while a delivery is pending), while keeping rewind recovery for true counter rollback.

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -3,6 +3,7 @@
 Contract for `## Unreleased` and all post-public `## v...` sections:
 
 - `### New Features`
+- `### Improvements`
 - `### Bug Fixes`
 - `### Internal Changes`
 
@@ -10,33 +11,34 @@ Contract for `## Unreleased` and all post-public `## v...` sections:
 
 ### New Features
 
-- `Starting Kirby Color` lets players begin a seed with a chosen Kirby palette instead of default Pink, including a random-color option for runs that want a surprise look (Issue #597).
-- Tracker support is broader, making it easier for players to follow room progress, location progress, and unique-item progress in tracker tools (Issue #114).
-- `Start With All Maps` lets players begin with every area map already unlocked for a more guided and readable playthrough (Issue #584).
-- Room names have been updated to match familiar Wikirby naming, making navigation and communication clearer for players (Issue #587).
-- Add 15 decomp-aligned world-map big-switch AP checks (`HUB_SWITCH_*`) with a dedicated ROM transport register (`hub_switch_flags` at `0x0203B04C`), BizHawk resend/dedupe polling, payload hook integration at the world-map unlock dispatcher callsite (`sub_08039ED4`), protocol/address contract updates, and regression coverage for data/polling/patch offsets/region binding (Issue #481).
-- Fix enemy copy-ability shuffled-mode source coverage gaps by adding missing known US-ROM ability sources (`GOLEM`, `PRANK`, `MASTER_CRAZY_HAND_BULLET`) so same-type enemy grants no longer diverge between patched and unpatched table entries across rooms (Issue #420).
-- Improve shuffled enemy copy-ability mapping to guarantee full allowed-ability representation across included enemy types when key cardinality permits (`no_ability_weight < 100`), while preserving explicit `no_ability_weight=100` semantics (all included sources resolve to no ability).
-- Add shuffled enemy copy-ability spoiler output listing each randomized source and resulting copy ability (`kind | source_key -> ability`) so seed analysis can verify enemy mappings and full allowed-ability representation (Issue #586).
-- Add generation-log shuffled assignment table output (`kind | source -> ability`) so seed build logs show deterministic enemy copy-ability grants for shuffled mode.
-- Add completely-random per-swallow reroll telemetry logging (`Kirby swallowed a <EnemyName>. Ability was rerolled to <AbilityName>.`) based on the latest observed runtime swallow event (best-effort; earlier events between polls are noted as missed), while only streaming that line to the live client when `enable_debug_logging` is enabled.
+- `Starting Kirby Color` lets players begin with a chosen Kirby color instead of always starting as Pink, including a random option for surprise runs (Issue #597).
+- `Start With All Maps` lets players begin with every area map already unlocked for a more guided playthrough (Issue #584).
+- Room names now match familiar Wikirby names, making the game easier to navigate and discuss (Issue #587).
+- World-map big switches are now full Archipelago checks (Issue #481).
+- Spoiler output and generation logs now show shuffled enemy ability assignments, making seeds easier to review (Issue #586).
+
+### Improvements
+- Enemy Ability Shuffle now covers more enemies, so shuffled abilities stay consistent in more rooms (Issue #420).
+- Enemy Ability Shuffle now spreads allowed abilities more evenly across enemies when possible, while still respecting settings that force no ability.
+- `Ability Randomization: Minny` is now off by default, fixing seeds that changed Minny unexpectedly unless players opted in (Issue #583).
 
 ### Bug Fixes
-
-- Restore room-sanity coverage for designed warp rooms by re-enabling their `room_sanity` metadata mappings (Issue #605).
-- Updated `Ability Randomization: Minny` (`ability_randomization_minny`) so that it's off by default (Issue #583).
-- Prevent skipped in-game item delivery when stale `debug_item_counter` values jump ahead of the client cursor by only trusting forward counter reconciliation for pending mailbox ACKs (`incoming_item_flag == 0` while a delivery is pending), while keeping rewind recovery for true counter rollback.
-- Ensure delivery diagnostics gated by `enable_debug_logging` are still written to log files and only hidden from the live client stream via `NoStream` (Issue #601).
-- Harden vitality delivery against transition/reset replay by clamping native vitality counter grants to the shipped AP vitality item cardinality (4), and in `one_hit_mode=exclude_vitality_counters` scrub native vitality back to `0` during gameplay so vitality receipts cannot persist in that mode (Issue #571).
-- Fix missing boss-defeat LocationChecks when the matching shard is already owned by adding a conservative client fallback: rising-edge bits from `boss_mirror_table_native` byte 0 (bits 0-7) now backfill boss checks when `boss_defeat_flags` is absent for that fight (Issue #573).
-- Hide additional KirbyAM reconnect/resend diagnostics from the live client output unless `Enable Debug Logging` is enabled, while still writing those diagnostics to log files unconditionally (`NoStream`-filtered stream suppression only); includes watcher transport reconnect messages and resend diagnostics for boss/major/vitality/sound-player LocationChecks polling (Issue #582).
+- Enemy Ability Randomization: Completely random now rerolls abilities per swallow, not per room (Issue #420).
+- Warp rooms that were missing Room Sanity checks now have them again (Issue #605).
+- Fixed a delivery issue that could cause items to be skipped when the client and game counters got out of sync.
+- Fixed debug-only delivery diagnostics so they still go to the log file even when they are hidden from the live client output (Issue #601).
+- Fixed vitality counter replays caused by transitions or resets, and prevented vitality counters from lingering in `One-Hit Mode` when that mode excludes them (Issue #571).
+- Fixed some boss checks not being sent when the matching shard was already owned (Issue #573).
+- Fixed extra reconnect and resend diagnostics showing up in the live client unless debug logging was enabled, while still keeping them in the log file (Issue #582).
 
 ### Internal Changes
 
+- Tracker support now gives trackers a clearer view of room progress, location progress, and unique-item progress (Issue #114).
 - Reduce duplicate CI runs on feature branches by limiting push-triggered workflow execution to `main` for native static analysis and other PR-validated checks (`scan-build`, `ctest`, `type check`, `build`, and `analyze-modified-files`), while keeping `pull_request` validation behavior unchanged.
 - Improve `worlds/kirbyam/build.py` usability for non-author machines by prompting for missing required patch inputs in interactive runs (including missing `--rom` when `--source-type arg` is selected), adding `--source-type file` fallback guidance when `rom_path.tmp` is invalid, and introducing `--non-interactive` fail-fast behavior for automation/CI (Issue #607).
 - Expose all configured KirbyAM seed options in `slot_data` (including `start_with_all_maps` and `enable_debug_logging`) so tracker surfaces can render the exact seed configuration from slot data without inferring from partial fields (Issue #114).
 - Move unswallowable enemy exclusion policy from a static runtime list into `data/enemies.json` source metadata (`can_be_swallowed`) and represent the currently configured non-swallowable enemies there: `GLUNK`, `JACK`, and `SQUISHY` (Issue #570).
+- When debug logging is enabled, completely random swallow abilities now log what Kirby got from the latest swallow event.
 
 ## v0.1.2
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -1,9 +1,9 @@
 # KirbyAM APWorld Changelog
 
-Contract for `## Unreleased` and all post-public `## v...` sections:
+Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 - `### New Features`
-- `### Improvements`
+- `### Improvements` (optional for older post-public sections)
 - `### Bug Fixes`
 - `### Internal Changes`
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -82,7 +82,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | Addr     | Size | Name                    | Description |
 |----------|------|-------------------------|-----------|
 | 0x02038970 | 1B | KIRBY_SHARD_FLAGS       | Native mirror shard bitfield (bits 0-7) |
-| 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This now reflects native map ownership only; AP major-chest checks use `major_chest_flags` in the transport block. |
+| 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This reflects native map ownership only; AP major-chest checks use `major_chest_flags` in the transport block, and the BizHawk client reasserts AP-owned map bits here from `start_with_all_maps` plus confirmed delivered map items to survive reconnect/save-state drift. |
 | 0x02038960 - 0x0203896A | 10B | Chest/Switch state    | Native chest and switch flags |
 | 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped) |
 | 0x02028CA0 | 576B | gVisitedDoors (`room_visit_flags_native`) | Native room-visit array (`u16[0x120]`); bit 15 marks visited state by `doorsIdx` |
@@ -160,7 +160,7 @@ Server → Client: ConnectionRefused | Connected
 `slot_data` currently includes:
 - `goal` (int): selected goal option.
 - `shards` (int): shard randomization mode.
-- `start_with_all_maps` (bool): when true, all map items are precollected and removed from randomized placement.
+- `start_with_all_maps` (bool): when true, all map items are precollected and removed from randomized placement, and the BizHawk client reasserts all native area-map bits during gameplay reconciliation.
 - `starting_kirby_color` (int): resolved Kirby starting color ID (`0..13`) after generation-time random resolution. Non-Pink colors become visible after the next room/area transition or after an enemy-hit runtime refresh.
 - `starting_kirby_color_name` (str): resolved Kirby starting color display name for logs/tracker surfaces.
 - `no_extra_lives` (bool): when true, exclude `1 Up` filler generation and have the BizHawk client clamp the native life counter to `0` during gameplay.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -77,12 +77,12 @@ EWRAM Layout (0x02000000 - 0x02040000):
 
 **Total: 136 bytes (0x0203B000 - 0x0203B087)**
 
-### Native Game State (Referenced but not Managed by AP)
+### Native Game State (Referenced by AP; some fields are client-reconciled)
 
 | Addr     | Size | Name                    | Description |
 |----------|------|-------------------------|-----------|
 | 0x02038970 | 1B | KIRBY_SHARD_FLAGS       | Native mirror shard bitfield (bits 0-7) |
-| 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This reflects native map ownership only; AP major-chest checks use `major_chest_flags` in the transport block, and the BizHawk client reasserts AP-owned map bits here from `start_with_all_maps` plus confirmed delivered map items to survive reconnect/save-state drift. |
+| 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This is the native map-ownership field. AP major-chest checks use `major_chest_flags` in the transport block, and the BizHawk client may reassert AP-owned map bits here from `start_with_all_maps` plus confirmed delivered map items to recover from reconnect/save-state drift. |
 | 0x02038960 - 0x0203896A | 10B | Chest/Switch state    | Native chest and switch flags |
 | 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped) |
 | 0x02028CA0 | 576B | gVisitedDoors (`room_visit_flags_native`) | Native room-visit array (`u16[0x120]`); bit 15 marks visited state by `doorsIdx` |

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -77,12 +77,12 @@ _MAP_ITEM_LABEL_TO_AREA_ID: dict[str, int] = {
     "Radish Ruins - Map": 8,
     "Candy Constellation - Map": 9,
 }
-_MAP_ITEM_IDS_TO_AREA_ID: dict[int, int] = {
+_MAP_ITEM_ID_TO_AREA_ID: dict[int, int] = {
     item.item_id: _MAP_ITEM_LABEL_TO_AREA_ID[item.label]
     for item in data.items.values()
     if item.label in _MAP_ITEM_LABEL_TO_AREA_ID
 }
-_MANAGED_NATIVE_MAP_BITMASK = sum(1 << area_id for area_id in _MAP_ITEM_IDS_TO_AREA_ID.values())
+_MANAGED_NATIVE_MAP_BITMASK = sum(1 << area_id for area_id in _MAP_ITEM_ID_TO_AREA_ID.values())
 _ABILITY_SOURCE_ADDR_TO_KEY: dict[int, str] = {
     address: source.key
     for source in ABILITY_SOURCES
@@ -318,7 +318,7 @@ class KirbyAmClient(BizHawkClient):
             if item_fields is None:
                 continue
             item_id, _player_id = item_fields
-            area_id = _MAP_ITEM_IDS_TO_AREA_ID.get(item_id)
+            area_id = _MAP_ITEM_ID_TO_AREA_ID.get(item_id)
             if area_id is not None:
                 owned_bits |= 1 << area_id
         return owned_bits

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -122,6 +122,9 @@ class KirbyAmClient(BizHawkClient):
         self._hook_heartbeat_stale_ticks: int = 0
         self._delivery_counter_ahead_fallback_active: bool = False
         self._delivery_counter_ahead_resume_logged: bool = False
+        self._cached_delivered_map_bits: int = 0
+        self._cached_map_bits_index: int = 0
+        self._cached_map_bits_items_len: int = 0
 
         # Deterministic location ordering
         self._all_location_ids_sorted: list[int] = [
@@ -289,6 +292,9 @@ class KirbyAmClient(BizHawkClient):
         self._starting_kirby_color_synced_id = None
         self._starting_kirby_color_logged_signature = None
         self._starting_kirby_color_revalidate_counter = 0
+        self._cached_delivered_map_bits = 0
+        self._cached_map_bits_index = 0
+        self._cached_map_bits_items_len = 0
 
     def _no_extra_lives_enabled(self, ctx: "BizHawkClientContext") -> bool:
         slot_data = getattr(ctx, "slot_data", None)
@@ -313,16 +319,33 @@ class KirbyAmClient(BizHawkClient):
         return self._coerce_bool(slot_data.get("start_with_all_maps", False), False)
 
     def _ap_owned_native_map_bits(self, ctx: "BizHawkClientContext") -> int:
-        owned_bits = _MANAGED_NATIVE_MAP_BITMASK if self._start_with_all_maps_enabled(ctx) else 0
-        delivered_count = min(self._delivered_item_index, len(getattr(ctx, "items_received", ())))
-        for network_item in getattr(ctx, "items_received", ())[:delivered_count]:
-            item_fields = self._extract_delivery_item_fields(network_item)
+        delivered_items = getattr(ctx, "items_received", ())
+        delivered_count = min(self._delivered_item_index, len(delivered_items))
+
+        # Rebuild cache on reconnect rewinds or when the received-item list shrinks.
+        if (
+            self._cached_map_bits_index > delivered_count
+            or self._cached_map_bits_items_len > len(delivered_items)
+        ):
+            self._cached_delivered_map_bits = 0
+            self._cached_map_bits_index = 0
+
+        # Apply only newly delivered entries so per-tick reconciliation stays O(1) after catch-up.
+        for item_index in range(self._cached_map_bits_index, delivered_count):
+            item_fields = self._extract_delivery_item_fields(delivered_items[item_index])
             if item_fields is None:
                 continue
             item_id, _player_id = item_fields
             area_id = _MAP_ITEM_ID_TO_AREA_ID.get(item_id)
             if area_id is not None:
-                owned_bits |= 1 << area_id
+                self._cached_delivered_map_bits |= 1 << area_id
+
+        self._cached_map_bits_index = delivered_count
+        self._cached_map_bits_items_len = len(delivered_items)
+
+        owned_bits = self._cached_delivered_map_bits
+        if self._start_with_all_maps_enabled(ctx):
+            owned_bits |= _MANAGED_NATIVE_MAP_BITMASK
         return owned_bits
 
     async def _reconcile_native_map_ownership(self, ctx: "BizHawkClientContext") -> None:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -82,7 +82,9 @@ _MAP_ITEM_ID_TO_AREA_ID: dict[int, int] = {
     for item in data.items.values()
     if item.label in _MAP_ITEM_LABEL_TO_AREA_ID
 }
-_MANAGED_NATIVE_MAP_BITMASK = sum(1 << area_id for area_id in _MAP_ITEM_ID_TO_AREA_ID.values())
+_MANAGED_NATIVE_MAP_BITMASK = 0
+for area_id in _MAP_ITEM_ID_TO_AREA_ID.values():
+    _MANAGED_NATIVE_MAP_BITMASK |= 1 << area_id
 _ABILITY_SOURCE_ADDR_TO_KEY: dict[int, str] = {
     address: source.key
     for source in ABILITY_SOURCES

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -525,6 +525,8 @@ class KirbyAmClient(BizHawkClient):
         config = self._get_starting_kirby_color_config(ctx)
         if config is None:
             return
+        if not self._debug_logging_enabled:
+            return
         if config == self._starting_kirby_color_logged_signature:
             return
 
@@ -572,6 +574,9 @@ class KirbyAmClient(BizHawkClient):
             [(color_transport_addr, int(color_id).to_bytes(4, "little"), "System Bus")],
         )
         self._starting_kirby_color_synced_id = color_id
+
+        if not self._debug_logging_enabled:
+            return
 
         from CommonClient import logger
 
@@ -896,7 +901,6 @@ class KirbyAmClient(BizHawkClient):
 
         self._load_notification_settings(ctx)
         self._load_debug_settings(ctx)
-        self._log_starting_kirby_color_config_once(ctx)
         await self._sync_death_link_setting(ctx)
         await self._sync_enemy_copy_ability_runtime_config(ctx)
 
@@ -910,6 +914,8 @@ class KirbyAmClient(BizHawkClient):
             if self._watcher_requires_bizhawk_resync:
                 self._reset_reconnect_transient_state()
                 self._watcher_requires_bizhawk_resync = False
+
+            self._log_starting_kirby_color_config_once(ctx)
 
             # Load persisted state from RAM once per session (after bizhawk_ctx is valid)
             if not self._ram_state_loaded:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -66,6 +66,23 @@ _ABILITY_ID_TO_NAME: dict[int, str] = {
     ability_id: ability_name
     for ability_name, ability_id in ABILITY_NAME_TO_ID.items()
 }
+_MAP_ITEM_LABEL_TO_AREA_ID: dict[str, int] = {
+    "Rainbow Route - Map": 1,
+    "Moonlight Mansion - Map": 2,
+    "Cabbage Cavern - Map": 3,
+    "Mustard Mountain - Map": 4,
+    "Carrot Castle - Map": 5,
+    "Olive Ocean - Map": 6,
+    "Peppermint Palace - Map": 7,
+    "Radish Ruins - Map": 8,
+    "Candy Constellation - Map": 9,
+}
+_MAP_ITEM_IDS_TO_AREA_ID: dict[int, int] = {
+    item.item_id: _MAP_ITEM_LABEL_TO_AREA_ID[item.label]
+    for item in data.items.values()
+    if item.label in _MAP_ITEM_LABEL_TO_AREA_ID
+}
+_MANAGED_NATIVE_MAP_BITMASK = sum(1 << area_id for area_id in _MAP_ITEM_IDS_TO_AREA_ID.values())
 _ABILITY_SOURCE_ADDR_TO_KEY: dict[int, str] = {
     address: source.key
     for source in ABILITY_SOURCES
@@ -286,6 +303,60 @@ class KirbyAmClient(BizHawkClient):
             return int(value)
         except (TypeError, ValueError):
             return OneHitMode.option_off
+
+    def _start_with_all_maps_enabled(self, ctx: "BizHawkClientContext") -> bool:
+        slot_data = getattr(ctx, "slot_data", None)
+        if not isinstance(slot_data, dict):
+            return False
+        return self._coerce_bool(slot_data.get("start_with_all_maps", False), False)
+
+    def _ap_owned_native_map_bits(self, ctx: "BizHawkClientContext") -> int:
+        owned_bits = _MANAGED_NATIVE_MAP_BITMASK if self._start_with_all_maps_enabled(ctx) else 0
+        delivered_count = min(self._delivered_item_index, len(getattr(ctx, "items_received", ())))
+        for network_item in getattr(ctx, "items_received", ())[:delivered_count]:
+            item_fields = self._extract_delivery_item_fields(network_item)
+            if item_fields is None:
+                continue
+            item_id, _player_id = item_fields
+            area_id = _MAP_ITEM_IDS_TO_AREA_ID.get(item_id)
+            if area_id is not None:
+                owned_bits |= 1 << area_id
+        return owned_bits
+
+    async def _reconcile_native_map_ownership(self, ctx: "BizHawkClientContext") -> None:
+        """
+        Reassert AP-owned native map bits from runtime state.
+
+        This covers start_with_all_maps precollects immediately from slot_data and
+        restores later map receipts after reconnect/savestate drift without relying
+        on native big-chest map ownership as the AP check authority.
+        """
+        map_addr = self._native_addr("big_chest_bitfield_native")
+        if map_addr is None:
+            return
+
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(map_addr, 4, "System Bus")]))[0]
+        current_bits = self._u32_le(raw)
+        desired_map_bits = self._ap_owned_native_map_bits(ctx)
+        desired_bits = (current_bits & ~_MANAGED_NATIVE_MAP_BITMASK) | desired_map_bits
+        if current_bits == desired_bits:
+            return
+
+        await bizhawk.write(
+            ctx.bizhawk_ctx,
+            [(map_addr, desired_bits.to_bytes(4, "little"), "System Bus")],
+        )
+
+        from CommonClient import logger
+
+        logger.info(
+            "KirbyAM: reconciled native map ownership (current=0x%08X, desired=0x%08X, start_with_all_maps=%s, delivered_item_index=%s)",
+            current_bits,
+            desired_bits,
+            self._start_with_all_maps_enabled(ctx),
+            self._delivered_item_index,
+            extra={"NoStream": not self._debug_logging_enabled},
+        )
 
     @staticmethod
     def _item_signature(item: object) -> tuple[int, int, int, int] | None:
@@ -879,6 +950,7 @@ class KirbyAmClient(BizHawkClient):
                 await self._display_client_message(ctx, "Item sending resumed")
                 self._last_runtime_gate_reason = None
 
+            await self._reconcile_native_map_ownership(ctx)
             await self._enforce_no_extra_lives(ctx)
             await self._enforce_one_hit_mode(ctx)
             await self._apply_pending_death_link(ctx)

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2597,7 +2597,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
 
     with patch.object(client, '_reset_reconnect_transient_state') as mock_reset, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock) as mock_apply_death_link, \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock) as mock_send_death_link, \
@@ -2725,7 +2725,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
     with patch('CommonClient.logger') as mock_logger, \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
             patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock) as mock_poll_locations, \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock) as mock_poll_boss, \
@@ -2780,7 +2780,7 @@ async def test_game_watcher_reconnect_entry_suppresses_session_ready_log_when_de
     with patch('CommonClient.logger') as mock_logger, \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
@@ -2989,7 +2989,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
@@ -3046,7 +3046,7 @@ async def test_game_watcher_emits_runtime_gate_logs_when_debug_enabled(mock_bizh
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
@@ -3089,7 +3089,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
             patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
@@ -3117,7 +3117,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
             patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -203,6 +203,75 @@ async def test_poll_locations_does_not_send_location_checks(mock_bizhawk_context
 
 
 @pytest.mark.asyncio
+async def test_reconcile_native_map_ownership_sets_all_map_bits_for_starting_option(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data["start_with_all_maps"] = True
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        mock_read.return_value = [(1).to_bytes(4, 'little')]
+
+        await client._reconcile_native_map_ownership(mock_bizhawk_context)
+
+    expected_bits = 1
+    for area_id in range(1, 10):
+        expected_bits |= 1 << area_id
+    mock_write.assert_awaited_once_with(
+        mock_bizhawk_context.bizhawk_ctx,
+        [(
+            data.native_ram_addresses["big_chest_bitfield_native"],
+            expected_bits.to_bytes(4, 'little'),
+            "System Bus",
+        )],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_native_map_ownership_uses_only_delivered_map_items(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._delivered_item_index = 2
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860010, player=1),
+        Mock(item=3860024, player=1),
+        Mock(item=3860017, player=1),
+    ]
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        mock_read.return_value = [(0).to_bytes(4, 'little')]
+
+        await client._reconcile_native_map_ownership(mock_bizhawk_context)
+
+    expected_bits = (1 << 1) | (1 << 4)
+    mock_write.assert_awaited_once_with(
+        mock_bizhawk_context.bizhawk_ctx,
+        [(
+            data.native_ram_addresses["big_chest_bitfield_native"],
+            expected_bits.to_bytes(4, 'little'),
+            "System Bus",
+        )],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_native_map_ownership_skips_write_when_native_bits_match(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._delivered_item_index = 1
+    mock_bizhawk_context.items_received = [Mock(item=3860013, player=1)]
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        mock_read.return_value = [((1 << 6)).to_bytes(4, 'little')]
+
+        await client._reconcile_native_map_ownership(mock_bizhawk_context)
+
+    mock_write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_poll_major_chest_sends_location_checks_for_set_bits(mock_bizhawk_context):
     """Set transport major-chest bits should map to major-chest LocationChecks."""
     client = KirbyAmClient()
@@ -2528,6 +2597,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
 
     with patch.object(client, '_reset_reconnect_transient_state') as mock_reset, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock) as mock_apply_death_link, \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock) as mock_send_death_link, \
@@ -2546,6 +2616,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
 
     mock_reset.assert_called_once_with()
     mock_load.assert_awaited_once_with(mock_bizhawk_context)
+    mock_reconcile_maps.assert_awaited_once_with(mock_bizhawk_context)
     mock_apply_death_link.assert_awaited_once_with(mock_bizhawk_context)
     mock_send_death_link.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_boss.assert_awaited_once_with(mock_bizhawk_context)
@@ -2654,6 +2725,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
     with patch('CommonClient.logger') as mock_logger, \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
             patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock) as mock_poll_locations, \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock) as mock_poll_boss, \
@@ -2683,6 +2755,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         assert client._last_unsafe_delivery_counter_values == {}
         mock_logger.info.assert_any_call("KirbyAM: AP session ready; reconnect-safe reconciliation active")
         mock_load.assert_awaited_once()
+        mock_reconcile_maps.assert_awaited()
         mock_poll_locations.assert_not_awaited()
         mock_poll_boss.assert_awaited_once()
         mock_poll_major_chests.assert_awaited_once()
@@ -2707,6 +2780,7 @@ async def test_game_watcher_reconnect_entry_suppresses_session_ready_log_when_de
     with patch('CommonClient.logger') as mock_logger, \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
@@ -2915,6 +2989,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
@@ -2971,6 +3046,7 @@ async def test_game_watcher_emits_runtime_gate_logs_when_debug_enabled(mock_bizh
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
@@ -3013,6 +3089,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
             patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
@@ -3040,6 +3117,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
             patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -8,7 +8,7 @@ import worlds._bizhawk as bizhawk
 from worlds._bizhawk.context import _game_watcher, AuthStatus
 
 from ..data import data
-from ..client import KirbyAmClient
+from ..client import KirbyAmClient, _MAP_ITEM_ID_TO_AREA_ID
 from ..options import OneHitMode
 from ..rom import KirbyAmProcedurePatch
 
@@ -269,6 +269,55 @@ async def test_reconcile_native_map_ownership_skips_write_when_native_bits_match
         await client._reconcile_native_map_ownership(mock_bizhawk_context)
 
     mock_write.assert_not_awaited()
+
+
+def test_ap_owned_native_map_bits_updates_cache_incrementally(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860010, player=1),
+        Mock(item=3860024, player=1),
+        Mock(item=3860017, player=1),
+    ]
+    client._delivered_item_index = 2
+
+    with patch.object(client, '_extract_delivery_item_fields', wraps=client._extract_delivery_item_fields) as wrapped_extract:
+        first_bits = client._ap_owned_native_map_bits(mock_bizhawk_context)
+        first_call_count = wrapped_extract.call_count
+
+        second_bits = client._ap_owned_native_map_bits(mock_bizhawk_context)
+
+        client._delivered_item_index = 3
+        third_bits = client._ap_owned_native_map_bits(mock_bizhawk_context)
+
+    first_expected = (
+        (1 << _MAP_ITEM_ID_TO_AREA_ID[3860010])
+        | (1 << _MAP_ITEM_ID_TO_AREA_ID[3860024])
+    )
+    third_expected = first_expected | (1 << _MAP_ITEM_ID_TO_AREA_ID[3860017])
+    assert first_bits == first_expected
+    assert second_bits == first_bits
+    assert third_bits == third_expected
+    assert first_call_count == 2
+    assert wrapped_extract.call_count == 3
+
+
+def test_ap_owned_native_map_bits_rebuilds_after_delivered_index_rewind(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860010, player=1),
+        Mock(item=3860024, player=1),
+        Mock(item=3860017, player=1),
+    ]
+
+    client._delivered_item_index = 3
+    _ = client._ap_owned_native_map_bits(mock_bizhawk_context)
+
+    client._delivered_item_index = 1
+    rewound_bits = client._ap_owned_native_map_bits(mock_bizhawk_context)
+
+    assert rewound_bits == (1 << _MAP_ITEM_ID_TO_AREA_ID[3860010])
 
 
 @pytest.mark.asyncio

--- a/worlds/kirbyam/test/test_logging.py
+++ b/worlds/kirbyam/test/test_logging.py
@@ -8,15 +8,16 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_kirbyam_test_logging_records_protocol_traffic(
-    kirbyam_test_log_file,
+    tmp_path,
     mock_bizhawk_context,
     mock_bizhawk_read,
     mock_bizhawk_write,
     caplog,
 ) -> None:
+    test_log_file = tmp_path / "kirbyam-test-logging.log"
     test_logger = logging.getLogger("worlds.kirbyam.test")
     previous_level = test_logger.level
-    test_file_handler = logging.FileHandler(kirbyam_test_log_file, mode="a", encoding="utf-8")
+    test_file_handler = logging.FileHandler(test_log_file, mode="w", encoding="utf-8")
     test_file_handler.setLevel(logging.DEBUG)
     test_logger.setLevel(logging.DEBUG)
     test_logger.addHandler(test_file_handler)
@@ -35,8 +36,8 @@ async def test_kirbyam_test_logging_records_protocol_traffic(
                 flush()
         test_file_handler.flush()
 
-        assert kirbyam_test_log_file.exists()
-        log_text = kirbyam_test_log_file.read_text(encoding="utf-8", errors="replace")
+        assert test_log_file.exists()
+        log_text = test_log_file.read_text(encoding="utf-8", errors="replace")
         marker_index = log_text.rfind(marker)
         assert marker_index != -1
         log_section = log_text[marker_index:]

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -126,6 +126,7 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
+            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -126,7 +126,7 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
-            patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
+         patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_starting_kirby_color.py
+++ b/worlds/kirbyam/test/test_starting_kirby_color.py
@@ -181,3 +181,129 @@ def test_reset_reconnect_transient_state_clears_starting_color_log_signature() -
     client._reset_reconnect_transient_state()
 
     assert client._starting_kirby_color_logged_signature is None
+
+
+def test_client_starting_color_config_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": False},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+
+    client._load_debug_settings(mock_bizhawk_context)
+    with patch("CommonClient.logger.info") as mock_info:
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+    assert mock_info.call_count == 0
+
+
+def test_client_starting_color_config_log_emits_once_when_debug_enabled(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": True},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+
+    client._load_debug_settings(mock_bizhawk_context)
+    with patch("CommonClient.logger.info") as mock_info:
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+    assert mock_info.call_count == 1
+    assert mock_info.call_args.args[0] == "KirbyAM: configured starting Kirby color is %s (%s)"
+
+
+def test_client_starting_color_config_log_emits_after_debug_toggle_on(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": False},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+
+    with patch("CommonClient.logger.info") as mock_info:
+        client._load_debug_settings(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+        mock_bizhawk_context.slot_data["debug"]["logging"] = True
+        client._load_debug_settings(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+    assert mock_info.call_count == 1
+    assert client._starting_kirby_color_logged_signature == (0, "Pink")
+
+
+@pytest.mark.asyncio
+async def test_client_starting_color_sync_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": False},
+        "starting_kirby_color": 7,
+        "starting_kirby_color_name": "Sapphire",
+    }
+
+    with (
+        patch.dict(
+            data.transport_ram_addresses,
+            {"starting_kirby_color_id": 0x0203B050},
+            clear=False,
+        ),
+        patch(
+            "worlds.kirbyam.client.bizhawk.read",
+            new_callable=AsyncMock,
+            side_effect=[[(0xFFFFFFFF).to_bytes(4, "little")]],
+        ),
+        patch(
+            "worlds.kirbyam.client.bizhawk.write",
+            new_callable=AsyncMock,
+        ),
+        patch("CommonClient.logger.info") as mock_info,
+    ):
+        client._load_debug_settings(mock_bizhawk_context)
+        await client._sync_starting_kirby_color_runtime_config(mock_bizhawk_context)
+
+    assert mock_info.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_client_game_watcher_logs_starting_color_once_after_initial_ready_transition(
+    mock_bizhawk_context,
+) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._ram_state_loaded = True
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": True},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+    mock_bizhawk_context.server = SimpleNamespace(socket=SimpleNamespace(closed=False))
+    mock_bizhawk_context.items_received = []
+    mock_bizhawk_context.bizhawk_ctx = object()
+
+    with (
+        patch.object(client, "_sync_death_link_setting", new=AsyncMock()),
+        patch.object(client, "_sync_enemy_copy_ability_runtime_config", new=AsyncMock()),
+        patch.object(client, "_sync_starting_kirby_color_runtime_config", new=AsyncMock()),
+        patch.object(client, "_runtime_gameplay_state", new=AsyncMock(return_value=(False, "menu", None))),
+        patch.object(client, "_log_boss_shard_debug_window", new=AsyncMock()),
+        patch.object(client, "_display_client_message", new=AsyncMock()),
+        patch.object(client, "_deliver_items", new=AsyncMock()),
+        patch.object(client, "_maybe_report_goal", new=AsyncMock()),
+        patch("CommonClient.logger.info") as mock_info,
+    ):
+        await client.game_watcher(mock_bizhawk_context)
+        await client.game_watcher(mock_bizhawk_context)
+
+    matching = [
+        call for call in mock_info.call_args_list
+        if call.args and call.args[0] == "KirbyAM: configured starting Kirby color is %s (%s)"
+    ]
+    assert len(matching) == 1


### PR DESCRIPTION
## Summary
Fix `start_with_all_maps` runtime behavior by reconciling native map ownership from AP state during gameplay.

## Changes
- reassert native area-map bits from `slot_data.start_with_all_maps`
- reassert native area-map bits from confirmed delivered AP map items after reconnect/save-state drift
- add client regression tests for starting maps and delivered-map reconciliation
- document the runtime contract in `PROTOCOL.md` and `CHANGELOG.md`

## Testing
- `d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_client.py -k "reconcile_native_map_ownership or deliver_items or poll_major_chest"`
- `d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_slot_data_contract.py`

Closes #650