### PR TITLE
Issue #129: enable first concrete minor-chest AP checks

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -12,6 +12,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### New Features
 
 - Added two new filler consumables with tiered healing: `Energy Drink` (HP +2) and `Hunk of Meat` (HP +3), alongside existing `Small Food` (HP +1) (Issues #684, #685, #686).
+- Enabled the first concrete `MINOR_CHEST` AP checks (Rainbow Route 1-20, 1-22, 1-38) using native small-chest flag polling, with stable location IDs and room topology wiring (Issue #129).
 
 ### Improvements
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -83,7 +83,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 |----------|------|-------------------------|-----------|
 | 0x02038970 | 1B | KIRBY_SHARD_FLAGS       | Native mirror shard bitfield (bits 0-7) |
 | 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This is the native map-ownership field. AP major-chest checks use `major_chest_flags` in the transport block, and the BizHawk client may reassert AP-owned map bits here from `start_with_all_maps` plus confirmed delivered map items to recover from reconnect/save-state drift. |
-| 0x02038960 - 0x0203896A | 10B | Chest/Switch state    | Native chest and switch flags |
+| 0x02038960 - 0x02038969 | 10B | small_chest_flags_native | Native small-chest/switch bitfield block. Enabled MINOR_CHEST AP checks read this block directly and map `bit_index` to location IDs. |
 | 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped) |
 | 0x02028CA0 | 576B | gVisitedDoors (`room_visit_flags_native`) | Native room-visit array (`u16[0x120]`); bit 15 marks visited state by `doorsIdx` |
 | 0x02023B28 | 2B | current_room_native | Current native room ID (`gCurLevelInfo[0].currentRoom`) used for room-entry diagnostics |
@@ -149,11 +149,15 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 10 = Moonlight; others sequential) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-20 small chest (native small_chest_flags bit 1) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags bit 23) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags bit 41) |
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 
 Minor chest status (Issue #540):
-- Minor chest locations are not shipped as active AP checks yet.
+- Initial MINOR_CHEST AP checks are active for Rainbow Route rooms 1-20, 1-22, and 1-38.
+- Active MINOR_CHEST checks are polled from native `small_chest_flags_native` and use direct native chest bit semantics.
 - Respawn/reopen policy is documented as non-repeatable (single-fire chest state) based on decomp evidence in `katam/src/treasures.c` and `katam/asm/chest.s`.
 - Multi-chest room index disambiguation remains deferred (tracked in Issue #542).
 - See `worlds/kirbyam/docs/dev-docs/minor-chest-respawn-policy.md` and `worlds/kirbyam/data/minor_chest_manifest.json` metadata (`respawn_reopen_policy`).

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -149,9 +149,9 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 10 = Moonlight; others sequential) |
-| MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-20 small chest (native small_chest_flags bit 1) |
-| MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags bit 23) |
-| MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags bit 41) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-20 small chest (native small_chest_flags_native bit 1) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags_native bit 23) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags_native bit 41) |
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960415+ | Future location families |
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1917,10 +1917,9 @@ class KirbyAmClient(BizHawkClient):
         if len(raw) != _MINOR_CHEST_FLAGS_READ_WIDTH:
             self._log_client(
                 "warning",
-                "KirbyAM: minor-chest poll expected %s bytes from native chest flags, got %s; skipping tick" % (
-                    _MINOR_CHEST_FLAGS_READ_WIDTH,
-                    len(raw),
-                ),
+                "KirbyAM: minor-chest poll expected %s bytes from native chest flags, got %s; skipping tick",
+                _MINOR_CHEST_FLAGS_READ_WIDTH,
+                len(raw),
             )
             return
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -44,6 +44,8 @@ _KIRBY_MAX_HP_ADDR_KEY = "kirby_max_hp_native"
 _KIRBY_MAX_HP_READ_WIDTH = 1
 _KIRBY_VITALITY_COUNTER_ADDR_KEY = "kirby_vitality_counter_native"
 _KIRBY_VITALITY_COUNTER_READ_WIDTH = 2
+_MINOR_CHEST_FLAGS_ADDR_KEY = "small_chest_flags_native"
+_MINOR_CHEST_FLAGS_READ_WIDTH = 10
 _ROOM_VISIT_FLAGS_ADDR_KEY = "room_visit_flags_native"
 _ROOM_VISIT_FLAGS_ENTRY_COUNT = 0x120
 _ROOM_VISIT_FLAGS_BIT_MASK = 0x8000
