### PR TITLE
Fix client starting Kirby color logs leaking when debug is off

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -454,13 +454,12 @@ class KirbyAmClient(BizHawkClient):
         config = self._get_starting_kirby_color_config(ctx)
         if config is None:
             return
+        if not self._debug_logging_enabled:
+            return
         if config == self._starting_kirby_color_logged_signature:
             return
 
         self._starting_kirby_color_logged_signature = config
-        if not self._debug_logging_enabled:
-            return
-
         color_id, color_name = config
 
         from CommonClient import logger
@@ -831,7 +830,6 @@ class KirbyAmClient(BizHawkClient):
 
         self._load_notification_settings(ctx)
         self._load_debug_settings(ctx)
-        self._log_starting_kirby_color_config_once(ctx)
         await self._sync_death_link_setting(ctx)
         await self._sync_enemy_copy_ability_runtime_config(ctx)
 
@@ -845,6 +843,8 @@ class KirbyAmClient(BizHawkClient):
             if self._watcher_requires_bizhawk_resync:
                 self._reset_reconnect_transient_state()
                 self._watcher_requires_bizhawk_resync = False
+
+            self._log_starting_kirby_color_config_once(ctx)
 
             # Load persisted state from RAM once per session (after bizhawk_ctx is valid)
             if not self._ram_state_loaded:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -458,6 +458,9 @@ class KirbyAmClient(BizHawkClient):
             return
 
         self._starting_kirby_color_logged_signature = config
+        if not self._debug_logging_enabled:
+            return
+
         color_id, color_name = config
 
         from CommonClient import logger
@@ -501,6 +504,9 @@ class KirbyAmClient(BizHawkClient):
             [(color_transport_addr, int(color_id).to_bytes(4, "little"), "System Bus")],
         )
         self._starting_kirby_color_synced_id = color_id
+
+        if not self._debug_logging_enabled:
+            return
 
         from CommonClient import logger
 

--- a/worlds/kirbyam/test/test_starting_kirby_color.py
+++ b/worlds/kirbyam/test/test_starting_kirby_color.py
@@ -181,3 +181,71 @@ def test_reset_reconnect_transient_state_clears_starting_color_log_signature() -
     client._reset_reconnect_transient_state()
 
     assert client._starting_kirby_color_logged_signature is None
+
+
+def test_client_starting_color_config_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": False},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+
+    client._load_debug_settings(mock_bizhawk_context)
+    with patch("CommonClient.logger.info") as mock_info:
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+    assert mock_info.call_count == 0
+
+
+def test_client_starting_color_config_log_emits_once_when_debug_enabled(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": True},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+
+    client._load_debug_settings(mock_bizhawk_context)
+    with patch("CommonClient.logger.info") as mock_info:
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+    assert mock_info.call_count == 1
+    assert mock_info.call_args.args[0] == "KirbyAM: configured starting Kirby color is %s (%s)"
+
+
+@pytest.mark.asyncio
+async def test_client_starting_color_sync_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": False},
+        "starting_kirby_color": 7,
+        "starting_kirby_color_name": "Sapphire",
+    }
+
+    with (
+        patch.dict(
+            data.transport_ram_addresses,
+            {"starting_kirby_color_id": 0x0203B050},
+            clear=False,
+        ),
+        patch(
+            "worlds.kirbyam.client.bizhawk.read",
+            new_callable=AsyncMock,
+            side_effect=[[(0xFFFFFFFF).to_bytes(4, "little")]],
+        ),
+        patch(
+            "worlds.kirbyam.client.bizhawk.write",
+            new_callable=AsyncMock,
+        ),
+        patch("CommonClient.logger.info") as mock_info,
+    ):
+        client._load_debug_settings(mock_bizhawk_context)
+        await client._sync_starting_kirby_color_runtime_config(mock_bizhawk_context)
+
+    assert mock_info.call_count == 0

--- a/worlds/kirbyam/test/test_starting_kirby_color.py
+++ b/worlds/kirbyam/test/test_starting_kirby_color.py
@@ -218,6 +218,27 @@ def test_client_starting_color_config_log_emits_once_when_debug_enabled(mock_biz
     assert mock_info.call_args.args[0] == "KirbyAM: configured starting Kirby color is %s (%s)"
 
 
+def test_client_starting_color_config_log_emits_after_debug_toggle_on(mock_bizhawk_context) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": False},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+
+    with patch("CommonClient.logger.info") as mock_info:
+        client._load_debug_settings(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+        mock_bizhawk_context.slot_data["debug"]["logging"] = True
+        client._load_debug_settings(mock_bizhawk_context)
+        client._log_starting_kirby_color_config_once(mock_bizhawk_context)
+
+    assert mock_info.call_count == 1
+    assert client._starting_kirby_color_logged_signature == (0, "Pink")
+
+
 @pytest.mark.asyncio
 async def test_client_starting_color_sync_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
     client = KirbyAmClient()
@@ -249,3 +270,40 @@ async def test_client_starting_color_sync_log_hidden_when_debug_disabled(mock_bi
         await client._sync_starting_kirby_color_runtime_config(mock_bizhawk_context)
 
     assert mock_info.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_client_game_watcher_logs_starting_color_once_after_initial_ready_transition(
+    mock_bizhawk_context,
+) -> None:
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._ram_state_loaded = True
+    mock_bizhawk_context.slot_data = {
+        "debug": {"logging": True},
+        "starting_kirby_color": 0,
+        "starting_kirby_color_name": "Pink",
+    }
+    mock_bizhawk_context.server = SimpleNamespace(socket=SimpleNamespace(closed=False))
+    mock_bizhawk_context.items_received = []
+    mock_bizhawk_context.bizhawk_ctx = object()
+
+    with (
+        patch.object(client, "_sync_death_link_setting", new=AsyncMock()),
+        patch.object(client, "_sync_enemy_copy_ability_runtime_config", new=AsyncMock()),
+        patch.object(client, "_sync_starting_kirby_color_runtime_config", new=AsyncMock()),
+        patch.object(client, "_runtime_gameplay_state", new=AsyncMock(return_value=(False, "menu", None))),
+        patch.object(client, "_log_boss_shard_debug_window", new=AsyncMock()),
+        patch.object(client, "_display_client_message", new=AsyncMock()),
+        patch.object(client, "_deliver_items", new=AsyncMock()),
+        patch.object(client, "_maybe_report_goal", new=AsyncMock()),
+        patch("CommonClient.logger.info") as mock_info,
+    ):
+        await client.game_watcher(mock_bizhawk_context)
+        await client.game_watcher(mock_bizhawk_context)
+
+    matching = [
+        call for call in mock_info.call_args_list
+        if call.args and call.args[0] == "KirbyAM: configured starting Kirby color is %s (%s)"
+    ]
+    assert len(matching) == 1


### PR DESCRIPTION
## Summary
- guard starting Kirby color config and runtime sync log lines behind explicit debug checks
- keep runtime config sync behavior unchanged while suppressing non-debug client output
- add regression tests for debug-disabled suppression and debug-enabled deduplicated logging

## Testing
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_starting_kirby_color.py

Fixes #655