### PR TITLE
Issue #540: codify minor chest respawn/reopen policy

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -152,6 +152,12 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 
+Minor chest status (Issue #540 / #542):
+- Minor chest locations are not shipped as active AP checks yet.
+- Respawn/reopen policy is currently documented as non-repeatable (single-fire chest state) based on decomp evidence in `katam/src/treasures.c` and `katam/asm/chest.s`.
+- Multi-chest room mappings remain deferred until chest-index disambiguation evidence is complete.
+- See `worlds/kirbyam/docs/dev-docs/minor-chest-respawn-policy.md` and `worlds/kirbyam/data/minor_chest_manifest.json` metadata (`respawn_reopen_policy`).
+
 ## Client Protocol
 
 ### 1. Connection & Initialization

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -152,10 +152,10 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 
-Minor chest status (Issue #540 / #542):
+Minor chest status (Issue #540):
 - Minor chest locations are not shipped as active AP checks yet.
-- Respawn/reopen policy is currently documented as non-repeatable (single-fire chest state) based on decomp evidence in `katam/src/treasures.c` and `katam/asm/chest.s`.
-- Multi-chest room mappings remain deferred until chest-index disambiguation evidence is complete.
+- Respawn/reopen policy is documented as non-repeatable (single-fire chest state) based on decomp evidence in `katam/src/treasures.c` and `katam/asm/chest.s`.
+- Multi-chest room index disambiguation remains deferred (tracked in Issue #542).
 - See `worlds/kirbyam/docs/dev-docs/minor-chest-respawn-policy.md` and `worlds/kirbyam/data/minor_chest_manifest.json` metadata (`respawn_reopen_policy`).
 
 ## Client Protocol

--- a/worlds/kirbyam/data/minor_chest_manifest.json
+++ b/worlds/kirbyam/data/minor_chest_manifest.json
@@ -12,6 +12,16 @@
     "identified_entries": 65,
     "unresolved_entries": 0,
     "modeled_non_collection_pool_entries": 14,
+    "respawn_reopen_policy": {
+      "conclusion": "no_repeatable_minor_chest_reopen_path_confirmed",
+      "ap_handling": "Treat each native small chest as single-fire check state when enabled as AP locations; keep unresolved/ambiguous mappings deferred until chest-index proof exists",
+      "evidence": [
+        "katam/src/treasures.c: CollectChest(u8) only sets chestFields bit; no clear/reset helper exists",
+        "katam/src/treasures.c: HasChest(u8) reads persisted chestFields bit",
+        "katam/asm/chest.s: spawn path gates chest state via HasChest at object+0xE2",
+        "katam/asm/chest.s: collect path calls CollectChest with object+0xE2"
+      ]
+    },
     "room_props": {
       "rom_offset": "0x009331AC",
       "size": "0x9998",

--- a/worlds/kirbyam/docs/dev-docs/minor-chest-respawn-policy.md
+++ b/worlds/kirbyam/docs/dev-docs/minor-chest-respawn-policy.md
@@ -1,0 +1,34 @@
+# Minor Chest Respawn/Reopen Policy (Issue #540)
+
+## Conclusion
+
+Minor chest reopen/respawn behavior is treated as **not repeatable** for AP check policy purposes.
+
+## Decomp Evidence
+
+Evidence references used for this policy:
+
+- `katam/src/treasures.c`
+  - `CollectChest(u8)` sets the `gTreasures.chestFields` bit and does not include a clear/reset path.
+  - `HasChest(u8)` reads the persisted `gTreasures.chestFields` bit.
+- `katam/asm/chest.s`
+  - Spawn logic gates chest state via `HasChest` using the chest index (`object + 0xE2`).
+  - Collection path writes chest collected state via `CollectChest` with the same chest index.
+
+Together these indicate sticky bitfield semantics for native small chest collection state.
+
+## AP Handling Policy
+
+- Treat each verified minor chest mapping as a single-fire AP location check.
+- Do not model chest reopen/respawn loops as repeatable AP checks.
+- Keep unresolved or ambiguous multi-chest mappings deferred until chest-index attribution is proven.
+
+## Contract Surface
+
+The generated manifest [worlds/kirbyam/data/minor_chest_manifest.json](../../data/minor_chest_manifest.json) now includes metadata:
+
+- `metadata.respawn_reopen_policy.conclusion`
+- `metadata.respawn_reopen_policy.ap_handling`
+- `metadata.respawn_reopen_policy.evidence`
+
+This keeps the policy machine-checkable and review-visible in versioned artifacts.

--- a/worlds/kirbyam/test/test_minor_chest_manifest_contract.py
+++ b/worlds/kirbyam/test/test_minor_chest_manifest_contract.py
@@ -1,0 +1,27 @@
+"""Contract checks for generated minor chest manifest metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+MANIFEST_PATH = Path(__file__).resolve().parents[1] / "data" / "minor_chest_manifest.json"
+
+
+def test_minor_chest_manifest_includes_respawn_policy_metadata() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    metadata = manifest.get("metadata")
+    assert isinstance(metadata, dict), "Manifest metadata must be a JSON object"
+
+    respawn_policy = metadata.get("respawn_reopen_policy")
+    assert isinstance(respawn_policy, dict), "Manifest metadata must include respawn_reopen_policy"
+
+    assert (
+        respawn_policy.get("conclusion") == "no_repeatable_minor_chest_reopen_path_confirmed"
+    ), "Respawn policy conclusion should remain explicit and stable"
+
+    evidence = respawn_policy.get("evidence")
+    assert isinstance(evidence, list) and evidence, "Respawn policy evidence list must be populated"
+    assert any("katam/src/treasures.c" in item for item in evidence), "Expected treasures.c evidence reference"
+    assert any("katam/asm/chest.s" in item for item in evidence), "Expected chest.s evidence reference"

--- a/worlds/kirbyam/tools/enumerate_minor_chests.py
+++ b/worlds/kirbyam/tools/enumerate_minor_chests.py
@@ -40,6 +40,12 @@ AMR_SMALL_CHEST_ITEM_OFFSET = 0x0E
 AMR_SMALL_CHEST_INDEX_OFFSET = 0x11
 AMR_PACKED_ITEM_SIZE = 6
 ROM_ENTRY_READ_SIZE = max(AMR_SMALL_CHEST_ITEM_OFFSET, AMR_SMALL_CHEST_INDEX_OFFSET) + 1
+RESPAWN_POLICY_EVIDENCE = [
+    "katam/src/treasures.c: CollectChest(u8) only sets chestFields bit; no clear/reset helper exists",
+    "katam/src/treasures.c: HasChest(u8) reads persisted chestFields bit",
+    "katam/asm/chest.s: spawn path gates chest state via HasChest at object+0xE2",
+    "katam/asm/chest.s: collect path calls CollectChest with object+0xE2",
+]
 
 
 def load_json(path: Path) -> dict:
@@ -483,6 +489,14 @@ def main() -> int:
             "identified_entries": len(manifest_entries) - sum(unresolved_counts.values()),
             "unresolved_entries": sum(unresolved_counts.values()),
             "modeled_non_collection_pool_entries": modeled_non_collection_pool_entries,
+            "respawn_reopen_policy": {
+                "conclusion": "no_repeatable_minor_chest_reopen_path_confirmed",
+                "ap_handling": (
+                    "Treat each native small chest as single-fire check state when enabled as AP locations; "
+                    "keep unresolved/ambiguous mappings deferred until chest-index proof exists"
+                ),
+                "evidence": RESPAWN_POLICY_EVIDENCE,
+            },
             "room_props": {
                 "rom_offset": f"0x{ROOM_PROPS_ROM_BASE:08X}",
                 "size": f"0x{ROOM_PROPS_SIZE:04X}",


### PR DESCRIPTION
## Summary
- codify issue #540 respawn/reopen handling as an explicit minor chest policy contract
- add decomp evidence-backed policy metadata to generated minor chest manifest
- add regression test to keep respawn policy metadata stable
- document policy status in protocol and new dev-doc note

## Testing
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest -q worlds/kirbyam/test/test_minor_chest_manifest_contract.py
- python -m py_compile worlds/kirbyam/tools/enumerate_minor_chests.py worlds/kirbyam/test/test_minor_chest_manifest_contract.py
- python worlds/kirbyam/tools/enumerate_minor_chests.py --rom ../local-files/ROMs/KirbyAM.gba

Closes #540