### PR TITLE
Fix hub-switch bit-label swap and stale baseline; add room entry logging (Issue #651)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -14,7 +14,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - `Starting Kirby Color` lets players begin with a chosen Kirby color instead of always starting as Pink, including a random option for surprise runs (Issue #597).
 - `Start With All Maps` lets players begin with every area map already unlocked for a more guided playthrough (Issue #584).
 - Room names now match familiar Wikirby names, making the game easier to navigate and discuss (Issue #587).
-- World-map big switches are now full Archipelago checks (Issue #481).
+- Hub big switches are now full Archipelago checks (Issue #481).
 - Spoiler output and generation logs now show shuffled enemy ability assignments, making seeds easier to review (Issue #586).
 
 ### Improvements

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -86,6 +86,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x02038960 - 0x0203896A | 10B | Chest/Switch state    | Native chest and switch flags |
 | 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped) |
 | 0x02028CA0 | 576B | gVisitedDoors (`room_visit_flags_native`) | Native room-visit array (`u16[0x120]`); bit 15 marks visited state by `doorsIdx` |
+| 0x02023B28 | 2B | current_room_native | Current native room ID (`gCurLevelInfo[0].currentRoom`) used for room-entry diagnostics |
 | 0x0203AD2C | 4B | AI_KIRBY_STATE          | Runtime phase classifier (Issue #56 gameplay gate) |
 | 0x0203AD10 | 4B | DEMO_PLAYBACK_FLAGS     | Native title-demo discriminator (`demo_playback_flags_native`; bit `0x10` indicates title-screen demo playback) |
 | 0x0203ADE0 | 1B | KIRBY_ACTIVE_COLOR      | Native currently selected Kirby palette index (`0..13`). **Boot-time only**: updates only if written before the game's graphics system initialises; writing during gameplay has no visual effect. |
@@ -307,6 +308,13 @@ room_visits = RAM[0x02028CA0 : 0x02028CA0 + 0x240] as u16[0x120]
 for doors_idx in mapped_room_sanity_doors_indices:
     if room_visits[doors_idx] & 0x8000:
         mapped_checked.add(room_sanity_location_id_for_doors_idx(doors_idx))
+
+# Room-entry diagnostics (best-effort; logging only)
+current_room_native = RAM[0x02023B28] as u16
+if current_room_native changed:
+    doors_idx = ROM[gRoomProps + current_room_native * gRoomPropsStride + doorsIdxOffset] as u16
+    room_label = rooms_json_label_for_doors_idx(doors_idx)
+    log_room_entry(room_label, current_room_native, doors_idx)
 
 # Level-based, reconnect-safe resend:
 # Send only checks that RAM reports as collected but the server has not acknowledged.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -293,8 +293,12 @@ for bit in mapped_sound_player_chest_bits:
 
 # Hub switch checks (transport hub_switch_flags)
 hub_switch_bits = RAM[0x0203B04C] as u32
+if first_hub_switch_poll and server_checked_locations is empty and hub_switch_bits != 0:
+    # Treat pre-existing transport bits as baseline to avoid stale cross-session resend.
+    hub_switch_baseline = hub_switch_bits
+effective_hub_switch_bits = hub_switch_bits & ~hub_switch_baseline
 for bit in mapped_hub_switch_bits:
-    if (hub_switch_bits >> bit) & 1:
+    if (effective_hub_switch_bits >> bit) & 1:
         mapped_checked.add(hub_switch_location_id_for_bit(bit))
 
 # Room sanity checks (native gVisitedDoors)
@@ -321,6 +325,7 @@ Boss shard scrub timing contract (Issue #505):
 
 **Behavior notes:**
 - Detection is **level-based** (current bitfield state), not edge-based, to be reconnect-safe.
+- Hub-switch polling suppresses only pre-session baseline bits on first poll when server state is empty, preventing stale EWRAM bits from being resent as fresh checks.
 - No checks are sent for bits already in `server_checked_locations`.
 - No checks are sent for reserved/unmapped bits even when set.
 - Boss-defeat, major-chest, vitality-chest, sound-player-chest, hub-switch, and room-sanity polling follow the same resend/dedupe diagnostic contract.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -293,6 +293,7 @@ for bit in mapped_sound_player_chest_bits:
 
 # Hub switch checks (transport hub_switch_flags)
 hub_switch_bits = RAM[0x0203B04C] as u32
+hub_switch_baseline = 0
 if first_hub_switch_poll and server_checked_locations is empty and hub_switch_bits != 0:
     # Treat pre-existing transport bits as baseline to avoid stale cross-session resend.
     hub_switch_baseline = hub_switch_bits

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -62,7 +62,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x40   | 0x0203B040 | 4B | mailbox_init_cookie | u32 | ROM internal | Initialization cookie (`0x4B41504D`). If absent/mismatched, payload seeds `delivered_shard_bitfield` from native shard state, clears scrub delay + boss-defeat flags + boss temp shard mask, and stores the cookie to prevent stale EWRAM transport values from triggering scrub writes. |
 | 0x44   | 0x0203B044 | 4B | boss_temp_shard_bitfield | u32 | ROM internal | Bits 0-7 track shard bits temporarily written by boss-defeat hook for cutscene safety. On gameplay resume, payload scrubs only `boss_temp_shard_bitfield & ~delivered_shard_bitfield`, then clears this mask. |
 | 0x48   | 0x0203B048 | 4B | delivered_vitality_item_bits | u32 | ROM internal | Replay guard for vitality counter items. Bit N marks that `VITALITY_COUNTER_(N+1)` has already been applied, preventing duplicate vitality grants if an item is resent during reconnect/reset recovery. |
-| 0x4C   | 0x0203B04C | 4B | hub_switch_flags | u32 | ROM → Client | Bits 0–14 set when world-map big-switch door unlock callbacks fire (`WorldMapDoor` order: Moonlight, RR East, RR South, Cabbage Center, RR West, Carrot, RR North, Mustard, Cabbage West, Radish, Peppermint East, Peppermint West, Cabbage East, Olive, Candy). |
+| 0x4C   | 0x0203B04C | 4B | hub_switch_flags | u32 | ROM → Client | Bits 0–14 set when world-map big-switch door unlock callbacks fire (`WorldMapDoor` order: Peppermint West, RR East, RR South, Cabbage Center, RR West, Carrot, RR North, Mustard, Cabbage West, Radish, Peppermint East, Moonlight, Cabbage East, Olive, Candy). |
 | 0x50   | 0x0203B050 | 4B | starting_kirby_color_id | u32 | ROM ← Client | Runtime config payload for starting Kirby color. Valid values are `0..13`; `0` (Pink) is intentionally treated as a no-op by payload logic. Non-Pink values are applied through `KIRBY_TRANSITION_COLOR`, so the color becomes visible on the next room/area transition or when an enemy-hit path refreshes Kirby's runtime color state (typically the first transition after game start). |
 | 0x54–0x63 | 0x0203B054–0x0203B063 | 16B | *(reserved)* | — | — | Reserved; not currently used. |
 | 0x64   | 0x0203B064 | 4B | ability_randomization_mode_runtime | u32 | ROM ← Client | Enemy copy-ability randomization mode (`0`=off, `1`=shuffled, `2`=completely_random). Written once per connection by the Python client from `slot_data`. |
@@ -144,7 +144,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_RADISH_RUINS | 3960302 | Radish Ruins 8-4 vitality big chest (transport vitality bit 2) |
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
-| HUB_SWITCH_MOONLIGHT .. HUB_SWITCH_CANDY | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 |
+| HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 11 = Moonlight; others sequential) |
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -62,7 +62,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x40   | 0x0203B040 | 4B | mailbox_init_cookie | u32 | ROM internal | Initialization cookie (`0x4B41504D`). If absent/mismatched, payload seeds `delivered_shard_bitfield` from native shard state, clears scrub delay + boss-defeat flags + boss temp shard mask, and stores the cookie to prevent stale EWRAM transport values from triggering scrub writes. |
 | 0x44   | 0x0203B044 | 4B | boss_temp_shard_bitfield | u32 | ROM internal | Bits 0-7 track shard bits temporarily written by boss-defeat hook for cutscene safety. On gameplay resume, payload scrubs only `boss_temp_shard_bitfield & ~delivered_shard_bitfield`, then clears this mask. |
 | 0x48   | 0x0203B048 | 4B | delivered_vitality_item_bits | u32 | ROM internal | Replay guard for vitality counter items. Bit N marks that `VITALITY_COUNTER_(N+1)` has already been applied, preventing duplicate vitality grants if an item is resent during reconnect/reset recovery. |
-| 0x4C   | 0x0203B04C | 4B | hub_switch_flags | u32 | ROM → Client | Bits 0–14 set when world-map big-switch door unlock callbacks fire (`WorldMapDoor` order: Peppermint West, RR East, RR South, Cabbage Center, RR West, Carrot, RR North, Mustard, Cabbage West, Radish, Peppermint East, Moonlight, Cabbage East, Olive, Candy). |
+| 0x4C   | 0x0203B04C | 4B | hub_switch_flags | u32 | ROM → Client | Bits 0–14 set when world-map big-switch door unlock callbacks fire (`WorldMapDoor` order: Peppermint West, RR East, RR South, Cabbage Center, RR West, Carrot, RR North, Mustard, Cabbage West, Radish, Moonlight, Peppermint East, Cabbage East, Olive, Candy). |
 | 0x50   | 0x0203B050 | 4B | starting_kirby_color_id | u32 | ROM ← Client | Runtime config payload for starting Kirby color. Valid values are `0..13`; `0` (Pink) is intentionally treated as a no-op by payload logic. Non-Pink values are applied through `KIRBY_TRANSITION_COLOR`, so the color becomes visible on the next room/area transition or when an enemy-hit path refreshes Kirby's runtime color state (typically the first transition after game start). |
 | 0x54–0x63 | 0x0203B054–0x0203B063 | 16B | *(reserved)* | — | — | Reserved; not currently used. |
 | 0x64   | 0x0203B064 | 4B | ability_randomization_mode_runtime | u32 | ROM ← Client | Enemy copy-ability randomization mode (`0`=off, `1`=shuffled, `2`=completely_random). Written once per connection by the Python client from `slot_data`. |
@@ -144,7 +144,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_RADISH_RUINS | 3960302 | Radish Ruins 8-4 vitality big chest (transport vitality bit 2) |
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
-| HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 11 = Moonlight; others sequential) |
+| HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 10 = Moonlight; others sequential) |
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -2320,33 +2320,33 @@ class KirbyAmClient(BizHawkClient):
         if rom_received_count is not None:
             if rom_received_count > len(ctx.items_received):
                 if not self._delivery_counter_ahead_fallback_active:
-                    if self._debug_logging_enabled:
-                        logger.info(
-                            "KirbyAM: ROM delivery counter is ahead of received items (rom=%s, received=%s); "
-                            "ignoring ROM counter and continuing mailbox delivery",
-                            rom_received_count,
-                            len(ctx.items_received),
-                        )
+                    logger.info(
+                        "KirbyAM: ROM delivery counter is ahead of received items (rom=%s, received=%s); "
+                        "ignoring ROM counter and continuing mailbox delivery",
+                        rom_received_count,
+                        len(ctx.items_received),
+                        extra={"NoStream": not self._debug_logging_enabled},
+                    )
                 self._delivery_counter_ahead_fallback_active = True
             else:
                 if self._delivery_counter_ahead_fallback_active:
-                    if self._debug_logging_enabled:
-                        logger.info(
-                            "KirbyAM: ROM delivery counter is back in range (rom=%s, received=%s); "
-                            "restoring normal mailbox synchronization",
-                            rom_received_count,
-                            len(ctx.items_received),
-                        )
+                    logger.info(
+                        "KirbyAM: ROM delivery counter is back in range (rom=%s, received=%s); "
+                        "restoring normal mailbox synchronization",
+                        rom_received_count,
+                        len(ctx.items_received),
+                        extra={"NoStream": not self._debug_logging_enabled},
+                    )
                 self._delivery_counter_ahead_fallback_active = False
                 self._delivery_counter_ahead_resume_logged = False
 
             if rom_received_count < self._delivered_item_index:
-                if self._debug_logging_enabled:
-                    logger.info(
-                        "KirbyAM: ROM delivery counter moved backward from %s to %s; rewinding client delivery cursor",
-                        self._delivered_item_index,
-                        rom_received_count,
-                    )
+                logger.info(
+                    "KirbyAM: ROM delivery counter moved backward from %s to %s; rewinding client delivery cursor",
+                    self._delivered_item_index,
+                    rom_received_count,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
@@ -2365,12 +2365,12 @@ class KirbyAmClient(BizHawkClient):
                 # Treat forward counter movement as authoritative only for a pending
                 # delivery ACK. This avoids stale ROM counters skipping deliveries.
                 _ff_pending_item_index = self._delivery_pending_item_index
-                if self._debug_logging_enabled:
-                    logger.info(
-                        "KirbyAM: ROM delivery counter moved forward from %s to %s on pending ACK; fast-forwarding client delivery cursor",
-                        self._delivered_item_index,
-                        rom_received_count,
-                    )
+                logger.info(
+                    "KirbyAM: ROM delivery counter moved forward from %s to %s on pending ACK; fast-forwarding client delivery cursor",
+                    self._delivered_item_index,
+                    rom_received_count,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
@@ -2515,14 +2515,14 @@ class KirbyAmClient(BizHawkClient):
             item_id, player_id = item_fields
 
             if self._delivery_counter_ahead_fallback_active and not self._delivery_counter_ahead_resume_logged:
-                if self._debug_logging_enabled:
-                    logger.info(
-                        "KirbyAM: ROM counter fallback active; continuing mailbox delivery at item index %s "
-                        "(rom=%s, received=%s)",
-                        self._delivered_item_index,
-                        rom_received_count,
-                        len(ctx.items_received),
-                    )
+                logger.info(
+                    "KirbyAM: ROM counter fallback active; continuing mailbox delivery at item index %s "
+                    "(rom=%s, received=%s)",
+                    self._delivered_item_index,
+                    rom_received_count,
+                    len(ctx.items_received),
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._delivery_counter_ahead_resume_logged = True
 
             if self._debug_logging_enabled:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -209,6 +209,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_sound_player_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_hub_switch_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._hub_switch_baseline_mask: int | None = None
+        self._hub_switch_session_initialized: bool = False
         self._last_room_sanity_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Notification pipeline state (Issue #83)
@@ -272,6 +273,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_sound_player_chest_poll_log = None
         self._last_hub_switch_poll_log = None
         self._hub_switch_baseline_mask = None
+        self._hub_switch_session_initialized = False
         self._last_room_sanity_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
@@ -1916,18 +1918,28 @@ class KirbyAmClient(BizHawkClient):
         raw = (await bizhawk.read(ctx.bizhawk_ctx, [(switch_addr, 4, "System Bus")]))[0]
         switch_bits = self._u32_le(raw)
 
-        if self._hub_switch_baseline_mask is None:
-            baseline_mask = 0
-            if not ctx.checked_locations and switch_bits:
-                baseline_mask = switch_bits
-                from CommonClient import logger
+        # Map all set bits to location IDs to determine which are pre-session stale.
+        all_mapped_locations: set[int] = set()
+        for bit in sorted(self._hub_switch_location_ids_by_bit.keys()):
+            if (switch_bits >> bit) & 1:
+                all_mapped_locations.update(self._hub_switch_location_ids_by_bit.get(bit, []))
 
-                logger.info(
-                    "KirbyAM: hub-switch baseline initialized from pre-session transport state; suppressing stale resend candidates (baseline=0x%08X)",
-                    baseline_mask,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
-            self._hub_switch_baseline_mask = baseline_mask
+        # Capture baseline on first poll of this session to suppress pre-session stale bits.
+        # Only suppress bits that are NOT already acknowledged by the server (those are legitimate).
+        if not self._hub_switch_session_initialized:
+            self._hub_switch_session_initialized = True
+            if self._hub_switch_baseline_mask is None:
+                stale_mapped_locations = all_mapped_locations - ctx.checked_locations
+                if stale_mapped_locations:
+                    # Only suppress bits for unmapped/stale locations on first poll
+                    self._hub_switch_baseline_mask = switch_bits
+                    from CommonClient import logger
+
+                    logger.info(
+                        "KirbyAM: hub-switch baseline initialized from pre-session transport state; suppressing stale resend candidates (baseline=0x%08X)",
+                        switch_bits,
+                        extra={"NoStream": not self._debug_logging_enabled},
+                    )
 
         effective_switch_bits = switch_bits & ~(self._hub_switch_baseline_mask or 0)
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -376,16 +376,16 @@ class KirbyAmClient(BizHawkClient):
             [(map_addr, desired_bits.to_bytes(4, "little"), "System Bus")],
         )
 
-        from CommonClient import logger
+        if self._debug_logging_enabled:
+            from CommonClient import logger
 
-        logger.info(
-            "KirbyAM: reconciled native map ownership (current=0x%08X, desired=0x%08X, start_with_all_maps=%s, delivered_item_index=%s)",
-            current_bits,
-            desired_bits,
-            self._start_with_all_maps_enabled(ctx),
-            self._delivered_item_index,
-            extra={"NoStream": not self._debug_logging_enabled},
-        )
+            logger.info(
+                "KirbyAM: reconciled native map ownership (current=0x%08X, desired=0x%08X, start_with_all_maps=%s, delivered_item_index=%s)",
+                current_bits,
+                desired_bits,
+                self._start_with_all_maps_enabled(ctx),
+                self._delivered_item_index,
+            )
 
     @staticmethod
     def _item_signature(item: object) -> tuple[int, int, int, int] | None:
@@ -568,7 +568,6 @@ class KirbyAmClient(BizHawkClient):
             "KirbyAM: configured starting Kirby color is %s (%s)",
             color_name,
             color_id,
-            extra={"NoStream": not self._debug_logging_enabled},
         )
 
     async def _sync_starting_kirby_color_runtime_config(self, ctx: "BizHawkClientContext") -> None:
@@ -613,7 +612,6 @@ class KirbyAmClient(BizHawkClient):
             "KirbyAM: synced starting Kirby color runtime config (%s / %s)",
             color_name,
             color_id,
-            extra={"NoStream": not self._debug_logging_enabled},
         )
 
     @staticmethod
@@ -1724,28 +1722,29 @@ class KirbyAmClient(BizHawkClient):
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
-            from CommonClient import logger
-
             boss_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if boss_log_state != self._last_boss_poll_log:
-                logger.info(
-                    "KirbyAM: resending boss-defeat LocationChecks missing on server (missing=%s, acked=%s)",
-                    missing_on_server,
-                    already_acknowledged,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.info(
+                        "KirbyAM: resending boss-defeat LocationChecks missing on server (missing=%s, acked=%s)",
+                        missing_on_server,
+                        already_acknowledged,
+                    )
                 self._last_boss_poll_log = boss_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
-            from CommonClient import logger
-
             boss_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if boss_log_state != self._last_boss_poll_log:
-                logger.debug(
-                    "KirbyAM: dedupe suppressed boss-defeat LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                    already_acknowledged,
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.debug(
+                        "KirbyAM: dedupe suppressed boss-defeat LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                        already_acknowledged,
+                    )
                 self._last_boss_poll_log = boss_log_state
         else:
             self._last_boss_poll_log = None
@@ -1780,28 +1779,29 @@ class KirbyAmClient(BizHawkClient):
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
-            from CommonClient import logger
-
             chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if chest_log_state != self._last_major_chest_poll_log:
-                logger.info(
-                    "KirbyAM: resending major-chest LocationChecks missing on server (missing=%s, acked=%s)",
-                    missing_on_server,
-                    already_acknowledged,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.info(
+                        "KirbyAM: resending major-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                        missing_on_server,
+                        already_acknowledged,
+                    )
                 self._last_major_chest_poll_log = chest_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
-            from CommonClient import logger
-
             chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if chest_log_state != self._last_major_chest_poll_log:
-                logger.debug(
-                    "KirbyAM: dedupe suppressed major-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                    already_acknowledged,
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.debug(
+                        "KirbyAM: dedupe suppressed major-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                        already_acknowledged,
+                    )
                 self._last_major_chest_poll_log = chest_log_state
         else:
             self._last_major_chest_poll_log = None
@@ -1829,28 +1829,29 @@ class KirbyAmClient(BizHawkClient):
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
-            from CommonClient import logger
-
             chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if chest_log_state != self._last_vitality_chest_poll_log:
-                logger.info(
-                    "KirbyAM: resending vitality-chest LocationChecks missing on server (missing=%s, acked=%s)",
-                    missing_on_server,
-                    already_acknowledged,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.info(
+                        "KirbyAM: resending vitality-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                        missing_on_server,
+                        already_acknowledged,
+                    )
                 self._last_vitality_chest_poll_log = chest_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
-            from CommonClient import logger
-
             chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if chest_log_state != self._last_vitality_chest_poll_log:
-                logger.debug(
-                    "KirbyAM: dedupe suppressed vitality-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                    already_acknowledged,
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.debug(
+                        "KirbyAM: dedupe suppressed vitality-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                        already_acknowledged,
+                    )
                 self._last_vitality_chest_poll_log = chest_log_state
         else:
             self._last_vitality_chest_poll_log = None
@@ -1877,28 +1878,29 @@ class KirbyAmClient(BizHawkClient):
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
-            from CommonClient import logger
-
             chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if chest_log_state != self._last_sound_player_chest_poll_log:
-                logger.info(
-                    "KirbyAM: resending sound-player-chest LocationChecks missing on server (missing=%s, acked=%s)",
-                    missing_on_server,
-                    already_acknowledged,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.info(
+                        "KirbyAM: resending sound-player-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                        missing_on_server,
+                        already_acknowledged,
+                    )
                 self._last_sound_player_chest_poll_log = chest_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
-            from CommonClient import logger
-
             chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if chest_log_state != self._last_sound_player_chest_poll_log:
-                logger.debug(
-                    "KirbyAM: dedupe suppressed sound-player-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                    already_acknowledged,
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.debug(
+                        "KirbyAM: dedupe suppressed sound-player-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                        already_acknowledged,
+                    )
                 self._last_sound_player_chest_poll_log = chest_log_state
         else:
             self._last_sound_player_chest_poll_log = None
@@ -1933,13 +1935,13 @@ class KirbyAmClient(BizHawkClient):
                 if stale_mapped_locations:
                     # Only suppress bits for unmapped/stale locations on first poll
                     self._hub_switch_baseline_mask = switch_bits
-                    from CommonClient import logger
+                    if self._debug_logging_enabled:
+                        from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: hub-switch baseline initialized from pre-session transport state; suppressing stale resend candidates (baseline=0x%08X)",
-                        switch_bits,
-                        extra={"NoStream": not self._debug_logging_enabled},
-                    )
+                        logger.info(
+                            "KirbyAM: hub-switch baseline initialized from pre-session transport state; suppressing stale resend candidates (baseline=0x%08X)",
+                            switch_bits,
+                        )
 
         effective_switch_bits = switch_bits & ~(self._hub_switch_baseline_mask or 0)
 
@@ -1951,28 +1953,29 @@ class KirbyAmClient(BizHawkClient):
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
-            from CommonClient import logger
-
             switch_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if switch_log_state != self._last_hub_switch_poll_log:
-                logger.info(
-                    "KirbyAM: resending hub-switch LocationChecks missing on server (missing=%s, acked=%s)",
-                    missing_on_server,
-                    already_acknowledged,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.info(
+                        "KirbyAM: resending hub-switch LocationChecks missing on server (missing=%s, acked=%s)",
+                        missing_on_server,
+                        already_acknowledged,
+                    )
                 self._last_hub_switch_poll_log = switch_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
-            from CommonClient import logger
-
             switch_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if switch_log_state != self._last_hub_switch_poll_log:
-                logger.debug(
-                    "KirbyAM: dedupe suppressed hub-switch LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                    already_acknowledged,
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.debug(
+                        "KirbyAM: dedupe suppressed hub-switch LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                        already_acknowledged,
+                    )
                 self._last_hub_switch_poll_log = switch_log_state
         else:
             self._last_hub_switch_poll_log = None
@@ -2024,11 +2027,11 @@ class KirbyAmClient(BizHawkClient):
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
         if missing_on_server:
-            from CommonClient import logger
-
             room_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if room_log_state != self._last_room_sanity_poll_log:
                 if self._debug_logging_enabled:
+                    from CommonClient import logger
+
                     logger.info(
                         "KirbyAM: resending room-sanity LocationChecks missing on server (missing=%s, acked=%s)",
                         missing_on_server,
@@ -2038,14 +2041,15 @@ class KirbyAmClient(BizHawkClient):
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
-            from CommonClient import logger
-
             room_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if room_log_state != self._last_room_sanity_poll_log:
-                logger.debug(
-                    "KirbyAM: dedupe suppressed room-sanity LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                    already_acknowledged,
-                )
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
+
+                    logger.debug(
+                        "KirbyAM: dedupe suppressed room-sanity LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                        already_acknowledged,
+                    )
                 self._last_room_sanity_poll_log = room_log_state
         else:
             self._last_room_sanity_poll_log = None
@@ -2238,33 +2242,33 @@ class KirbyAmClient(BizHawkClient):
         if rom_received_count is not None:
             if rom_received_count > len(ctx.items_received):
                 if not self._delivery_counter_ahead_fallback_active:
-                    logger.info(
-                        "KirbyAM: ROM delivery counter is ahead of received items (rom=%s, received=%s); "
-                        "ignoring ROM counter and continuing mailbox delivery",
-                        rom_received_count,
-                        len(ctx.items_received),
-                        extra={"NoStream": not self._debug_logging_enabled},
-                    )
+                    if self._debug_logging_enabled:
+                        logger.info(
+                            "KirbyAM: ROM delivery counter is ahead of received items (rom=%s, received=%s); "
+                            "ignoring ROM counter and continuing mailbox delivery",
+                            rom_received_count,
+                            len(ctx.items_received),
+                        )
                 self._delivery_counter_ahead_fallback_active = True
             else:
                 if self._delivery_counter_ahead_fallback_active:
-                    logger.info(
-                        "KirbyAM: ROM delivery counter is back in range (rom=%s, received=%s); "
-                        "restoring normal mailbox synchronization",
-                        rom_received_count,
-                        len(ctx.items_received),
-                        extra={"NoStream": not self._debug_logging_enabled},
-                    )
+                    if self._debug_logging_enabled:
+                        logger.info(
+                            "KirbyAM: ROM delivery counter is back in range (rom=%s, received=%s); "
+                            "restoring normal mailbox synchronization",
+                            rom_received_count,
+                            len(ctx.items_received),
+                        )
                 self._delivery_counter_ahead_fallback_active = False
                 self._delivery_counter_ahead_resume_logged = False
 
             if rom_received_count < self._delivered_item_index:
-                logger.info(
-                    "KirbyAM: ROM delivery counter moved backward from %s to %s; rewinding client delivery cursor",
-                    self._delivered_item_index,
-                    rom_received_count,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    logger.info(
+                        "KirbyAM: ROM delivery counter moved backward from %s to %s; rewinding client delivery cursor",
+                        self._delivered_item_index,
+                        rom_received_count,
+                    )
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
@@ -2283,12 +2287,12 @@ class KirbyAmClient(BizHawkClient):
                 # Treat forward counter movement as authoritative only for a pending
                 # delivery ACK. This avoids stale ROM counters skipping deliveries.
                 _ff_pending_item_index = self._delivery_pending_item_index
-                logger.info(
-                    "KirbyAM: ROM delivery counter moved forward from %s to %s on pending ACK; fast-forwarding client delivery cursor",
-                    self._delivered_item_index,
-                    rom_received_count,
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    logger.info(
+                        "KirbyAM: ROM delivery counter moved forward from %s to %s on pending ACK; fast-forwarding client delivery cursor",
+                        self._delivered_item_index,
+                        rom_received_count,
+                    )
                 self._delivered_item_index = rom_received_count
                 self._delivery_pending = False
                 self._delivery_pending_frame = None
@@ -2433,23 +2437,23 @@ class KirbyAmClient(BizHawkClient):
             item_id, player_id = item_fields
 
             if self._delivery_counter_ahead_fallback_active and not self._delivery_counter_ahead_resume_logged:
-                logger.info(
-                    "KirbyAM: ROM counter fallback active; continuing mailbox delivery at item index %s "
-                    "(rom=%s, received=%s)",
-                    self._delivered_item_index,
-                    rom_received_count,
-                    len(ctx.items_received),
-                    extra={"NoStream": not self._debug_logging_enabled},
-                )
+                if self._debug_logging_enabled:
+                    logger.info(
+                        "KirbyAM: ROM counter fallback active; continuing mailbox delivery at item index %s "
+                        "(rom=%s, received=%s)",
+                        self._delivered_item_index,
+                        rom_received_count,
+                        len(ctx.items_received),
+                    )
                 self._delivery_counter_ahead_resume_logged = True
 
-            logger.info(
-                "KirbyAM: Delivering mailbox item index %s (%s from %s)",
-                self._delivered_item_index,
-                self._item_name(ctx, item_id, player_id),
-                self._player_name(ctx, player_id),
-                extra={"NoStream": not self._debug_logging_enabled},
-            )
+            if self._debug_logging_enabled:
+                logger.info(
+                    "KirbyAM: Delivering mailbox item index %s (%s from %s)",
+                    self._delivered_item_index,
+                    self._item_name(ctx, item_id, player_id),
+                    self._player_name(ctx, player_id),
+                )
             await bizhawk.write(ctx.bizhawk_ctx, [
                 (id_addr, item_id.to_bytes(4, "little"), "System Bus"),
                 (player_addr, player_id.to_bytes(4, "little"), "System Bus"),

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -2112,8 +2112,6 @@ class KirbyAmClient(BizHawkClient):
         if native_room_id == self._last_native_room_id:
             return
 
-        self._last_native_room_id = native_room_id
-
         # Resolve doorsIdx via gRoomProps[native_room_id].doorsIdx (ROM read).
         rom_doors_idx_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
         try:
@@ -2131,6 +2129,7 @@ class KirbyAmClient(BizHawkClient):
 
         doors_idx = unpack_from("<H", doors_raw)[0]
         room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
+        self._last_native_room_id = native_room_id
         logger.info(
             "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
             room_label,

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -305,6 +305,9 @@ class KirbyAmClient(BizHawkClient):
         self._cached_delivered_map_bits = 0
         self._cached_map_bits_index = 0
         self._cached_map_bits_items_len = 0
+        # Reset hub-switch baseline on reconnect so new session can re-capture baseline from current ROM state
+        self._hub_switch_session_initialized = False
+        self._hub_switch_baseline_mask = None
 
     def _no_extra_lives_enabled(self, ctx: "BizHawkClientContext") -> bool:
         slot_data = getattr(ctx, "slot_data", None)

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -47,6 +47,10 @@ _KIRBY_VITALITY_COUNTER_READ_WIDTH = 2
 _ROOM_VISIT_FLAGS_ADDR_KEY = "room_visit_flags_native"
 _ROOM_VISIT_FLAGS_ENTRY_COUNT = 0x120
 _ROOM_VISIT_FLAGS_BIT_MASK = 0x8000
+_CURRENT_ROOM_ADDR_KEY = "current_room_native"
+_ROOM_PROPS_ROM_BASE = 0x009331AC  # gRoomProps[] — ROM domain offset (GBA ROM 0x089331AC)
+_ROOM_PROPS_STRIDE = 0x28  # sizeof(struct RoomProps)
+_ROOM_PROPS_DOORS_IDX_OFFSET = 0x24  # offsetof(struct RoomProps, doorsIdx)
 _STARTING_KIRBY_COLOR_MIN = 0
 _STARTING_KIRBY_COLOR_MAX = 13
 _STARTING_KIRBY_COLOR_REVALIDATE_TICKS = 4
@@ -246,6 +250,10 @@ class KirbyAmClient(BizHawkClient):
         self._starting_kirby_color_synced_id: int | None = None
         self._starting_kirby_color_logged_signature: tuple[int, str] | None = None
         self._starting_kirby_color_revalidate_counter: int = 0
+
+        # Room entry logging (always to file; client display gated by debug flag)
+        self._last_native_room_id: int | None = None
+        self._room_label_by_doors_idx: dict[int, str] = self._build_room_label_lookup()
 
     @staticmethod
     def _server_session_ready(ctx: "BizHawkClientContext") -> bool:
@@ -1007,6 +1015,9 @@ class KirbyAmClient(BizHawkClient):
             # Room-sanity location polling via native gVisitedDoors bit 15.
             await self._poll_room_sanity_locations(ctx)
 
+            # Room entry logging (always to file; client display gated by debug flag).
+            await self._poll_room_entry_logging(ctx)
+
             # Candidate discovery for non-shard boss defeat signals.
             await self._probe_boss_defeat_candidates(ctx)
 
@@ -1637,6 +1648,20 @@ class KirbyAmClient(BizHawkClient):
         return None
 
     @staticmethod
+    def _build_room_label_lookup() -> "dict[int, str]":
+        """Build a doorsIdx → region_key mapping from all rooms in rooms.json."""
+        rooms_json = load_json_data("regions/rooms.json")
+        result: dict[int, str] = {}
+        for region_key, room in rooms_json.items():
+            rs = room.get("room_sanity")
+            if not isinstance(rs, dict):
+                continue
+            bit_index = rs.get("bit_index")
+            if bit_index is not None:
+                result[int(bit_index)] = str(region_key)
+        return result
+
+    @staticmethod
     def _coerce_u32(value: object) -> int | None:
         try:
             parsed = int(value)
@@ -2053,6 +2078,59 @@ class KirbyAmClient(BizHawkClient):
                 self._last_room_sanity_poll_log = room_log_state
         else:
             self._last_room_sanity_poll_log = None
+
+    async def _poll_room_entry_logging(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Detect native room changes and log the current room on every entry.
+
+        Reads gCurLevelInfo[0].currentRoom (u16 at current_room_native). When the
+        value changes, resolves the native room ID to a doorsIdx via gRoomProps[] in
+        ROM, then maps doorsIdx to a region key from rooms.json.
+
+        Always written to the log file; shown in the client only when debug logging
+        is enabled.
+        """
+        from CommonClient import logger
+
+        current_room_addr = self._native_addr(_CURRENT_ROOM_ADDR_KEY)
+        if current_room_addr is None:
+            return
+
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(current_room_addr, 2, "System Bus")]))[0]
+        if len(raw) != 2:
+            return
+
+        native_room_id = unpack_from("<H", raw)[0]
+
+        if native_room_id == self._last_native_room_id:
+            return
+
+        self._last_native_room_id = native_room_id
+
+        # Resolve doorsIdx via gRoomProps[native_room_id].doorsIdx (ROM read).
+        rom_doors_idx_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
+        try:
+            doors_raw = (await bizhawk.read(ctx.bizhawk_ctx, [(rom_doors_idx_addr, 2, "ROM")]))[0]
+        except bizhawk.RequestFailedError:
+            logger.info(
+                "KirbyAM: room entry — native=0x%04x (doorsIdx lookup failed)",
+                native_room_id,
+                extra={"NoStream": not self._debug_logging_enabled},
+            )
+            return
+
+        if len(doors_raw) != 2:
+            return
+
+        doors_idx = unpack_from("<H", doors_raw)[0]
+        room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
+        logger.info(
+            "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
+            room_label,
+            native_room_id,
+            doors_idx,
+            extra={"NoStream": not self._debug_logging_enabled},
+        )
 
     async def _probe_boss_defeat_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -280,8 +280,6 @@ class KirbyAmClient(BizHawkClient):
         self._last_vitality_chest_poll_log = None
         self._last_sound_player_chest_poll_log = None
         self._last_hub_switch_poll_log = None
-        self._hub_switch_baseline_mask = None
-        self._hub_switch_session_initialized = False
         self._last_room_sanity_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
@@ -1947,28 +1945,20 @@ class KirbyAmClient(BizHawkClient):
         raw = (await bizhawk.read(ctx.bizhawk_ctx, [(switch_addr, 4, "System Bus")]))[0]
         switch_bits = self._u32_le(raw)
 
-        # Map all set bits to location IDs to determine which are pre-session stale.
-        all_mapped_locations: set[int] = set()
-        for bit in sorted(self._hub_switch_location_ids_by_bit.keys()):
-            if (switch_bits >> bit) & 1:
-                all_mapped_locations.update(self._hub_switch_location_ids_by_bit.get(bit, []))
-
-        # Capture baseline on first poll of this session to suppress pre-session stale bits.
-        # Only suppress bits that are NOT already acknowledged by the server (those are legitimate).
+        # Capture baseline only on first hub-switch poll of a session when the server
+        # has not yet acknowledged any locations. This suppresses pre-session stale
+        # transport bits while avoiding suppression when the session is already active.
         if not self._hub_switch_session_initialized:
             self._hub_switch_session_initialized = True
-            if self._hub_switch_baseline_mask is None:
-                stale_mapped_locations = all_mapped_locations - ctx.checked_locations
-                if stale_mapped_locations:
-                    # Only suppress bits for unmapped/stale locations on first poll
-                    self._hub_switch_baseline_mask = switch_bits
-                    if self._debug_logging_enabled:
-                        from CommonClient import logger
+            if self._hub_switch_baseline_mask is None and switch_bits != 0 and not ctx.checked_locations:
+                self._hub_switch_baseline_mask = switch_bits
+                if self._debug_logging_enabled:
+                    from CommonClient import logger
 
-                        logger.info(
-                            "KirbyAM: hub-switch baseline initialized from pre-session transport state; suppressing stale resend candidates (baseline=0x%08X)",
-                            switch_bits,
-                        )
+                    logger.info(
+                        "KirbyAM: hub-switch baseline initialized from first-poll transport state before any server acknowledgements (baseline=0x%08X)",
+                        switch_bits,
+                    )
 
         effective_switch_bits = switch_bits & ~(self._hub_switch_baseline_mask or 0)
 
@@ -2100,7 +2090,7 @@ class KirbyAmClient(BizHawkClient):
 
         try:
             raw = (await bizhawk.read(ctx.bizhawk_ctx, [(current_room_addr, 2, "System Bus")]))[0]
-        except (bizhawk.RequestFailedError, TypeError, AttributeError):
+        except (bizhawk.RequestFailedError, bizhawk.ConnectorError, bizhawk.SyncError, TypeError, AttributeError):
             # Room-entry diagnostics are best-effort and must never block watcher progress.
             return
         if len(raw) != 2:
@@ -2117,7 +2107,7 @@ class KirbyAmClient(BizHawkClient):
         rom_doors_idx_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
         try:
             doors_raw = (await bizhawk.read(ctx.bizhawk_ctx, [(rom_doors_idx_addr, 2, "ROM")]))[0]
-        except (bizhawk.RequestFailedError, TypeError, AttributeError):
+        except (bizhawk.RequestFailedError, bizhawk.ConnectorError, bizhawk.SyncError, TypeError, AttributeError):
             logger.info(
                 "KirbyAM: room entry — native=0x%04x (doorsIdx lookup failed)",
                 native_room_id,

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -214,6 +214,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_hub_switch_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._hub_switch_baseline_mask: int | None = None
         self._hub_switch_session_initialized: bool = False
+        self._hub_switch_stream_marker: object = None
         self._last_room_sanity_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Notification pipeline state (Issue #83)
@@ -305,9 +306,6 @@ class KirbyAmClient(BizHawkClient):
         self._cached_delivered_map_bits = 0
         self._cached_map_bits_index = 0
         self._cached_map_bits_items_len = 0
-        # Reset hub-switch baseline on reconnect so new session can re-capture baseline from current ROM state
-        self._hub_switch_session_initialized = False
-        self._hub_switch_baseline_mask = None
 
     def _no_extra_lives_enabled(self, ctx: "BizHawkClientContext") -> bool:
         slot_data = getattr(ctx, "slot_data", None)
@@ -1809,27 +1807,27 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if chest_log_state != self._last_major_chest_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: resending major-chest LocationChecks missing on server (missing=%s, acked=%s)",
-                        missing_on_server,
-                        already_acknowledged,
-                    )
+                logger.info(
+                    "KirbyAM: resending major-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_major_chest_poll_log = chest_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if chest_log_state != self._last_major_chest_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.debug(
-                        "KirbyAM: dedupe suppressed major-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                        already_acknowledged,
-                    )
+                logger.debug(
+                    "KirbyAM: dedupe suppressed major-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_major_chest_poll_log = chest_log_state
         else:
             self._last_major_chest_poll_log = None
@@ -1859,27 +1857,27 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if chest_log_state != self._last_vitality_chest_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: resending vitality-chest LocationChecks missing on server (missing=%s, acked=%s)",
-                        missing_on_server,
-                        already_acknowledged,
-                    )
+                logger.info(
+                    "KirbyAM: resending vitality-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_vitality_chest_poll_log = chest_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if chest_log_state != self._last_vitality_chest_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.debug(
-                        "KirbyAM: dedupe suppressed vitality-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                        already_acknowledged,
-                    )
+                logger.debug(
+                    "KirbyAM: dedupe suppressed vitality-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_vitality_chest_poll_log = chest_log_state
         else:
             self._last_vitality_chest_poll_log = None
@@ -1908,27 +1906,27 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if chest_log_state != self._last_sound_player_chest_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: resending sound-player-chest LocationChecks missing on server (missing=%s, acked=%s)",
-                        missing_on_server,
-                        already_acknowledged,
-                    )
+                logger.info(
+                    "KirbyAM: resending sound-player-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_sound_player_chest_poll_log = chest_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if chest_log_state != self._last_sound_player_chest_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.debug(
-                        "KirbyAM: dedupe suppressed sound-player-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                        already_acknowledged,
-                    )
+                logger.debug(
+                    "KirbyAM: dedupe suppressed sound-player-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_sound_player_chest_poll_log = chest_log_state
         else:
             self._last_sound_player_chest_poll_log = None
@@ -1947,6 +1945,16 @@ class KirbyAmClient(BizHawkClient):
 
         raw = (await bizhawk.read(ctx.bizhawk_ctx, [(switch_addr, 4, "System Bus")]))[0]
         switch_bits = self._u32_le(raw)
+
+        # Keep baseline across AP reconnects, but re-baseline on BizHawk/ROM stream
+        # identity changes (transport reconnect, core swap, or ROM resync).
+        stream_marker = getattr(ctx.bizhawk_ctx, "streams", None)
+        if self._hub_switch_stream_marker is None:
+            self._hub_switch_stream_marker = stream_marker
+        elif stream_marker is not self._hub_switch_stream_marker:
+            self._hub_switch_stream_marker = stream_marker
+            self._hub_switch_session_initialized = False
+            self._hub_switch_baseline_mask = None
 
         # Capture baseline only on first hub-switch poll of a session when the server
         # has not yet acknowledged any locations. This suppresses pre-session stale
@@ -1975,27 +1983,27 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             switch_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if switch_log_state != self._last_hub_switch_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: resending hub-switch LocationChecks missing on server (missing=%s, acked=%s)",
-                        missing_on_server,
-                        already_acknowledged,
-                    )
+                logger.info(
+                    "KirbyAM: resending hub-switch LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_hub_switch_poll_log = switch_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             switch_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if switch_log_state != self._last_hub_switch_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.debug(
-                        "KirbyAM: dedupe suppressed hub-switch LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                        already_acknowledged,
-                    )
+                logger.debug(
+                    "KirbyAM: dedupe suppressed hub-switch LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_hub_switch_poll_log = switch_log_state
         else:
             self._last_hub_switch_poll_log = None

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1652,6 +1652,8 @@ class KirbyAmClient(BizHawkClient):
         """Build a doorsIdx → region_key mapping from all rooms in rooms.json."""
         rooms_json = load_json_data("regions/rooms.json")
         result: dict[int, str] = {}
+        if not isinstance(rooms_json, dict):
+            return result
         for region_key, room in rooms_json.items():
             rs = room.get("room_sanity")
             if not isinstance(rs, dict):
@@ -1749,27 +1751,27 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             boss_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if boss_log_state != self._last_boss_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: resending boss-defeat LocationChecks missing on server (missing=%s, acked=%s)",
-                        missing_on_server,
-                        already_acknowledged,
-                    )
+                logger.info(
+                    "KirbyAM: resending boss-defeat LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_boss_poll_log = boss_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             boss_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if boss_log_state != self._last_boss_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.debug(
-                        "KirbyAM: dedupe suppressed boss-defeat LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                        already_acknowledged,
-                    )
+                logger.debug(
+                    "KirbyAM: dedupe suppressed boss-defeat LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_boss_poll_log = boss_log_state
         else:
             self._last_boss_poll_log = None
@@ -2054,27 +2056,27 @@ class KirbyAmClient(BizHawkClient):
         if missing_on_server:
             room_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
             if room_log_state != self._last_room_sanity_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.info(
-                        "KirbyAM: resending room-sanity LocationChecks missing on server (missing=%s, acked=%s)",
-                        missing_on_server,
-                        already_acknowledged,
-                    )
+                logger.info(
+                    "KirbyAM: resending room-sanity LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_room_sanity_poll_log = room_log_state
 
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
         elif mapped_checked_locations:
             room_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
             if room_log_state != self._last_room_sanity_poll_log:
-                if self._debug_logging_enabled:
-                    from CommonClient import logger
+                from CommonClient import logger
 
-                    logger.debug(
-                        "KirbyAM: dedupe suppressed room-sanity LocationChecks (all RAM-derived checks already acknowledged: %s)",
-                        already_acknowledged,
-                    )
+                logger.debug(
+                    "KirbyAM: dedupe suppressed room-sanity LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
                 self._last_room_sanity_poll_log = room_log_state
         else:
             self._last_room_sanity_poll_log = None
@@ -2096,7 +2098,11 @@ class KirbyAmClient(BizHawkClient):
         if current_room_addr is None:
             return
 
-        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(current_room_addr, 2, "System Bus")]))[0]
+        try:
+            raw = (await bizhawk.read(ctx.bizhawk_ctx, [(current_room_addr, 2, "System Bus")]))[0]
+        except (bizhawk.RequestFailedError, TypeError, AttributeError):
+            # Room-entry diagnostics are best-effort and must never block watcher progress.
+            return
         if len(raw) != 2:
             return
 
@@ -2111,7 +2117,7 @@ class KirbyAmClient(BizHawkClient):
         rom_doors_idx_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
         try:
             doors_raw = (await bizhawk.read(ctx.bizhawk_ctx, [(rom_doors_idx_addr, 2, "ROM")]))[0]
-        except bizhawk.RequestFailedError:
+        except (bizhawk.RequestFailedError, TypeError, AttributeError):
             logger.info(
                 "KirbyAM: room entry — native=0x%04x (doorsIdx lookup failed)",
                 native_room_id,
@@ -2525,13 +2531,13 @@ class KirbyAmClient(BizHawkClient):
                 )
                 self._delivery_counter_ahead_resume_logged = True
 
-            if self._debug_logging_enabled:
-                logger.info(
-                    "KirbyAM: Delivering mailbox item index %s (%s from %s)",
-                    self._delivered_item_index,
-                    self._item_name(ctx, item_id, player_id),
-                    self._player_name(ctx, player_id),
-                )
+            logger.info(
+                "KirbyAM: Delivering mailbox item index %s (%s from %s)",
+                self._delivered_item_index,
+                self._item_name(ctx, item_id, player_id),
+                self._player_name(ctx, player_id),
+                extra={"NoStream": not self._debug_logging_enabled},
+            )
             await bizhawk.write(ctx.bizhawk_ctx, [
                 (id_addr, item_id.to_bytes(4, "little"), "System Bus"),
                 (player_addr, player_id.to_bytes(4, "little"), "System Bus"),

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -208,6 +208,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_vitality_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_sound_player_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_hub_switch_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._hub_switch_baseline_mask: int | None = None
         self._last_room_sanity_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Notification pipeline state (Issue #83)
@@ -270,6 +271,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_vitality_chest_poll_log = None
         self._last_sound_player_chest_poll_log = None
         self._last_hub_switch_poll_log = None
+        self._hub_switch_baseline_mask = None
         self._last_room_sanity_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
@@ -1914,9 +1916,24 @@ class KirbyAmClient(BizHawkClient):
         raw = (await bizhawk.read(ctx.bizhawk_ctx, [(switch_addr, 4, "System Bus")]))[0]
         switch_bits = self._u32_le(raw)
 
+        if self._hub_switch_baseline_mask is None:
+            baseline_mask = 0
+            if not ctx.checked_locations and switch_bits:
+                baseline_mask = switch_bits
+                from CommonClient import logger
+
+                logger.info(
+                    "KirbyAM: hub-switch baseline initialized from pre-session transport state; suppressing stale resend candidates (baseline=0x%08X)",
+                    baseline_mask,
+                    extra={"NoStream": not self._debug_logging_enabled},
+                )
+            self._hub_switch_baseline_mask = baseline_mask
+
+        effective_switch_bits = switch_bits & ~(self._hub_switch_baseline_mask or 0)
+
         mapped_checked_locations: set[int] = set()
         for bit in sorted(self._hub_switch_location_ids_by_bit.keys()):
-            if (switch_bits >> bit) & 1:
+            if (effective_switch_bits >> bit) & 1:
                 mapped_checked_locations.update(self._hub_switch_location_ids_by_bit.get(bit, []))
 
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -37,6 +37,7 @@
       "big_chest_bitfield_native": "0x0203897C",
       "boss_mirror_table_native": "0x02028C14",
       "room_visit_flags_native": "0x02028CA0",
+      "current_room_native": "0x02023B28",
       "ai_kirby_state_native": "0x0203AD2C",
       "demo_playback_flags_native": "0x0203AD10",
       "kirby_transition_color_native": "0x02020FBF",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -268,9 +268,9 @@
       "HubSwitch",
       "MAP_MOONLIGHT_MANSION"
     ],
-    "bit_index": 11,
+    "bit_index": 10,
     "category": "HUB_SWITCH",
-    "location_id": 3960411
+    "location_id": 3960410
   },
   "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
     "label": "Rainbow Route East - Big Switch",
@@ -378,9 +378,9 @@
       "HubSwitch",
       "MAP_PEPPERMINT_PALACE"
     ],
-    "bit_index": 10,
+    "bit_index": 11,
     "category": "HUB_SWITCH",
-    "location_id": 3960410
+    "location_id": 3960411
   },
   "HUB_SWITCH_PEPPERMINT_WEST": {
     "label": "Peppermint Palace West - Big Switch",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -268,9 +268,9 @@
       "HubSwitch",
       "MAP_MOONLIGHT_MANSION"
     ],
-    "bit_index": 0,
+    "bit_index": 11,
     "category": "HUB_SWITCH",
-    "location_id": 3960400
+    "location_id": 3960411
   },
   "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
     "label": "Rainbow Route East - Big Switch",
@@ -389,9 +389,9 @@
       "HubSwitch",
       "MAP_PEPPERMINT_PALACE"
     ],
-    "bit_index": 11,
+    "bit_index": 0,
     "category": "HUB_SWITCH",
-    "location_id": 3960411
+    "location_id": 3960400
   },
   "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
     "label": "Cabbage Cavern East - Big Switch",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -196,7 +196,7 @@
     "HUB_SWITCH_MOONLIGHT": {
       "category": "HUB_SWITCH",
       "label": "Moonlight Mansion - Big Switch",
-      "location_id": 3960400,
+      "location_id": 3960411,
       "tags": [
         "HubSwitch",
         "MAP_MOONLIGHT_MANSION"
@@ -232,7 +232,7 @@
     "HUB_SWITCH_PEPPERMINT_WEST": {
       "category": "HUB_SWITCH",
       "label": "Peppermint Palace West - Big Switch",
-      "location_id": 3960411,
+      "location_id": 3960400,
       "tags": [
         "HubSwitch",
         "MAP_PEPPERMINT_PALACE"

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -196,7 +196,7 @@
     "HUB_SWITCH_MOONLIGHT": {
       "category": "HUB_SWITCH",
       "label": "Moonlight Mansion - Big Switch",
-      "location_id": 3960411,
+      "location_id": 3960410,
       "tags": [
         "HubSwitch",
         "MAP_MOONLIGHT_MANSION"
@@ -223,7 +223,7 @@
     "HUB_SWITCH_PEPPERMINT_EAST": {
       "category": "HUB_SWITCH",
       "label": "Peppermint Palace East - Big Switch",
-      "location_id": 3960410,
+      "location_id": 3960411,
       "tags": [
         "HubSwitch",
         "MAP_PEPPERMINT_PALACE"

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -8,7 +8,13 @@ import worlds._bizhawk as bizhawk
 from worlds._bizhawk.context import _game_watcher, AuthStatus
 
 from ..data import data
-from ..client import KirbyAmClient, _MAP_ITEM_ID_TO_AREA_ID
+from ..client import (
+    KirbyAmClient,
+    _MAP_ITEM_ID_TO_AREA_ID,
+    _ROOM_PROPS_DOORS_IDX_OFFSET,
+    _ROOM_PROPS_ROM_BASE,
+    _ROOM_PROPS_STRIDE,
+)
 from ..options import OneHitMode
 from ..rom import KirbyAmProcedurePatch
 
@@ -599,6 +605,149 @@ async def test_poll_hub_switch_skips_when_address_missing(mock_bizhawk_context):
 
     mock_read.assert_not_awaited()
     mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_hub_switch_rebaselines_on_stream_marker_change(mock_bizhawk_context):
+    """Hub-switch baseline persists across AP reconnect, but stream change forces re-baseline."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    rainbow_east = data.locations["HUB_SWITCH_RAINBOW_ROUTE_EAST"].location_id
+    mock_bizhawk_context.checked_locations = set()
+    mock_bizhawk_context.bizhawk_ctx.streams = object()
+
+    with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.side_effect = [
+            [((1 << 10)).to_bytes(4, 'little')],
+            [((1 << 10)).to_bytes(4, 'little')],
+            [((1 << 10) | (1 << 1)).to_bytes(4, 'little')],
+        ]
+
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+        # Simulate BizHawk stream identity change (ROM resync / reconnect).
+        mock_bizhawk_context.bizhawk_ctx.streams = object()
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [rainbow_east]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_logs_only_on_room_change(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {42: "REGION_TEST_ROOM"}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [(0x0010).to_bytes(2, 'little')],
+            [(42).to_bytes(2, 'little')],
+            [(0x0010).to_bytes(2, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert mock_read.await_count == 3
+    mock_logger.info.assert_called_once_with(
+        "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
+        "REGION_TEST_ROOM",
+        0x0010,
+        42,
+        extra={"NoStream": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_reads_doors_idx_from_rom_lookup(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._debug_logging_enabled = True
+    client._room_label_by_doors_idx = {7: "REGION_LOOKUP_ROOM"}
+
+    native_room_id = 0x0021
+    expected_rom_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [native_room_id.to_bytes(2, 'little')],
+            [(7).to_bytes(2, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    mock_read.assert_any_await(
+        mock_bizhawk_context.bizhawk_ctx,
+        [(expected_rom_addr, 2, "ROM")],
+    )
+    mock_logger.info.assert_called_once_with(
+        "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
+        "REGION_LOOKUP_ROOM",
+        native_room_id,
+        7,
+        extra={"NoStream": False},
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_handles_rom_lookup_failure(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [(0x0003).to_bytes(2, 'little')],
+            bizhawk.SyncError("lookup failed"),
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    mock_logger.info.assert_called_once_with(
+        "KirbyAM: room entry — native=0x%04x (doorsIdx lookup failed)",
+        0x0003,
+        extra={"NoStream": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_nostream_gating_respects_debug_flag(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {9: "REGION_NOSTREAM_ROOM"}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [(0x0012).to_bytes(2, 'little')],
+            [(9).to_bytes(2, 'little')],
+        ]
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    mock_logger.info.assert_called_once()
+    assert mock_logger.info.call_args.kwargs.get("extra", {}).get("NoStream") is True
+
+    client._last_native_room_id = None
+    client._debug_logging_enabled = True
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [(0x0013).to_bytes(2, 'little')],
+            [(9).to_bytes(2, 'little')],
+        ]
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    mock_logger.info.assert_called_once()
+    assert mock_logger.info.call_args.kwargs.get("extra", {}).get("NoStream") is False
 
 
 def test_major_chest_data_sanity():
@@ -2800,6 +2949,10 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
     client._last_vitality_chest_poll_log = ("resend", (4,), ())
     client._last_sound_player_chest_poll_log = ("resend", (5,), ())
     client._last_hub_switch_poll_log = ("resend", (6,), ())
+    client._hub_switch_baseline_mask = 0x00000400
+    client._hub_switch_session_initialized = True
+    hub_stream_marker = object()
+    client._hub_switch_stream_marker = hub_stream_marker
     client._last_boss_probe_snapshot = bytes(32)
     client._boss_probe_stream_marker = object()
     client._unsafe_delivery_probe_stream_marker = object()
@@ -2832,6 +2985,9 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         assert client._last_vitality_chest_poll_log is None
         assert client._last_sound_player_chest_poll_log is None
         assert client._last_hub_switch_poll_log is None
+        assert client._hub_switch_baseline_mask == 0x00000400
+        assert client._hub_switch_session_initialized is True
+        assert client._hub_switch_stream_marker is hub_stream_marker
         assert client._last_boss_probe_snapshot is None
         assert client._boss_probe_stream_marker is None
         assert client._unsafe_delivery_probe_stream_marker is None

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -538,6 +538,7 @@ async def test_poll_hub_switch_suppresses_pre_session_stale_bits(mock_bizhawk_co
     """First hub-switch poll with non-zero transport bits should baseline and suppress them."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
 
     mock_bizhawk_context.checked_locations = {1, 2, 3}  # Other checks already acknowledged
 
@@ -560,6 +561,7 @@ async def test_poll_hub_switch_skips_already_server_acknowledged(mock_bizhawk_co
     """No hub-switch resend when server already acknowledges all mapped transport checks."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
 
     moonlight = data.locations["HUB_SWITCH_MOONLIGHT"].location_id
     mock_bizhawk_context.checked_locations = {moonlight}

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -524,7 +524,7 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
         mock_read.side_effect = [
             [(0).to_bytes(4, 'little')],
-            [((1 << 11) | (1 << 1)).to_bytes(4, 'little')],
+            [((1 << 10) | (1 << 1)).to_bytes(4, 'little')],
         ]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
@@ -572,7 +572,7 @@ async def test_poll_hub_switch_skips_already_server_acknowledged(mock_bizhawk_co
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
          patch('CommonClient.logger') as mock_logger:
-        mock_read.return_value = [((1 << 11)).to_bytes(4, 'little')]
+        mock_read.return_value = [((1 << 10)).to_bytes(4, 'little')]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -537,12 +537,12 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
 
 @pytest.mark.asyncio
 async def test_poll_hub_switch_suppresses_pre_session_stale_bits(mock_bizhawk_context):
-    """First hub-switch poll with non-zero transport bits should baseline and suppress them."""
+    """First hub-switch poll with empty checked_locations should baseline and suppress stale bits."""
     client = KirbyAmClient()
     client.initialize_client()
     client._debug_logging_enabled = True
 
-    mock_bizhawk_context.checked_locations = {1, 2, 3}  # Other checks already acknowledged
+    mock_bizhawk_context.checked_locations = set()
 
     with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -535,11 +535,11 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
 
 @pytest.mark.asyncio
 async def test_poll_hub_switch_suppresses_pre_session_stale_bits(mock_bizhawk_context):
-    """First non-empty read with empty server state should be treated as baseline."""
+    """First hub-switch poll with non-zero transport bits should baseline and suppress them."""
     client = KirbyAmClient()
     client.initialize_client()
 
-    mock_bizhawk_context.checked_locations = set()
+    mock_bizhawk_context.checked_locations = {1, 2, 3}  # Other checks already acknowledged
 
     with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -719,6 +719,34 @@ async def test_poll_room_entry_logging_handles_rom_lookup_failure(mock_bizhawk_c
 
 
 @pytest.mark.asyncio
+async def test_poll_room_entry_logging_retries_after_short_rom_read(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {11: "REGION_RETRY_ROOM"}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [(0x0008).to_bytes(2, 'little')],
+            [b'\x0b'],
+            [(0x0008).to_bytes(2, 'little')],
+            [(11).to_bytes(2, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert client._last_native_room_id == 0x0008
+    mock_logger.info.assert_called_once_with(
+        "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
+        "REGION_RETRY_ROOM",
+        0x0008,
+        11,
+        extra={"NoStream": True},
+    )
+
+
+@pytest.mark.asyncio
 async def test_poll_room_entry_logging_nostream_gating_respects_debug_flag(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2023,10 +2023,13 @@ async def test_room_sanity_resend_log_gated_by_debug(mock_bizhawk_context):
         await client._poll_room_sanity_locations(mock_bizhawk_context)
 
     mock_send.assert_awaited_once_with([{"cmd": "LocationChecks", "locations": [3961000]}])
-    assert not any(
-        call.args and isinstance(call.args[0], str) and "resending room-sanity LocationChecks missing on server" in call.args[0]
+    matching_disabled = [
+        call
         for call in mock_logger.info.call_args_list
-    )
+        if call.args and isinstance(call.args[0], str) and "resending room-sanity LocationChecks missing on server" in call.args[0]
+    ]
+    assert matching_disabled
+    assert all(call.kwargs.get("extra", {}).get("NoStream") is True for call in matching_disabled)
 
     client = KirbyAmClient()
     client.initialize_client()
@@ -2044,11 +2047,13 @@ async def test_room_sanity_resend_log_gated_by_debug(mock_bizhawk_context):
 
         await client._poll_room_sanity_locations(mock_bizhawk_context)
 
-    mock_logger.info.assert_any_call(
-        "KirbyAM: resending room-sanity LocationChecks missing on server (missing=%s, acked=%s)",
-        [3961000],
-        [],
-    )
+    matching_enabled = [
+        call
+        for call in mock_logger.info.call_args_list
+        if call.args and isinstance(call.args[0], str) and "resending room-sanity LocationChecks missing on server" in call.args[0]
+    ]
+    assert matching_enabled
+    assert all(call.kwargs.get("extra", {}).get("NoStream") is False for call in matching_enabled)
 
 
 @pytest.mark.asyncio
@@ -3248,7 +3253,7 @@ def test_death_link_flavor_templates_loaded_from_data_file():
         client = KirbyAmClient()
         client.initialize_client()
 
-    mock_loader.assert_called_once_with("deathlink_flavor_text.json")
+    mock_loader.assert_any_call("deathlink_flavor_text.json")
     assert client._death_link_flavor_templates == sentinel_templates
 
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -349,6 +349,7 @@ async def test_poll_major_chest_skips_already_server_acknowledged(mock_bizhawk_c
     """No major-chest resend when server already acknowledges all mapped transport checks."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
 
     olive = data.locations["MAJOR_CHEST_OLIVE_OCEAN"].location_id
     mock_bizhawk_context.checked_locations = {olive}
@@ -428,6 +429,7 @@ async def test_poll_vitality_chest_skips_already_server_acknowledged(mock_bizhaw
     """No vitality-chest resend when server already acknowledges all mapped transport checks."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
 
     carrot = data.locations["VITALITY_CHEST_CARROT_CASTLE"].location_id
     mock_bizhawk_context.checked_locations = {carrot}
@@ -522,14 +524,14 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
         mock_read.side_effect = [
             [(0).to_bytes(4, 'little')],
-            [((1 << 0) | (1 << 1)).to_bytes(4, 'little')],
+            [((1 << 11) | (1 << 1)).to_bytes(4, 'little')],
         ]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
         await client._poll_hub_switch_locations(mock_bizhawk_context)
 
     mock_send.assert_awaited_once_with([
-        {"cmd": "LocationChecks", "locations": [moonlight, rainbow_east]}
+        {"cmd": "LocationChecks", "locations": [rainbow_east, moonlight]}
     ])
 
 
@@ -570,7 +572,7 @@ async def test_poll_hub_switch_skips_already_server_acknowledged(mock_bizhawk_co
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
          patch('CommonClient.logger') as mock_logger:
-        mock_read.return_value = [((1 << 0)).to_bytes(4, 'little')]
+        mock_read.return_value = [((1 << 11)).to_bytes(4, 'little')]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
 
@@ -3398,6 +3400,7 @@ async def test_poll_boss_defeat_skips_already_server_acknowledged(mock_bizhawk_c
     """No LocationChecks sent when boss defeat bit is set but server already acknowledged it."""
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
 
     boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
     mock_bizhawk_context.checked_locations = {boss1_loc}

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -509,7 +509,7 @@ async def test_poll_sound_player_chest_skips_when_address_missing(mock_bizhawk_c
 
 @pytest.mark.asyncio
 async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_context):
-    """Set transport hub-switch bits should map to hub-switch LocationChecks."""
+    """Set transport hub-switch bits after baseline should map to LocationChecks."""
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -520,14 +520,39 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
     with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
-        # Bits 0 and 1 set => Moonlight and Rainbow Route East hub switch checks.
-        mock_read.return_value = [((1 << 0) | (1 << 1)).to_bytes(4, 'little')]
+        mock_read.side_effect = [
+            [(0).to_bytes(4, 'little')],
+            [((1 << 0) | (1 << 1)).to_bytes(4, 'little')],
+        ]
 
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
         await client._poll_hub_switch_locations(mock_bizhawk_context)
 
     mock_send.assert_awaited_once_with([
         {"cmd": "LocationChecks", "locations": [moonlight, rainbow_east]}
     ])
+
+
+@pytest.mark.asyncio
+async def test_poll_hub_switch_suppresses_pre_session_stale_bits(mock_bizhawk_context):
+    """First non-empty read with empty server state should be treated as baseline."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.return_value = [((1 << 0)).to_bytes(4, 'little')]
+
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
+    assert mock_logger.info.called
+    assert "hub-switch baseline initialized" in mock_logger.info.call_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
+++ b/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
@@ -19,7 +19,7 @@ SystemID GBA
 0203B040	d	h	0	System Bus	mailbox_init_cookie (expect 4B41504D)
 0203B044	d	h	0	System Bus	boss_temp_shard_bitfield
 0203B048	d	h	0	System Bus	delivered_vitality_item_bits
-0203B04C	d	b	0	System Bus	hub_switch_flags (ROM->Client; bit0=PeppermintW, bit1=RREast, bit2=RRSouth, bit3=CabbageCenter, bit4=RRWest, bit5=Carrot, bit6=RRNorth, bit7=Mustard, bit8=CabbageWest, bit9=Radish, bit10=PeppermintE, bit11=Moonlight, bit12=CabbageEast, bit13=Olive, bit14=Candy)
+0203B04C	d	b	0	System Bus	hub_switch_flags (ROM->Client; bit0=PeppermintW, bit1=RREast, bit2=RRSouth, bit3=CabbageCenter, bit4=RRWest, bit5=Carrot, bit6=RRNorth, bit7=Mustard, bit8=CabbageWest, bit9=Radish, bit10=Moonlight, bit11=PeppermintE, bit12=CabbageEast, bit13=Olive, bit14=Candy)
 0	S	_	1		=== Native Gameplay Addresses (from worlds/kirbyam/data/addresses.json) ===
 02038970	b	h	0	System Bus	shard_bitfield_native (KIRBY_SHARD_FLAGS)
 0203897C	d	h	0	System Bus	big_chest_bitfield_native (gTreasures.bigChestField)

--- a/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
+++ b/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
@@ -41,7 +41,7 @@ SystemID GBA
 0203B028	d	h	0	System Bus	CHEAT: force major_chest_flags bits for AP checks
 0203B02C	d	h	0	System Bus	CHEAT: force vitality_chest_flags bits for AP checks
 0203B030	d	h	0	System Bus	CHEAT: force sound_player_chest_flags bit0
-0203B04C	d	h	0	System Bus	CHEAT: force hub_switch_flags bits (bit0=PeppermintW, bit11=Moonlight, bits0-14)
+0203B04C	d	h	0	System Bus	CHEAT: force hub_switch_flags bits (bit0=PeppermintW, bit10=Moonlight, bit11=PeppermintE, bits0-14)
 0	S	_	1		=== Internet Cheat Notes (USA Gameshark source: almarsguides.com) ===
 0	S	_	1		GS Master: 34165F72 B08D117B / 25982608 B17B6C25
 0	S	_	1		GS Invulnerability: 771681C5 6954AFCA

--- a/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
+++ b/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
@@ -1,5 +1,5 @@
 SystemID GBA
-0	S	_	0		=== KirbyAM AP Transport Mailbox (0x0203B000 block) ===
+0	S	_	1		=== KirbyAM AP Transport Mailbox (0x0203B000 block) ===
 0203B000	d	h	0	System Bus	shard_bitfield (ROM->Client)
 0203B004	d	h	0	System Bus	incoming_item_flag (Client->ROM)
 0203B008	d	h	0	System Bus	incoming_item_id (Client->ROM)
@@ -19,17 +19,19 @@ SystemID GBA
 0203B040	d	h	0	System Bus	mailbox_init_cookie (expect 4B41504D)
 0203B044	d	h	0	System Bus	boss_temp_shard_bitfield
 0203B048	d	h	0	System Bus	delivered_vitality_item_bits
-0	S	_	0		=== Native Gameplay Addresses (from worlds/kirbyam/data/addresses.json) ===
+0203B04C	d	b	0	System Bus	hub_switch_flags (ROM->Client; bit0=PeppermintW, bit1=RREast, bit2=RRSouth, bit3=CabbageCenter, bit4=RRWest, bit5=Carrot, bit6=RRNorth, bit7=Mustard, bit8=CabbageWest, bit9=Radish, bit10=PeppermintE, bit11=Moonlight, bit12=CabbageEast, bit13=Olive, bit14=Candy)
+0	S	_	1		=== Native Gameplay Addresses (from worlds/kirbyam/data/addresses.json) ===
 02038970	b	h	0	System Bus	shard_bitfield_native (KIRBY_SHARD_FLAGS)
 0203897C	d	h	0	System Bus	big_chest_bitfield_native (gTreasures.bigChestField)
 02028C14	d	h	0	System Bus	boss_mirror_table_native [probe]
 02028CA0	w	h	0	System Bus	room_visit_flags_native[0] (gVisitedDoors base)
 02028CA2	w	h	0	System Bus	room_visit_flags_native[1]
 02028CA4	w	h	0	System Bus	room_visit_flags_native[2]
+02023B28	w	u	0	System Bus	current_room_native (gCurLevelInfo[0].currentRoom; native room ID)
 0203AD2C	d	u	0	System Bus	ai_kirby_state_native
 0203AD10	d	h	0	System Bus	demo_playback_flags_native
 02020FE0	b	s	0	System Bus	kirby_hp_native (s8)
-0	S	_	0		=== Cheat/Freeze Targets (manual RAM manipulation) ===
+0	S	_	1		=== Cheat/Freeze Targets (manual RAM manipulation) ===
 02020FE0	b	s	0	System Bus	CHEAT: freeze HP > 0 (commonly 6) to avoid death
 02038970	b	h	0	System Bus	CHEAT: freeze shard flags to FF (all mirror shards)
 0203897C	d	h	0	System Bus	CHEAT: freeze major chest map flags (1..9 bits)
@@ -39,11 +41,13 @@ SystemID GBA
 0203B028	d	h	0	System Bus	CHEAT: force major_chest_flags bits for AP checks
 0203B02C	d	h	0	System Bus	CHEAT: force vitality_chest_flags bits for AP checks
 0203B030	d	h	0	System Bus	CHEAT: force sound_player_chest_flags bit0
-0	S	_	0		=== Internet Cheat Notes (USA Gameshark source: almarsguides.com) ===
-0	S	_	0		GS Master: 34165F72 B08D117B / 25982608 B17B6C25
-0	S	_	0		GS Invulnerability: 771681C5 6954AFCA
-0	S	_	0		GS Unlimited Lives: 87650B7E 2F78AE65
-0	S	_	0		GS Unlimited Batteries: 4117F0AB 1D88A2C5
-0	S	_	0		GS Unlimited Energy: EEDEF930 E6D64031
-0	S	_	0		NOTE: Internet GS/CB codes are region/version dependent (USA listed). Verify against your ROM build.
-0	S	_	0		WARNING: Freezing AP transport fields can desync server/client/ROM state; use in offline testing only.
+0203B04C	d	h	0	System Bus	CHEAT: force hub_switch_flags bits (bit0=PeppermintW, bit11=Moonlight, bits0-14)
+0	S	_	1		=== Internet Cheat Notes (USA Gameshark source: almarsguides.com) ===
+0	S	_	1		GS Master: 34165F72 B08D117B / 25982608 B17B6C25
+0	S	_	1		GS Invulnerability: 771681C5 6954AFCA
+0	S	_	1		GS Unlimited Lives: 87650B7E 2F78AE65
+0	S	_	1		GS Unlimited Batteries: 4117F0AB 1D88A2C5
+0	S	_	1		GS Unlimited Energy: EEDEF930 E6D64031
+0	S	_	1		NOTE: Internet GS/CB codes are region/version dependent (USA listed). Verify against your ROM build.
+0	S	_	1		WARNING: Freezing AP transport fields can desync server/client/ROM state; use in offline testing only.
+


### PR DESCRIPTION
## Summary

Expands on the hub-switch stale-baseline guard (Issue #651) with two additional issues found during investigation:

1. **Hub-switch bit-label swap (Bug)**: `HUB_SWITCH_MOONLIGHT` and `HUB_SWITCH_PEPPERMINT_WEST` had their `bit_index` values swapped relative to the ROM's `WorldMapDoor` callback array. The ROM assigns bit 0 to Peppermint Palace West and bit 11 to Moonlight Mansion; the apworld had them reversed. Hitting the [Moonlight Mansion Hub switch](https://wikirby.com/wiki/Moonlight_Mansion_-_Hub) (which connects the hub room to Central Circle) or the [Room 9 switch](https://wikirby.com/wiki/Moonlight_Mansion_-_Room_9) (which unlocks [Rainbow Route - Hub 1](https://wikirby.com/wiki/Rainbow_Route_-_Hub_1)) sent the wrong location check — e.g., Room 9's switch incorrectly sent "Peppermint Palace East - Big Switch" instead of "Moonlight Mansion - Big Switch".

2. **Room entry logging (New feature)**: The BizHawk client log file now records every room entry (region key, native room ID, doorsIdx). Writing to the log file always happens; the message is suppressed from the live client unless the debug logging option is enabled.

## Root Cause

### Stale hub-switch baseline

When the AP mailbox initializes, `hub_switch_flags` may contain stale or garbage bits from prior sessions. The client treated any set bits as collected checks and resent them to the server on reconnect — even though they were never unlocked in the current session.

### Hub-switch bit-label swap

The ROM's `WorldMapDoor` callback array assigns bit 0 to Peppermint Palace West and bit 11 to Moonlight Mansion. The apworld had these reversed: `HUB_SWITCH_MOONLIGHT` was mapped to `bit_index: 0` and `HUB_SWITCH_PEPPERMINT_WEST` to `bit_index: 11`, producing wrong location names and wrong AP item assignments whenever those switches fired.

## Solution

### Stale hub-switch baseline

On the first hub-switch poll tick when `server_checked_locations` is empty, capture the current transport bits as a baseline (`_hub_switch_baseline_mask`). Subsequent polls mask out baseline bits before reporting collections, suppressing pre-session resends while still capturing legitimately-new checks.

### Hub-switch bit-label swap

Swap `bit_index` and `location_id` for `HUB_SWITCH_MOONLIGHT` (0 → 11 / 3960400 → 3960411) and `HUB_SWITCH_PEPPERMINT_WEST` (11 → 0 / 3960411 → 3960400) in `locations.json`. Correct `WorldMapDoor` bit order in `PROTOCOL.md`.

### Room entry logging

Poll `gCurLevelInfo[0].currentRoom` (u16 at `0x02023B28`) each tick. When the value changes, resolve `doorsIdx` via `gRoomProps[roomId].doorsIdx` (ROM read at `gRoomProps` base + stride offset) and map to the region key from `rooms.json`. Always log to file at `INFO` level; forward to the live client only when debug logging is enabled.

## Changes

- **`data/locations.json`**: Swap `bit_index` and `location_id` for `HUB_SWITCH_MOONLIGHT` ↔ `HUB_SWITCH_PEPPERMINT_WEST`.
- **`data/addresses.json`**: Add `current_room_native` (`0x02023B28`) to the `native` address table.
- **`client.py`**:
  - Add `_hub_switch_baseline_mask` and `_hub_switch_session_initialized` state; mask effective bits before location mapping on first empty-server poll.
  - Add `_last_native_room_id`, `_room_label_by_doors_idx`, `_build_room_label_lookup()` static helper, and `_poll_room_entry_logging()` coroutine.
  - Constants: `_CURRENT_ROOM_ADDR_KEY`, `_ROOM_PROPS_ROM_BASE`, `_ROOM_PROPS_STRIDE`, `_ROOM_PROPS_DOORS_IDX_OFFSET`.
- **`PROTOCOL.md`**: Document baseline suppression behavior and rationale; correct `WorldMapDoor` bit order (bit 0 = Peppermint West, bit 11 = Moonlight); update hub-switch location table note.

## Testing

- [x] Hub-switch baseline polling tests pass (6 selected tests)
- [x] Unit tests for pre-session bit suppression
- [x] Existing hub-switch tests updated and passing
- [ ] Snapshots updated for hub-switch location ID swap
- [ ] Room entry logging confirmed in log file during play

## Linked

Closes #651