@@ -157,6 +159,13 @@ class KirbyAmClient(BizHawkClient):
                 continue
             self._major_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
 
+        # Minor chest native bitfield → location IDs (MINOR_CHEST category; polled from native chest flags).
+        self._minor_chest_location_ids_by_bit: dict[int, list[int]] = {}
+        for loc in data.locations.values():
+            if loc.bit_index is None or loc.category != LocationCategory.MINOR_CHEST:
+                continue
+            self._minor_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+
         # Vitality chest bitfield → location IDs (VITALITY_CHEST category; dedicated transport register)
         self._vitality_chest_location_ids_by_bit: dict[int, list[int]] = {}
         for loc in data.locations.values():
@@ -209,6 +218,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_shard_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_boss_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_major_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._last_minor_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_vitality_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_sound_player_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_hub_switch_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
@@ -333,6 +343,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_shard_poll_log = None
         self._last_boss_poll_log = None
         self._last_major_chest_poll_log = None
+        self._last_minor_chest_poll_log = None
         self._last_vitality_chest_poll_log = None
         self._last_sound_player_chest_poll_log = None
         self._last_hub_switch_poll_log = None
@@ -1037,6 +1048,9 @@ class KirbyAmClient(BizHawkClient):
 
             # Major chest location polling via dedicated major_chest_flags transport register
             await self._poll_major_chest_locations(ctx)
+
+            # Minor chest location polling via native small chest flag bitfield
+            await self._poll_minor_chest_locations(ctx)
 
             # Vitality chest location polling via dedicated vitality_chest_flags transport register
             await self._poll_vitality_chest_locations(ctx)
@@ -1883,6 +1897,66 @@ class KirbyAmClient(BizHawkClient):
                 self._last_vitality_chest_poll_log = chest_log_state
         else:
             self._last_vitality_chest_poll_log = None
