### PR TITLE
Update locations documentation for accuracy

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -30,6 +30,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Fixed vitality counter replays caused by transitions or resets, and prevented vitality counters from lingering in `One-Hit Mode` when that mode excludes them (Issue #571).
 - Fixed some boss checks not being sent when the matching shard was already owned (Issue #573).
 - Fixed extra reconnect and resend diagnostics showing up in the live client unless debug logging was enabled, while still keeping them in the log file (Issue #582).
+- Updated big chest labels to be consistent and no longer uses room names. Also updated location parent regions to be accurate. (Issue #603)
 
 ### Internal Changes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -20,6 +20,7 @@ Contract for `## Unreleased` and all post-public `## v...` sections:
 - Add shuffled enemy copy-ability spoiler output listing each randomized source and resulting copy ability (`kind | source_key -> ability`) so seed analysis can verify enemy mappings and full allowed-ability representation (Issue #586).
 - Add generation-log shuffled assignment table output (`kind | source -> ability`) so seed build logs show deterministic enemy copy-ability grants for shuffled mode.
 - Add completely-random per-swallow reroll telemetry logging (`Kirby swallowed a <EnemyName>. Ability was rerolled to <AbilityName>.`) based on the latest observed runtime swallow event (best-effort; earlier events between polls are noted as missed), while only streaming that line to the live client when `enable_debug_logging` is enabled.
+- Updated big chest labels to be consistent and no longer uses room names. Also updated location parent regions to be accurate. (Issue #603)
 
 ### Bug Fixes
 

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -10,7 +10,7 @@
   },
   "BOSS_DEFEAT_1": {
     "label": "Mustard Mountain - Boss Defeat",
-    "parent_region": "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/ROOM_4_BOSS",
     "default_item": "MAP_MUSTARD_MOUNTAIN",
     "tags": [
       "Boss"
@@ -20,7 +20,7 @@
   },
   "BOSS_DEFEAT_2": {
     "label": "Moonlight Mansion - Boss Defeat",
-    "parent_region": "REGION_MOONLIGHT_MANSION/ROOM_2_14",
+    "parent_region": "REGION_MOONLIGHT_MANSION/ROOM_2_BOSS",
     "default_item": "MAP_MOONLIGHT_MANSION",
     "tags": [
       "Boss"
@@ -30,7 +30,7 @@
   },
   "BOSS_DEFEAT_3": {
     "label": "Candy Constellation - Boss Defeat",
-    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_18",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_BOSS",
     "default_item": "MAP_CANDY_CONSTELLATION",
     "tags": [
       "Boss"
@@ -40,7 +40,7 @@
   },
   "BOSS_DEFEAT_4": {
     "label": "Olive Ocean - Boss Defeat",
-    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_11",
+    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_BOSS",
     "default_item": "MAP_OLIVE_OCEAN",
     "tags": [
       "Boss"
@@ -50,7 +50,7 @@
   },
   "BOSS_DEFEAT_5": {
     "label": "Peppermint Palace - Boss Defeat",
-    "parent_region": "REGION_PEPPERMINT_PALACE/ROOM_7_14",
+    "parent_region": "REGION_PEPPERMINT_PALACE/ROOM_7_BOSS",
     "default_item": "MAP_PEPPERMINT_PALACE",
     "tags": [
       "Boss"
@@ -60,7 +60,7 @@
   },
   "BOSS_DEFEAT_6": {
     "label": "Cabbage Cavern - Boss Defeat",
-    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_15",
+    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_BOSS",
     "default_item": "MAP_CABBAGE_CAVERN",
     "tags": [
       "Boss"
@@ -70,7 +70,7 @@
   },
   "BOSS_DEFEAT_7": {
     "label": "Carrot Castle - Boss Defeat",
-    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_15",
+    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_BOSS",
     "default_item": "MAP_CARROT_CASTLE",
     "tags": [
       "Boss"
@@ -80,7 +80,7 @@
   },
   "BOSS_DEFEAT_8": {
     "label": "Radish Ruins - Boss Defeat",
-    "parent_region": "REGION_RADISH_RUINS/ROOM_8_03",
+    "parent_region": "REGION_RADISH_RUINS/ROOM_8_BOSS",
     "default_item": "MAP_RADISH_RUINS",
     "tags": [
       "Boss"
@@ -89,8 +89,8 @@
     "category": "BOSS_DEFEAT"
   },
   "MAJOR_CHEST_CABBAGE_CAVERN": {
-    "label": "Cabbage Cavern 3-7 - Big Chest",
-    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_HUB_2",
+    "label": "Cabbage Cavern Map - Big Chest",
+    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_GOAL",
     "default_item": "MAP_CABBAGE_CAVERN",
     "tags": [
       "BigChest",
@@ -101,8 +101,8 @@
     "location_id": 3960200
   },
   "MAJOR_CHEST_OLIVE_OCEAN": {
-    "label": "Olive Ocean 6-15 - Big Chest",
-    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_03",
+    "label": "Olive Ocean Map - Big Chest",
+    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_CHEST_2",
     "default_item": "MAP_OLIVE_OCEAN",
     "tags": [
       "BigChest",
@@ -113,7 +113,7 @@
     "location_id": 3960201
   },
   "MAJOR_CHEST_PEPPERMINT_PALACE": {
-    "label": "Peppermint Palace 7-4 - Big Chest",
+    "label": "Peppermint Palace Map - Big Chest",
     "parent_region": "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST",
     "default_item": "MAP_PEPPERMINT_PALACE",
     "tags": [
@@ -125,8 +125,8 @@
     "location_id": 3960202
   },
   "MAJOR_CHEST_RAINBOW_ROUTE": {
-    "label": "Rainbow Route 1-9 - Big Chest",
-    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_09",
+    "label": "Rainbow Route Map - Big Chest",
+    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_HUB_1",
     "default_item": "MAP_RAINBOW_ROUTE",
     "tags": [
       "BigChest",
@@ -137,7 +137,7 @@
     "location_id": 3960203
   },
   "MAJOR_CHEST_MOONLIGHT_MANSION": {
-    "label": "Moonlight Mansion 2-1 - Big Chest",
+    "label": "Moonlight Mansion Map - Big Chest",
     "parent_region": "REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY",
     "default_item": "MAP_MOONLIGHT_MANSION",
     "tags": [
@@ -149,8 +149,8 @@
     "location_id": 3960204
   },
   "MAJOR_CHEST_MUSTARD_MOUNTAIN": {
-    "label": "Mustard Mountain 4-25 - Big Chest",
-    "parent_region": "REGION_MUSTARD_MOUNTAIN/ROOM_4_03",
+    "label": "Mustard Mountain Map - Big Chest",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/ROOM_4_CHEST",
     "default_item": "MAP_MUSTARD_MOUNTAIN",
     "tags": [
       "BigChest",
@@ -161,8 +161,8 @@
     "location_id": 3960205
   },
   "MAJOR_CHEST_CARROT_CASTLE": {
-    "label": "Carrot Castle 5-15 - Big Chest",
-    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_09",
+    "label": "Carrot Castle Map - Big Chest",
+    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_CHEST_2",
     "default_item": "MAP_CARROT_CASTLE",
     "tags": [
       "BigChest",
@@ -173,8 +173,8 @@
     "location_id": 3960206
   },
   "MAJOR_CHEST_RADISH_RUINS": {
-    "label": "Radish Ruins 8-29 - Big Chest",
-    "parent_region": "REGION_RADISH_RUINS/ROOM_8_15",
+    "label": "Radish Ruins Map - Big Chest",
+    "parent_region": "REGION_RADISH_RUINS/ROOM_8_CHEST_2",
     "default_item": "MAP_RADISH_RUINS",
     "tags": [
       "BigChest",
@@ -185,8 +185,8 @@
     "location_id": 3960207
   },
   "MAJOR_CHEST_CANDY_CONSTELLATION": {
-    "label": "Candy Constellation 9-18 - Big Chest",
-    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_02",
+    "label": "Candy Constellation Map - Big Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_3",
     "default_item": "MAP_CANDY_CONSTELLATION",
     "tags": [
       "BigChest",
@@ -197,8 +197,8 @@
     "location_id": 3960208
   },
   "VITALITY_CHEST_CARROT_CASTLE": {
-    "label": "Carrot Castle 5-23 - Big Chest",
-    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_WARP",
+    "label": "Carrot Castle Vitality - Big Chest",
+    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_CHEST_1",
     "default_item": "VITALITY_COUNTER_1",
     "tags": [
       "BigChest",
@@ -210,8 +210,8 @@
     "location_id": 3960300
   },
   "VITALITY_CHEST_OLIVE_OCEAN": {
-    "label": "Olive Ocean 6-21 - Big Chest",
-    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_GOAL_2",
+    "label": "Olive Ocean Vitality - Big Chest",
+    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_CHEST_1",
     "default_item": "VITALITY_COUNTER_2",
     "tags": [
       "BigChest",
@@ -223,8 +223,8 @@
     "location_id": 3960301
   },
   "VITALITY_CHEST_RADISH_RUINS": {
-    "label": "Radish Ruins 8-4 - Big Chest",
-    "parent_region": "REGION_RADISH_RUINS/ROOM_8_14",
+    "label": "Radish Ruins Vitality - Big Chest",
+    "parent_region": "REGION_RADISH_RUINS/ROOM_8_CHEST_1",
     "default_item": "VITALITY_COUNTER_3",
     "tags": [
       "BigChest",
@@ -236,8 +236,8 @@
     "location_id": 3960302
   },
   "VITALITY_CHEST_CANDY_CONSTELLATION": {
-    "label": "Candy Constellation 9-8 - Big Chest",
-    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_1",
+    "label": "Candy Constellation Vitality - Big Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2",
     "default_item": "VITALITY_COUNTER_4",
     "tags": [
       "BigChest",
@@ -249,8 +249,8 @@
     "location_id": 3960303
   },
   "SOUND_PLAYER_CHEST": {
-    "label": "Candy Constellation 9-4 - Big Chest",
-    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2",
+    "label": "Candy Constellation Sound Player - Big Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_1",
     "default_item": "SOUND_PLAYER",
     "tags": [
       "BigChest",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -285,7 +285,7 @@
     },
     "MAJOR_CHEST_CABBAGE_CAVERN": {
       "category": "MAJOR_CHEST",
-      "label": "Cabbage Cavern 3-7 - Big Chest",
+      "label": "Cabbage Cavern Map - Big Chest",
       "location_id": 3960200,
       "tags": [
         "BigChest",
@@ -294,7 +294,7 @@
     },
     "MAJOR_CHEST_CANDY_CONSTELLATION": {
       "category": "MAJOR_CHEST",
-      "label": "Candy Constellation 9-18 - Big Chest",
+      "label": "Candy Constellation Map - Big Chest",
       "location_id": 3960208,
       "tags": [
         "BigChest",
@@ -303,7 +303,7 @@
     },
     "MAJOR_CHEST_CARROT_CASTLE": {
       "category": "MAJOR_CHEST",
-      "label": "Carrot Castle 5-15 - Big Chest",
+      "label": "Carrot Castle Map - Big Chest",
       "location_id": 3960206,
       "tags": [
         "BigChest",
@@ -312,7 +312,7 @@
     },
     "MAJOR_CHEST_MOONLIGHT_MANSION": {
       "category": "MAJOR_CHEST",
-      "label": "Moonlight Mansion 2-1 - Big Chest",
+      "label": "Moonlight Mansion Map - Big Chest",
       "location_id": 3960204,
       "tags": [
         "BigChest",
@@ -321,7 +321,7 @@
     },
     "MAJOR_CHEST_MUSTARD_MOUNTAIN": {
       "category": "MAJOR_CHEST",
-      "label": "Mustard Mountain 4-25 - Big Chest",
+      "label": "Mustard Mountain Map - Big Chest",
       "location_id": 3960205,
       "tags": [
         "BigChest",
@@ -330,7 +330,7 @@
     },
     "MAJOR_CHEST_OLIVE_OCEAN": {
       "category": "MAJOR_CHEST",
-      "label": "Olive Ocean 6-15 - Big Chest",
+      "label": "Olive Ocean Map - Big Chest",
       "location_id": 3960201,
       "tags": [
         "BigChest",
@@ -339,7 +339,7 @@
     },
     "MAJOR_CHEST_PEPPERMINT_PALACE": {
       "category": "MAJOR_CHEST",
-      "label": "Peppermint Palace 7-4 - Big Chest",
+      "label": "Peppermint Palace Map - Big Chest",
       "location_id": 3960202,
       "tags": [
         "BigChest",
@@ -348,7 +348,7 @@
     },
     "MAJOR_CHEST_RADISH_RUINS": {
       "category": "MAJOR_CHEST",
-      "label": "Radish Ruins 8-29 - Big Chest",
+      "label": "Radish Ruins Map - Big Chest",
       "location_id": 3960207,
       "tags": [
         "BigChest",
@@ -357,7 +357,7 @@
     },
     "MAJOR_CHEST_RAINBOW_ROUTE": {
       "category": "MAJOR_CHEST",
-      "label": "Rainbow Route 1-9 - Big Chest",
+      "label": "Rainbow Route Map - Big Chest",
       "location_id": 3960203,
       "tags": [
         "BigChest",
@@ -2470,7 +2470,7 @@
     },
     "SOUND_PLAYER_CHEST": {
       "category": "SOUND_PLAYER_CHEST",
-      "label": "Candy Constellation 9-4 - Big Chest",
+      "label": "Candy Constellation Sound Player - Big Chest",
       "location_id": 3960304,
       "tags": [
         "BigChest",
@@ -2480,7 +2480,7 @@
     },
     "VITALITY_CHEST_CANDY_CONSTELLATION": {
       "category": "VITALITY_CHEST",
-      "label": "Candy Constellation 9-8 - Big Chest",
+      "label": "Candy Constellation Vitality - Big Chest",
       "location_id": 3960303,
       "tags": [
         "BigChest",
@@ -2490,7 +2490,7 @@
     },
     "VITALITY_CHEST_CARROT_CASTLE": {
       "category": "VITALITY_CHEST",
-      "label": "Carrot Castle 5-23 - Big Chest",
+      "label": "Carrot Castle Vitality - Big Chest",
       "location_id": 3960300,
       "tags": [
         "BigChest",
@@ -2500,7 +2500,7 @@
     },
     "VITALITY_CHEST_OLIVE_OCEAN": {
       "category": "VITALITY_CHEST",
-      "label": "Olive Ocean 6-21 - Big Chest",
+      "label": "Olive Ocean Vitality - Big Chest",
       "location_id": 3960301,
       "tags": [
         "BigChest",
@@ -2510,7 +2510,7 @@
     },
     "VITALITY_CHEST_RADISH_RUINS": {
       "category": "VITALITY_CHEST",
-      "label": "Radish Ruins 8-4 - Big Chest",
+      "label": "Radish Ruins Vitality - Big Chest",
       "location_id": 3960302,
       "tags": [
         "BigChest",

--- a/worlds/kirbyam/test/test_naming_conventions.py
+++ b/worlds/kirbyam/test/test_naming_conventions.py
@@ -40,20 +40,20 @@ def test_vitality_items_use_area_specific_names() -> None:
 
 def test_physical_big_chest_locations_hide_contents_in_labels() -> None:
     expected = {
-        "Rainbow Route 1-9 - Big Chest",
-        "Moonlight Mansion 2-1 - Big Chest",
-        "Cabbage Cavern 3-7 - Big Chest",
-        "Mustard Mountain 4-25 - Big Chest",
-        "Carrot Castle 5-15 - Big Chest",
-        "Olive Ocean 6-15 - Big Chest",
-        "Peppermint Palace 7-4 - Big Chest",
-        "Radish Ruins 8-29 - Big Chest",
-        "Candy Constellation 9-18 - Big Chest",
-        "Carrot Castle 5-23 - Big Chest",
-        "Olive Ocean 6-21 - Big Chest",
-        "Radish Ruins 8-4 - Big Chest",
-        "Candy Constellation 9-8 - Big Chest",
-        "Candy Constellation 9-4 - Big Chest",
+        "Rainbow Route Map - Big Chest",
+        "Moonlight Mansion Map - Big Chest",
+        "Cabbage Cavern Map - Big Chest",
+        "Mustard Mountain Map - Big Chest",
+        "Carrot Castle Map - Big Chest",
+        "Olive Ocean Map - Big Chest",
+        "Peppermint Palace Map - Big Chest",
+        "Radish Ruins Map - Big Chest",
+        "Candy Constellation Map - Big Chest",
+        "Carrot Castle Vitality - Big Chest",
+        "Olive Ocean Vitality - Big Chest",
+        "Radish Ruins Vitality - Big Chest",
+        "Candy Constellation Vitality - Big Chest",
+        "Candy Constellation Sound Player - Big Chest",
     }
     actual = {
         location.label


### PR DESCRIPTION
Updates `locations.json` big chest names and parent regions to be accurate and consistent.

I opted for a standard name for big chests as opposed to referencing the room name.

Closes #603 