### PR TITLE
KirbyAM: prepare v0.2.0 release metadata

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -11,6 +11,24 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### New Features
 
+- None.
+
+### Improvements
+
+- None.
+
+### Bug Fixes
+
+- None.
+
+### Internal Changes
+
+- None.
+
+## v0.2.0
+
+### New Features
+
 - `Starting Kirby Color` lets players begin with a chosen Kirby color instead of always starting as Pink, including a random option for surprise runs (Issue #597).
 - `Start With All Maps` lets players begin with every area map already unlocked for a more guided playthrough (Issue #584).
 - Room names now match familiar Wikirby names, making the game easier to navigate and discuss (Issue #587).

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.1.2",
+  "world_version": "0.2.0",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- freeze the current unreleased KirbyAM changelog into `v0.2.0`
- pre-sync `world_version` to `0.2.0` so the tagged commit is internally consistent
- leave a fresh empty `Unreleased` section for follow-up changes

## Why
This follows the pre-tag sync flow for `kirbyam-v0.2.0` so the eventual tagged commit on `main` does not rely on the post-tag manifest sync PR.

## Merge gate still pending
- ROM patch regeneration remains a user-run step before merge/tag. The release workflow builds with `--skip-patch`, so `worlds/kirbyam/data/base_patch.bsdiff4` must be current before the release is tagged.

## Validation
- changelog now contains `## v0.2.0`
- `worlds/kirbyam/archipelago.json` now has `"world_version": "0.2.0"`