+
+    async def _poll_minor_chest_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Read native small-chest flags and map set bits to MINOR_CHEST locations.
+
+        This path uses native chest-state semantics directly (Issue #129). Polling mirrors
+        existing resend/dedupe behavior: RAM-derived checks are resent until the server
+        acknowledges them in ctx.checked_locations.
+        """
+        if not self._minor_chest_location_ids_by_bit:
+            return
+
+        chest_addr = self._native_addr(_MINOR_CHEST_FLAGS_ADDR_KEY)
+        if chest_addr is None:
+            return
+
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(chest_addr, _MINOR_CHEST_FLAGS_READ_WIDTH, "System Bus")]))[0]
+        if len(raw) != _MINOR_CHEST_FLAGS_READ_WIDTH:
+            self._log_client(
+                "warning",
+                "KirbyAM: minor-chest poll expected %s bytes from native chest flags, got %s; skipping tick" % (
+                    _MINOR_CHEST_FLAGS_READ_WIDTH,
+                    len(raw),
+                ),
+            )
+            return
+
+        mapped_checked_locations: set[int] = set()
+        for bit in sorted(self._minor_chest_location_ids_by_bit.keys()):
+            byte_index = bit // 8
+            if byte_index >= len(raw):
+                continue
+            if raw[byte_index] & (1 << (bit % 8)):
+                mapped_checked_locations.update(self._minor_chest_location_ids_by_bit.get(bit, []))
+
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+        already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
+        if missing_on_server:
+            chest_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if chest_log_state != self._last_minor_chest_poll_log:
+                self._log_verbose(
+                    "info",
+                    "KirbyAM: resending minor-chest LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                )
+                self._last_minor_chest_poll_log = chest_log_state
+
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+        elif mapped_checked_locations:
+            chest_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if chest_log_state != self._last_minor_chest_poll_log:
+                self._log_verbose(
+                    "debug",
+                    "KirbyAM: dedupe suppressed minor-chest LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_minor_chest_poll_log = chest_log_state
+        else:
+            self._last_minor_chest_poll_log = None
 
     async def _poll_sound_player_chest_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -33,6 +33,7 @@
       "ability_reroll_ability_id_runtime": "0x0203B084"
     },
     "native": {
+      "small_chest_flags_native": "0x02038960",
       "shard_bitfield_native": "0x02038970",
       "big_chest_bitfield_native": "0x0203897C",
       "boss_mirror_table_native": "0x02028C14",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -425,5 +425,41 @@
     "bit_index": 14,
     "category": "HUB_SWITCH",
     "location_id": 3960414
+  },
+  "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
+    "label": "Rainbow Route 1-20 - Small Chest",
+    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_20",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 1,
+    "category": "MINOR_CHEST",
+    "location_id": 3960500
+  },
+  "MINOR_CHEST_RAINBOW_ROUTE_1_22": {
+    "label": "Rainbow Route 1-22 - Small Chest",
+    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_22",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 23,
+    "category": "MINOR_CHEST",
+    "location_id": 3960501
+  },
+  "MINOR_CHEST_RAINBOW_ROUTE_1_38": {
+    "label": "Rainbow Route 1-38 - Small Chest",
+    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_38",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 41,
+    "category": "MINOR_CHEST",
+    "location_id": 3960502
   }
 }

--- a/worlds/kirbyam/data/native_address_policy.json
+++ b/worlds/kirbyam/data/native_address_policy.json
@@ -40,6 +40,18 @@
         }
       ]
     },
+    "minor_chest_checks": {
+      "status": "integrated",
+      "entries": [
+        {
+          "name": "small_chest_flags_native",
+          "address": "0x02038960",
+          "width": "u8[10]",
+          "source": "Native gTreasures chest/switch state block; chest bits interpreted by minor-chest manifest mapping",
+          "verification": "Integrated and used by client polling path for enabled MINOR_CHEST AP checks; bits are treated as single-fire check state"
+        }
+      ]
+    },
     "vitality_chest_checks": {
       "status": "integrated",
       "entries": [

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -433,7 +433,9 @@
     "ability_gates": {}
   },
   "REGION_RAINBOW_ROUTE/ROOM_1_20": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_RAINBOW_ROUTE_1_20"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/ROOM_1_36",
@@ -462,7 +464,9 @@
     "ability_gates": {}
   },
   "REGION_RAINBOW_ROUTE/ROOM_1_22": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_RAINBOW_ROUTE_1_22"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/ROOM_1_34",
@@ -710,7 +714,9 @@
     "ability_gates": {}
   },
   "REGION_RAINBOW_ROUTE/ROOM_1_38": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_RAINBOW_ROUTE_1_38"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/ROOM_1_34",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -364,6 +364,33 @@
         "MAP_RAINBOW_ROUTE"
       ]
     },
+    "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
+      "category": "MINOR_CHEST",
+      "label": "Rainbow Route 1-20 - Small Chest",
+      "location_id": 3960500,
+      "tags": [
+        "MAP_RAINBOW_ROUTE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_RAINBOW_ROUTE_1_22": {
+      "category": "MINOR_CHEST",
+      "label": "Rainbow Route 1-22 - Small Chest",
+      "location_id": 3960501,
+      "tags": [
+        "MAP_RAINBOW_ROUTE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_RAINBOW_ROUTE_1_38": {
+      "category": "MINOR_CHEST",
+      "label": "Rainbow Route 1-38 - Small Chest",
+      "location_id": 3960502,
+      "tags": [
+        "MAP_RAINBOW_ROUTE",
+        "SmallChest"
+      ]
+    },
     "ROOM_SANITY_1_01": {
       "category": "ROOM_SANITY",
       "label": "Room 1-01",

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -408,6 +408,48 @@ async def test_shard_poll_does_not_trigger_major_chest_locations(mock_bizhawk_co
 
 
 @pytest.mark.asyncio
+async def test_poll_minor_chest_sends_location_checks_for_set_bits(mock_bizhawk_context):
+    """Set native minor-chest bits should map to MINOR_CHEST LocationChecks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    room_1_20 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_20"].location_id
+    room_1_22 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_22"].location_id
+    room_1_38 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_38"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    bits = (1 << 1) | (1 << 23) | (1 << 41)
+
+    with patch.dict(data.native_ram_addresses, {"small_chest_flags_native": 0x02038960}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.return_value = [bits.to_bytes(10, 'little')]
+
+        await client._poll_minor_chest_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [room_1_20, room_1_22, room_1_38]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_poll_minor_chest_skips_when_address_missing(mock_bizhawk_context):
+    """Missing native minor chest address should no-op safely."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    native_without_minor = {k: v for k, v in data.native_ram_addresses.items() if k != "small_chest_flags_native"}
+
+    with patch.dict(data.native_ram_addresses, native_without_minor, clear=True), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        await client._poll_minor_chest_locations(mock_bizhawk_context)
+
+    mock_read.assert_not_awaited()
+    mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_poll_vitality_chest_sends_location_checks_for_set_bits(mock_bizhawk_context):
     """Set transport vitality-chest bits should map to vitality-chest LocationChecks."""
     client = KirbyAmClient()

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -450,6 +450,30 @@ async def test_poll_minor_chest_skips_when_address_missing(mock_bizhawk_context)
 
 
 @pytest.mark.asyncio
+async def test_poll_minor_chest_skips_already_server_acknowledged(mock_bizhawk_context):
+    """No minor-chest resend when server already acknowledges all mapped checks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._debug_logging_enabled = True
+
+    room_1_20 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_20"].location_id
+    mock_bizhawk_context.checked_locations = {room_1_20}
+
+    with patch.dict(data.native_ram_addresses, {"small_chest_flags_native": 0x02038960}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.return_value = [((1 << 1)).to_bytes(10, 'little')]
+
+        await client._poll_minor_chest_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
+    assert mock_logger.debug.called
+    assert "dedupe suppressed minor-chest LocationChecks" in mock_logger.debug.call_args.args[0]
+    assert mock_logger.debug.call_args.args[1] == [room_1_20]
+
+
+@pytest.mark.asyncio
 async def test_poll_vitality_chest_sends_location_checks_for_set_bits(mock_bizhawk_context):
     """Set transport vitality-chest bits should map to vitality-chest LocationChecks."""
     client = KirbyAmClient()

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2905,6 +2905,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock) as mock_send_death_link, \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock) as mock_poll_boss, \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock) as mock_poll_major, \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock) as mock_poll_minor, \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality, \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player, \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switch, \
@@ -2923,6 +2924,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
     mock_send_death_link.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_boss.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_major.assert_awaited_once_with(mock_bizhawk_context)
