### PR TITLE
Issue #541: add minor-chest rollout guardrails and category wiring

### DIFF
--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -370,6 +370,7 @@ class KirbyAmWorld(World):
             vitality_chest_locations: list[KirbyAmLocation] = []
             sound_player_chest_locations: list[KirbyAmLocation] = []
             hub_switch_locations: list[KirbyAmLocation] = []
+            minor_chest_locations: list[KirbyAmLocation] = []
             room_sanity_locations: list[KirbyAmLocation] = []
             location_by_key: dict[str, KirbyAmLocation] = {}
             for loc in fill_locations:
@@ -389,6 +390,8 @@ class KirbyAmWorld(World):
                     sound_player_chest_locations.append(loc)
                 elif loc_meta.category == LocationCategory.HUB_SWITCH:
                     hub_switch_locations.append(loc)
+                elif loc_meta.category == LocationCategory.MINOR_CHEST:
+                    minor_chest_locations.append(loc)
                 elif loc_meta.category == LocationCategory.ROOM_SANITY:
                     room_sanity_locations.append(loc)
 
@@ -397,11 +400,12 @@ class KirbyAmWorld(World):
             vitality_chest_locations.sort(key=lambda loc: loc.key or "")
             sound_player_chest_locations.sort(key=lambda loc: loc.key or "")
             hub_switch_locations.sort(key=lambda loc: loc.key or "")
+            minor_chest_locations.sort(key=lambda loc: loc.key or "")
             room_sanity_locations.sort(key=lambda loc: loc.key or "")
 
             locked_shard_count = 0
             randomized_item_codes: list[int] = []
-            if boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or room_sanity_locations:
+            if boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or minor_chest_locations or room_sanity_locations:
                 shard_label_to_code = {
                     item.label: item.item_id
                     for item in kirby_data.items.values()
@@ -455,7 +459,7 @@ class KirbyAmWorld(World):
                     )
 
                 open_physical_locations = [
-                    loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations + hub_switch_locations + room_sanity_locations
+                    loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations + hub_switch_locations + minor_chest_locations + room_sanity_locations
                     if loc.item is None
                 ]
                 needed_pool_size = len(open_physical_locations)
@@ -586,10 +590,10 @@ class KirbyAmWorld(World):
                         self.player,
                     )
 
-            if (boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or room_sanity_locations) and not randomized_item_codes:
+            if (boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or minor_chest_locations or room_sanity_locations) and not randomized_item_codes:
                 raise ValueError(
                     "KirbyAM item pool build failed: no randomized items were produced. "
-                    "This likely indicates a problem with boss/major/vitality/sound-player/hub-switch locations, "
+                    "This likely indicates a problem with boss/major/vitality/sound-player/hub-switch/minor-chest locations, "
                     "room-sanity locations, or region/location data."
                 )
 

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -153,6 +153,7 @@ class LocationCategory(IntEnum):
     SOUND_PLAYER_CHEST = 11
     ROOM_SANITY = 12
     HUB_SWITCH = 13
+    MINOR_CHEST = 14
 
 
 class ItemData(NamedTuple):