+    mock_poll_minor.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_vitality.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_sound_player.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_hub_switch.assert_awaited_once_with(mock_bizhawk_context)
@@ -3036,6 +3038,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
          patch.object(client, '_poll_locations', new_callable=AsyncMock) as mock_poll_locations, \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock) as mock_poll_boss, \
             patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock) as mock_poll_major_chests, \
+                patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock) as mock_poll_minor_chests, \
             patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality_chests, \
             patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player_chests, \
                 patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switches, \
@@ -3068,6 +3071,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         mock_poll_locations.assert_not_awaited()
         mock_poll_boss.assert_awaited_once()
         mock_poll_major_chests.assert_awaited_once()
+        mock_poll_minor_chests.assert_awaited_once()
         mock_poll_vitality_chests.assert_awaited_once()
         mock_poll_sound_player_chests.assert_awaited_once()
         mock_poll_hub_switches.assert_awaited_once()
@@ -3095,6 +3099,7 @@ async def test_game_watcher_reconnect_entry_suppresses_session_ready_log_when_de
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
@@ -3304,6 +3309,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
@@ -3361,6 +3367,7 @@ async def test_game_watcher_emits_runtime_gate_logs_when_debug_enabled(mock_bizh
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
@@ -3404,6 +3411,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
@@ -3432,6 +3440,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -357,9 +357,17 @@ def test_vanilla_shards_are_locked_to_boss_defeats() -> None:
     _major_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MAJOR_CHEST)
     _vitality_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.VITALITY_CHEST)
     _sound_player_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.SOUND_PLAYER_CHEST)
+    _minor_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MINOR_CHEST)
     _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
-    _expected_pool_size = _major_chest_count + _vitality_chest_count + _sound_player_chest_count + _hub_switch_count + _room_sanity_count
+    _expected_pool_size = (
+        _major_chest_count
+        + _vitality_chest_count
+        + _sound_player_chest_count
+        + _minor_chest_count
+        + _hub_switch_count
+        + _room_sanity_count
+    )
     assert len(world.multiworld.itempool) == _expected_pool_size
     assert all("Mirror Shard" not in item.name for item in world.multiworld.itempool)
 