--- a/worlds/kirbyam/groups.py
+++ b/worlds/kirbyam/groups.py
@@ -44,6 +44,7 @@ _LOCATION_GROUP_MAPS: dict[str, set[str]] = {
 _LOCATION_CATEGORY_TO_GROUP_NAME = {
     LocationCategory.MAJOR_CHEST: "Major Chests",
     LocationCategory.HUB_SWITCH: "Hub Switches",
+    LocationCategory.MINOR_CHEST: "Minor Chests",
 }
 
 # Pre-create category groups and map/area groups so they are always present during build.

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.context import _game_watcher, AuthStatus
 
-from ..data import data
+from ..data import LocationCategory, data
 from ..client import (
     KirbyAmClient,
     _MAP_ITEM_ID_TO_AREA_ID,
@@ -3849,16 +3849,11 @@ def test_hub_switch_locations_defined_in_regions():
 
 def test_minor_chest_locations_defined_in_regions_when_present():
     """All MINOR_CHEST locations (when enabled) must be registered in regions/rooms."""
-    location_category_enum = getattr(data, "LocationCategory", None)
-    minor_chest_category = getattr(location_category_enum, "MINOR_CHEST", None) if location_category_enum else None
-    if minor_chest_category is None:
-        return
-
     minor_chest_keys = {
         key
         for key, loc in data.locations.items()
         if key.startswith("MINOR_CHEST_")
-        or (getattr(loc, "category", None) == minor_chest_category)
+        or (getattr(loc, "category", None) == LocationCategory.MINOR_CHEST)
     }
 
     if not minor_chest_keys:
@@ -3875,14 +3870,10 @@ def test_minor_chest_locations_defined_in_regions_when_present():
 
 def test_minor_chest_locations_have_unique_bit_indices_when_present():
     """Enabled MINOR_CHEST locations must not reuse native bit indices."""
-    location_category_enum = getattr(data, "LocationCategory", None)
-    minor_chest_category = getattr(location_category_enum, "MINOR_CHEST", None) if location_category_enum else None
-    if minor_chest_category is None:
-        return
-
     minor_chest_with_bits = [
         loc for loc in data.locations.values()
-        if getattr(loc, "category", None) == minor_chest_category and getattr(loc, "bit_index", None) is not None
+        if getattr(loc, "category", None) == LocationCategory.MINOR_CHEST
+        and getattr(loc, "bit_index", None) is not None
     ]
     if not minor_chest_with_bits:
         return

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -3845,3 +3845,50 @@ def test_hub_switch_locations_defined_in_regions():
     for key in hub_switch_keys:
         assert key in all_region_locations, \
             f"HUB_SWITCH location '{key}' defined in locations.json but not registered in any region in areas.json"
+
+
+def test_minor_chest_locations_defined_in_regions_when_present():
+    """All MINOR_CHEST locations (when enabled) must be registered in regions/rooms."""
+    location_category_enum = getattr(data, "LocationCategory", None)
+    minor_chest_category = getattr(location_category_enum, "MINOR_CHEST", None) if location_category_enum else None
+    if minor_chest_category is None:
+        return
+
+    minor_chest_keys = {
+        key
+        for key, loc in data.locations.items()
+        if key.startswith("MINOR_CHEST_")
+        or (getattr(loc, "category", None) == minor_chest_category)
+    }
+
+    if not minor_chest_keys:
+        return
+
+    all_region_locations = set()
+    for region_data in data.regions.values():
+        all_region_locations.update(region_data.locations)
+
+    for key in minor_chest_keys:
+        assert key in all_region_locations, \
+            f"MINOR_CHEST location '{key}' defined in locations.json but not registered in any region in rooms.json"
+
+
+def test_minor_chest_locations_have_unique_bit_indices_when_present():
+    """Enabled MINOR_CHEST locations must not reuse native bit indices."""
+    location_category_enum = getattr(data, "LocationCategory", None)
+    minor_chest_category = getattr(location_category_enum, "MINOR_CHEST", None) if location_category_enum else None
+    if minor_chest_category is None:
+        return
+
+    minor_chest_with_bits = [
+        loc for loc in data.locations.values()
+        if getattr(loc, "category", None) == minor_chest_category and getattr(loc, "bit_index", None) is not None
+    ]
+    if not minor_chest_with_bits:
+        return
+
+    bit_indices = [loc.bit_index for loc in minor_chest_with_bits if loc.bit_index is not None]
+    assert len(bit_indices) == len(set(bit_indices)), (
+        "MINOR_CHEST locations must use unique bit_index values to avoid duplicate AP checks: "
+        f"{bit_indices}"
+    )

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -3848,7 +3848,7 @@ def test_hub_switch_locations_defined_in_regions():
 
 
 def test_minor_chest_locations_defined_in_regions_when_present():
-    """All MINOR_CHEST locations (when enabled) must be registered in regions/rooms."""
+    """All MINOR_CHEST locations (when enabled) must be registered in some data/regions entry."""
     minor_chest_keys = {
         key
         for key, loc in data.locations.items()
@@ -3865,7 +3865,7 @@ def test_minor_chest_locations_defined_in_regions_when_present():
 
     for key in minor_chest_keys:
         assert key in all_region_locations, \
-            f"MINOR_CHEST location '{key}' defined in locations.json but not registered in any region in rooms.json"
+            f"MINOR_CHEST location '{key}' defined in locations.json but not registered in any data/regions/*.json entry"
 
 
 def test_minor_chest_locations_have_unique_bit_indices_when_present():


### PR DESCRIPTION
Part of #541.

## Summary

This batch lands rollout guardrails and category wiring for future MINOR_CHEST activation without enabling concrete minor-chest AP locations yet.

## Changes

- Added LocationCategory.MINOR_CHEST in worlds/kirbyam/data.py.
- Added Minor Chests location grouping in worlds/kirbyam/groups.py.
- Updated item-pool category partitioning in worlds/kirbyam/__init__.py to include MINOR_CHEST so future enabled minor-chest locations are included in pool sizing and invariant checks.
- Added regression tests in worlds/kirbyam/test/test_client.py:
  - minor-chest locations must be region-registered when present;
  - minor-chest locations must use globally unique bit_index values when present.

## Validation

- pytest worlds/kirbyam/test/test_client.py -k "minor_chest or hub_switch_locations_defined_in_regions or vitality_chest_locations_defined_in_regions" -v
- pytest worlds/kirbyam/test/test_item_pool.py -v

## Why no concrete MINOR_CHEST entries in this batch

Manifest evidence shows disambiguated candidates in ROOM_7_06 and ROOM_7_24, but both still collide on native flag bits 0 and 3. Enabling them now would risk aliased or duplicate AP checks.

This PR therefore lands safety wiring first. Concrete minor-chest location activation remains blocked on unique signal or mapping proof (tracked by #542 and #701).