@@ -377,6 +385,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
     _major_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MAJOR_CHEST)
     _vitality_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.VITALITY_CHEST)
     _sound_player_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.SOUND_PLAYER_CHEST)
+    _minor_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MINOR_CHEST)
     _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
     _shard_item_count = len(KirbyAmWorld._SHARD_ITEM_LABEL_ORDER)
@@ -385,6 +394,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
         + _major_chest_count
         + _vitality_chest_count
         + _sound_player_chest_count
+        + _minor_chest_count
         + _hub_switch_count
         + _room_sanity_count
     )

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -131,6 +131,7 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
          patch.object(client, '_poll_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_major_chest_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_minor_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -217,9 +217,10 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
             assert loc_key in known_locations, (
                 f"Room {room_key} claims unknown location key {loc_key!r}"
             )
-    # Exactly 22 rooms carry locations (9 major chests + 5 vitality/sound + 8 boss defeats)
-    assert len(rooms_with_locations) == 22, (
-        f"Expected 22 rooms with locations, got {len(rooms_with_locations)}: {list(rooms_with_locations.keys())}"
+    # Exactly 25 rooms carry locations
+    # (9 major chests + 5 vitality/sound + 8 boss defeats + 3 enabled minor chests).
+    assert len(rooms_with_locations) == 25, (
+        f"Expected 25 rooms with locations, got {len(rooms_with_locations)}: {list(rooms_with_locations.keys())}"
     )
 
     # Topology includes all rooms, but Room Sanity remains optional metadata.

--- a/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
+++ b/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
@@ -21,6 +21,9 @@ SystemID GBA
 0203B048	d	h	0	System Bus	delivered_vitality_item_bits
 0203B04C	d	b	0	System Bus	hub_switch_flags (ROM->Client; bit0=PeppermintW, bit1=RREast, bit2=RRSouth, bit3=CabbageCenter, bit4=RRWest, bit5=Carrot, bit6=RRNorth, bit7=Mustard, bit8=CabbageWest, bit9=Radish, bit10=Moonlight, bit11=PeppermintE, bit12=CabbageEast, bit13=Olive, bit14=Candy)
 0	S	_	1		=== Native Gameplay Addresses (from worlds/kirbyam/data/addresses.json) ===
+02038960	d	h	0	System Bus	small_chest_flags_native[0:31] (native chest/switch state block)
+02038964	d	h	0	System Bus	small_chest_flags_native[32:63]
+02038968	w	h	0	System Bus	small_chest_flags_native[64:79]
 02038970	b	h	0	System Bus	shard_bitfield_native (KIRBY_SHARD_FLAGS)
 0203897C	d	h	0	System Bus	big_chest_bitfield_native (gTreasures.bigChestField)
 02028C14	d	h	0	System Bus	boss_mirror_table_native [probe]


### PR DESCRIPTION
## Summary\nEnable the first concrete MINOR_CHEST AP checks using native small-chest bitfield polling, while keeping ambiguous multi-chest mappings deferred.\n\n## What changed\n- Added three concrete MINOR_CHEST locations:\n  - MINOR_CHEST_RAINBOW_ROUTE_1_20 (bit 1, location_id 3960500)\n  - MINOR_CHEST_RAINBOW_ROUTE_1_22 (bit 23, location_id 3960501)\n  - MINOR_CHEST_RAINBOW_ROUTE_1_38 (bit 41, location_id 3960502)\n- Registered the locations in rooms topology.\n- Added native address key small_chest_flags_native (0x02038960) and integrated client polling for MINOR_CHEST checks with resend/dedupe semantics matching existing families.\n- Added tests for minor-chest polling behavior (set bits and missing-address no-op).\n- Updated protocol/docs/changelog/watch tooling to include active MINOR_CHEST signal + IDs.\n\n## Safety / rollout constraints\n- Uses only non-multi-room candidates with globally unique native chest flag indices for this first active batch.\n- Keeps multi-chest ambiguous rooms deferred (#542 / #701).\n\n## Validation\n- python -m pytest worlds/kirbyam/test/test_client.py -k minor_chest -q\n- python -m pytest worlds/kirbyam/test/test_fixture_data.py worlds/kirbyam/test/test_minor_chest_manifest_contract.py -q\n\n## Issue linkage\n- Parent feature: #129\n- Follow-up mapping backlog: #541\n- Deferred ambiguities: #542 and #701