### PR TITLE
Fix inconsistent hub/boss location label formatting

### DIFF
--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -19,7 +19,7 @@ from .ability_randomization import (
     build_enemy_copy_ability_policy,
 )
 from .colors import STARTING_KIRBY_COLOR_RANDOM_OPTION, resolve_kirby_color
-from .data import LocationCategory, load_json_data, data as kirby_data
+from .data import LocationCategory, format_room_region_label, load_json_data, data as kirby_data
 from .enemy_ability_runtime_patch import build_enemy_copy_spoiler_rows
 from .generation_logging import (
     generation_stage,
@@ -754,7 +754,7 @@ class KirbyAmWorld(World):
         rooms = rooms_payload if isinstance(rooms_payload, dict) else {}
         slot_data["rooms"] = {
             room_key: {
-                "label": room_data.get("label", room_key),
+                "label": room_data.get("label") or format_room_region_label(room_key),
                 "exits": room_data.get("exits", []),
                 "parent_region": room_key.split("/")[0] if "/" in room_key else "",
                 "room_sanity_location_id": room_data.get("room_sanity", {}).get("location_id"),

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -8,7 +8,7 @@ import Utils
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
 
-from .data import LocationCategory, data, load_json_data
+from .data import LocationCategory, data, format_room_region_label, load_json_data
 from .enemy_ability_data import ABILITY_SOURCES
 from .enemy_ability_data import ABILITY_NAME_TO_ID
 from .kirby_ap_payload.thumb_branch import is_thumb_bl_instruction
@@ -323,7 +323,7 @@ class KirbyAmClient(BizHawkClient):
 
     @staticmethod
     def _build_room_label_lookup() -> "dict[int, str]":
-        """Build a doorsIdx → region_key mapping from all rooms in rooms.json."""
+        """Build a doorsIdx → room label mapping from all rooms in rooms.json."""
         rooms_json = load_json_data("regions/rooms.json")
         result: dict[int, str] = {}
         if not isinstance(rooms_json, dict):
@@ -334,7 +334,7 @@ class KirbyAmClient(BizHawkClient):
                 continue
             bit_index = rs.get("bit_index")
             if bit_index is not None:
-                result[int(bit_index)] = str(region_key)
+                result[int(bit_index)] = format_room_region_label(str(region_key))
         return result
 
     def _reset_reconnect_transient_state(self) -> None:

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -20,6 +20,7 @@ from BaseClasses import ItemClassification
 
 # If your JSON does not provide explicit numeric IDs, we will auto-assign IDs starting here.
 BASE_OFFSET = 3_860_000
+_ROOM_REGION_KEY_PATTERN = re.compile(r"^REGION_[A-Z_]+/ROOM_(\d+)_([A-Z0-9_]+)$")
 
 
 def load_json_data(data_name: str) -> list[Any] | dict[str, Any]:
@@ -62,6 +63,38 @@ def _maybe_load_json_data(data_name: str) -> list[Any] | dict[str, Any] | None:
     return orjson.loads(raw.decode("utf-8-sig"))
 
 
+def _format_room_code_special_label(room_code: str) -> str | None:
+    if room_code == "BOSS":
+        return "Boss Room"
+    if room_code == "HUB":
+        return "Hub Room"
+    if room_code.startswith("HUB_"):
+        suffix = room_code[len("HUB_"):]
+        if suffix.isdigit():
+            return f"Hub Room {int(suffix)}"
+        return f"Hub Room {suffix.replace('_', ' ')}"
+    return None
+
+
+def format_room_region_label(region_key: str) -> str:
+    """
+    Convert raw room region constants into friendly labels for player-facing output.
+
+    Only room types with known readability issues are rewritten (hub and boss rooms);
+    all other region keys are returned unchanged.
+    """
+    match = _ROOM_REGION_KEY_PATTERN.match(region_key)
+    if not match:
+        return region_key
+
+    area_num = int(match.group(1))
+    room_code = match.group(2)
+    special_label = _format_room_code_special_label(room_code)
+    if special_label is None:
+        return region_key
+    return f"Area {area_num} - {special_label}"
+
+
 def _load_room_sanity_locations_from_room_subareas() -> dict[str, dict[str, Any]]:
     """Build ROOM_SANITY location definitions from regions/rooms.json metadata."""
     room_subareas = _maybe_load_json_data("regions/rooms.json")
@@ -69,8 +102,6 @@ def _load_room_sanity_locations_from_room_subareas() -> dict[str, dict[str, Any]
         return {}
 
     generated_locations: dict[str, dict[str, Any]] = {}
-    room_key_pattern = re.compile(r"^REGION_[A-Z_]+/ROOM_(\d+)_([A-Z0-9_]+)$")
-
     for region_name, region_def in room_subareas.items():
         if not isinstance(region_name, str) or not isinstance(region_def, dict):
             continue
@@ -81,7 +112,7 @@ def _load_room_sanity_locations_from_room_subareas() -> dict[str, dict[str, Any]
         if not bool(room_meta.get("included", False)):
             continue
 
-        match = room_key_pattern.match(region_name)
+        match = _ROOM_REGION_KEY_PATTERN.match(region_name)
         if not match:
             raise ValueError(
                 "room_sanity metadata is only valid on ROOM regions; "
@@ -91,6 +122,8 @@ def _load_room_sanity_locations_from_room_subareas() -> dict[str, dict[str, Any]
         area_num = int(match.group(1))
         room_code = match.group(2)
         location_key = f"ROOM_SANITY_{area_num}_{room_code}"
+        special_label = _format_room_code_special_label(room_code)
+        room_label = f"Area {area_num} - {special_label}" if special_label else f"Room {area_num}-{room_code}"
 
         bit_index_raw = room_meta.get("bit_index")
         location_id_raw = room_meta.get("location_id")
@@ -100,7 +133,7 @@ def _load_room_sanity_locations_from_room_subareas() -> dict[str, dict[str, Any]
             )
 
         generated_locations[location_key] = {
-            "label": f"Room {area_num}-{room_code}",
+            "label": room_label,
             "parent_region": region_name,
             "tags": ["RoomSanity"],
             "bit_index": int(bit_index_raw),

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -268,9 +268,9 @@
       "HubSwitch",
       "MAP_MOONLIGHT_MANSION"
     ],
-    "bit_index": 10,
+    "bit_index": 11,
     "category": "HUB_SWITCH",
-    "location_id": 3960410
+    "location_id": 3960411
   },
   "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
     "label": "Rainbow Route East - Big Switch",
@@ -372,15 +372,15 @@
     "location_id": 3960409
   },
   "HUB_SWITCH_PEPPERMINT_EAST": {
-    "label": "Moonlight Mansion East - Big Switch",
+    "label": "Peppermint Palace East - Big Switch",
     "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
     "tags": [
       "HubSwitch",
       "MAP_PEPPERMINT_PALACE"
     ],
-    "bit_index": 11,
+    "bit_index": 10,
     "category": "HUB_SWITCH",
-    "location_id": 3960411
+    "location_id": 3960410
   },
   "HUB_SWITCH_PEPPERMINT_WEST": {
     "label": "Peppermint Palace West - Big Switch",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -372,7 +372,7 @@
     "location_id": 3960409
   },
   "HUB_SWITCH_PEPPERMINT_EAST": {
-    "label": "Peppermint Palace East - Big Switch",
+    "label": "Moonlight Mansion East - Big Switch",
     "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
     "tags": [
       "HubSwitch",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -196,7 +196,7 @@
     "HUB_SWITCH_MOONLIGHT": {
       "category": "HUB_SWITCH",
       "label": "Moonlight Mansion - Big Switch",
-      "location_id": 3960410,
+      "location_id": 3960411,
       "tags": [
         "HubSwitch",
         "MAP_MOONLIGHT_MANSION"
@@ -222,8 +222,8 @@
     },
     "HUB_SWITCH_PEPPERMINT_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Moonlight Mansion East - Big Switch",
-      "location_id": 3960411,
+      "label": "Peppermint Palace East - Big Switch",
+      "location_id": 3960410,
       "tags": [
         "HubSwitch",
         "MAP_PEPPERMINT_PALACE"

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -222,7 +222,7 @@
     },
     "HUB_SWITCH_PEPPERMINT_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Peppermint Palace East - Big Switch",
+      "label": "Moonlight Mansion East - Big Switch",
       "location_id": 3960411,
       "tags": [
         "HubSwitch",
@@ -761,7 +761,7 @@
     },
     "ROOM_SANITY_1_HUB_1": {
       "category": "ROOM_SANITY",
-      "label": "Room 1-HUB_1",
+      "label": "Area 1 - Hub Room 1",
       "location_id": 3961022,
       "tags": [
         "RoomSanity"
@@ -769,7 +769,7 @@
     },
     "ROOM_SANITY_1_HUB_2": {
       "category": "ROOM_SANITY",
-      "label": "Room 1-HUB_2",
+      "label": "Area 1 - Hub Room 2",
       "location_id": 3961026,
       "tags": [
         "RoomSanity"
@@ -777,7 +777,7 @@
     },
     "ROOM_SANITY_1_HUB_3": {
       "category": "ROOM_SANITY",
-      "label": "Room 1-HUB_3",
+      "label": "Area 1 - Hub Room 3",
       "location_id": 3961049,
       "tags": [
         "RoomSanity"
@@ -785,7 +785,7 @@
     },
     "ROOM_SANITY_1_HUB_4": {
       "category": "ROOM_SANITY",
-      "label": "Room 1-HUB_4",
+      "label": "Area 1 - Hub Room 4",
       "location_id": 3961011,
       "tags": [
         "RoomSanity"
@@ -961,7 +961,7 @@
     },
     "ROOM_SANITY_2_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 2-BOSS",
+      "label": "Area 2 - Boss Room",
       "location_id": 3961064,
       "tags": [
         "RoomSanity"
@@ -993,7 +993,7 @@
     },
     "ROOM_SANITY_2_HUB": {
       "category": "ROOM_SANITY",
-      "label": "Room 2-HUB",
+      "label": "Area 2 - Hub Room",
       "location_id": 3961070,
       "tags": [
         "RoomSanity"
@@ -1137,7 +1137,7 @@
     },
     "ROOM_SANITY_3_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 3-BOSS",
+      "label": "Area 3 - Boss Room",
       "location_id": 3961079,
       "tags": [
         "RoomSanity"
@@ -1153,7 +1153,7 @@
     },
     "ROOM_SANITY_3_HUB_1": {
       "category": "ROOM_SANITY",
-      "label": "Room 3-HUB_1",
+      "label": "Area 3 - Hub Room 1",
       "location_id": 3961094,
       "tags": [
         "RoomSanity"
@@ -1161,7 +1161,7 @@
     },
     "ROOM_SANITY_3_HUB_2": {
       "category": "ROOM_SANITY",
-      "label": "Room 3-HUB_2",
+      "label": "Area 3 - Hub Room 2",
       "location_id": 3961093,
       "tags": [
         "RoomSanity"
@@ -1169,7 +1169,7 @@
     },
     "ROOM_SANITY_3_HUB_3": {
       "category": "ROOM_SANITY",
-      "label": "Room 3-HUB_3",
+      "label": "Area 3 - Hub Room 3",
       "location_id": 3961095,
       "tags": [
         "RoomSanity"
@@ -1329,7 +1329,7 @@
     },
     "ROOM_SANITY_4_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 4-BOSS",
+      "label": "Area 4 - Boss Room",
       "location_id": 3961116,
       "tags": [
         "RoomSanity"
@@ -1361,7 +1361,7 @@
     },
     "ROOM_SANITY_4_HUB": {
       "category": "ROOM_SANITY",
-      "label": "Room 4-HUB",
+      "label": "Area 4 - Hub Room",
       "location_id": 3961119,
       "tags": [
         "RoomSanity"
@@ -1521,7 +1521,7 @@
     },
     "ROOM_SANITY_5_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 5-BOSS",
+      "label": "Area 5 - Boss Room",
       "location_id": 3961138,
       "tags": [
         "RoomSanity"
@@ -1545,7 +1545,7 @@
     },
     "ROOM_SANITY_5_HUB": {
       "category": "ROOM_SANITY",
-      "label": "Room 5-HUB",
+      "label": "Area 5 - Hub Room",
       "location_id": 3961126,
       "tags": [
         "RoomSanity"
@@ -1745,7 +1745,7 @@
     },
     "ROOM_SANITY_6_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 6-BOSS",
+      "label": "Area 6 - Boss Room",
       "location_id": 3961170,
       "tags": [
         "RoomSanity"
@@ -1785,7 +1785,7 @@
     },
     "ROOM_SANITY_6_HUB": {
       "category": "ROOM_SANITY",
-      "label": "Room 6-HUB",
+      "label": "Area 6 - Hub Room",
       "location_id": 3961163,
       "tags": [
         "RoomSanity"
@@ -1985,7 +1985,7 @@
     },
     "ROOM_SANITY_7_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 7-BOSS",
+      "label": "Area 7 - Boss Room",
       "location_id": 3961194,
       "tags": [
         "RoomSanity"
@@ -2017,7 +2017,7 @@
     },
     "ROOM_SANITY_7_HUB_1": {
       "category": "ROOM_SANITY",
-      "label": "Room 7-HUB_1",
+      "label": "Area 7 - Hub Room 1",
       "location_id": 3961188,
       "tags": [
         "RoomSanity"
@@ -2025,7 +2025,7 @@
     },
     "ROOM_SANITY_7_HUB_2": {
       "category": "ROOM_SANITY",
-      "label": "Room 7-HUB_2",
+      "label": "Area 7 - Hub Room 2",
       "location_id": 3961200,
       "tags": [
         "RoomSanity"
@@ -2225,7 +2225,7 @@
     },
     "ROOM_SANITY_8_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 8-BOSS",
+      "label": "Area 8 - Boss Room",
       "location_id": 3961229,
       "tags": [
         "RoomSanity"
@@ -2265,7 +2265,7 @@
     },
     "ROOM_SANITY_8_HUB": {
       "category": "ROOM_SANITY",
-      "label": "Room 8-HUB",
+      "label": "Area 8 - Hub Room",
       "location_id": 3961221,
       "tags": [
         "RoomSanity"
@@ -2433,7 +2433,7 @@
     },
     "ROOM_SANITY_9_BOSS": {
       "category": "ROOM_SANITY",
-      "label": "Room 9-BOSS",
+      "label": "Area 9 - Boss Room",
       "location_id": 3961245,
       "tags": [
         "RoomSanity"
@@ -2481,7 +2481,7 @@
     },
     "ROOM_SANITY_9_HUB": {
       "category": "ROOM_SANITY",
-      "label": "Room 9-HUB",
+      "label": "Area 9 - Hub Room",
       "location_id": 3961256,
       "tags": [
         "RoomSanity"
@@ -2706,7 +2706,7 @@
         "REGION_CABBAGE_CAVERN/ROOM_3_04",
         "REGION_RAINBOW_ROUTE/ROOM_1_01"
       ],
-      "label": "REGION_CABBAGE_CAVERN/ROOM_3_BOSS",
+      "label": "Area 3 - Boss Room",
       "parent_region": "REGION_CABBAGE_CAVERN",
       "room_sanity_location_id": 3961079
     },
@@ -2726,7 +2726,7 @@
         "REGION_CABBAGE_CAVERN/ROOM_3_HUB_2",
         "REGION_RAINBOW_ROUTE/ROOM_1_10"
       ],
-      "label": "REGION_CABBAGE_CAVERN/ROOM_3_HUB_1",
+      "label": "Area 3 - Hub Room 1",
       "parent_region": "REGION_CABBAGE_CAVERN",
       "room_sanity_location_id": 3961094
     },
@@ -2736,7 +2736,7 @@
         "REGION_CABBAGE_CAVERN/ROOM_3_HUB_1",
         "REGION_DIMENSION_MIRROR/ROOM_10_19"
       ],
-      "label": "REGION_CABBAGE_CAVERN/ROOM_3_HUB_2",
+      "label": "Area 3 - Hub Room 2",
       "parent_region": "REGION_CABBAGE_CAVERN",
       "room_sanity_location_id": 3961093
     },
@@ -2746,7 +2746,7 @@
         "REGION_RADISH_RUINS/ROOM_8_BOSS",
         "REGION_RAINBOW_ROUTE/ROOM_1_HUB_3"
       ],
-      "label": "REGION_CABBAGE_CAVERN/ROOM_3_HUB_3",
+      "label": "Area 3 - Hub Room 3",
       "parent_region": "REGION_CABBAGE_CAVERN",
       "room_sanity_location_id": 3961095
     },
@@ -2945,7 +2945,7 @@
       "exits": [
         "REGION_CANDY_CONSTELLATION/ROOM_9_20"
       ],
-      "label": "REGION_CANDY_CONSTELLATION/ROOM_9_BOSS",
+      "label": "Area 9 - Boss Room",
       "parent_region": "REGION_CANDY_CONSTELLATION",
       "room_sanity_location_id": 3961245
     },
@@ -3006,7 +3006,7 @@
         "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_3",
         "REGION_RAINBOW_ROUTE/ROOM_1_HUB_3"
       ],
-      "label": "REGION_CANDY_CONSTELLATION/ROOM_9_HUB",
+      "label": "Area 9 - Hub Room",
       "parent_region": "REGION_CANDY_CONSTELLATION",
       "room_sanity_location_id": 3961256
     },
@@ -3213,7 +3213,7 @@
         "REGION_CARROT_CASTLE/ROOM_5_CHEST_1",
         "REGION_CARROT_CASTLE/ROOM_5_15"
       ],
-      "label": "REGION_CARROT_CASTLE/ROOM_5_BOSS",
+      "label": "Area 5 - Boss Room",
       "parent_region": "REGION_CARROT_CASTLE",
       "room_sanity_location_id": 3961138
     },
@@ -3243,7 +3243,7 @@
         "REGION_PEPPERMINT_PALACE/ROOM_7_01",
         "REGION_PEPPERMINT_PALACE/ROOM_7_17"
       ],
-      "label": "REGION_CARROT_CASTLE/ROOM_5_HUB",
+      "label": "Area 5 - Hub Room",
       "parent_region": "REGION_CARROT_CASTLE",
       "room_sanity_location_id": 3961126
     },
@@ -3625,7 +3625,7 @@
         "REGION_MOONLIGHT_MANSION/ROOM_2_03",
         "REGION_MOONLIGHT_MANSION/ROOM_2_01"
       ],
-      "label": "REGION_MOONLIGHT_MANSION/ROOM_2_BOSS",
+      "label": "Area 2 - Boss Room",
       "parent_region": "REGION_MOONLIGHT_MANSION",
       "room_sanity_location_id": 3961064
     },
@@ -3663,7 +3663,7 @@
         "REGION_MOONLIGHT_MANSION/ROOM_2_15",
         "REGION_MOONLIGHT_MANSION/ROOM_2_WARP"
       ],
-      "label": "REGION_MOONLIGHT_MANSION/ROOM_2_HUB",
+      "label": "Area 2 - Hub Room",
       "parent_region": "REGION_MOONLIGHT_MANSION",
       "room_sanity_location_id": 3961070
     },
@@ -3872,7 +3872,7 @@
         "REGION_MUSTARD_MOUNTAIN/ROOM_4_16",
         "REGION_RAINBOW_ROUTE/ROOM_1_21"
       ],
-      "label": "REGION_MUSTARD_MOUNTAIN/ROOM_4_BOSS",
+      "label": "Area 4 - Boss Room",
       "parent_region": "REGION_MUSTARD_MOUNTAIN",
       "room_sanity_location_id": 3961116
     },
@@ -3910,7 +3910,7 @@
         "REGION_DIMENSION_MIRROR/ROOM_10_19",
         "REGION_MUSTARD_MOUNTAIN/ROOM_4_GOAL_2"
       ],
-      "label": "REGION_MUSTARD_MOUNTAIN/ROOM_4_HUB",
+      "label": "Area 4 - Hub Room",
       "parent_region": "REGION_MUSTARD_MOUNTAIN",
       "room_sanity_location_id": 3961119
     },
@@ -4151,7 +4151,7 @@
         "REGION_OLIVE_OCEAN/ROOM_6_09",
         "REGION_OLIVE_OCEAN/ROOM_6_18"
       ],
-      "label": "REGION_OLIVE_OCEAN/ROOM_6_BOSS",
+      "label": "Area 6 - Boss Room",
       "parent_region": "REGION_OLIVE_OCEAN",
       "room_sanity_location_id": 3961170
     },
@@ -4200,7 +4200,7 @@
         "REGION_OLIVE_OCEAN/ROOM_6_02",
         "REGION_OLIVE_OCEAN/ROOM_6_23"
       ],
-      "label": "REGION_OLIVE_OCEAN/ROOM_6_HUB",
+      "label": "Area 6 - Hub Room",
       "parent_region": "REGION_OLIVE_OCEAN",
       "room_sanity_location_id": 3961163
     },
@@ -4446,7 +4446,7 @@
         "REGION_PEPPERMINT_PALACE/ROOM_7_05",
         "REGION_PEPPERMINT_PALACE/ROOM_7_15"
       ],
-      "label": "REGION_PEPPERMINT_PALACE/ROOM_7_BOSS",
+      "label": "Area 7 - Boss Room",
       "parent_region": "REGION_PEPPERMINT_PALACE",
       "room_sanity_location_id": 3961194
     },
@@ -4486,7 +4486,7 @@
         "REGION_PEPPERMINT_PALACE/ROOM_7_12",
         "REGION_PEPPERMINT_PALACE/ROOM_7_GOAL_2"
       ],
-      "label": "REGION_PEPPERMINT_PALACE/ROOM_7_HUB_1",
+      "label": "Area 7 - Hub Room 1",
       "parent_region": "REGION_PEPPERMINT_PALACE",
       "room_sanity_location_id": 3961188
     },
@@ -4496,7 +4496,7 @@
         "REGION_PEPPERMINT_PALACE/ROOM_7_17",
         "REGION_PEPPERMINT_PALACE/ROOM_7_15"
       ],
-      "label": "REGION_PEPPERMINT_PALACE/ROOM_7_HUB_2",
+      "label": "Area 7 - Hub Room 2",
       "parent_region": "REGION_PEPPERMINT_PALACE",
       "room_sanity_location_id": 3961200
     },
@@ -4744,7 +4744,7 @@
         "REGION_RADISH_RUINS/ROOM_8_14",
         "REGION_RADISH_RUINS/ROOM_8_CHEST_2"
       ],
-      "label": "REGION_RADISH_RUINS/ROOM_8_BOSS",
+      "label": "Area 8 - Boss Room",
       "parent_region": "REGION_RADISH_RUINS",
       "room_sanity_location_id": 3961229
     },
@@ -4796,7 +4796,7 @@
         "REGION_RADISH_RUINS/ROOM_8_15",
         "REGION_RADISH_RUINS/ROOM_8_17"
       ],
-      "label": "REGION_RADISH_RUINS/ROOM_8_HUB",
+      "label": "Area 8 - Hub Room",
       "parent_region": "REGION_RADISH_RUINS",
       "room_sanity_location_id": 3961221
     },
@@ -5285,7 +5285,7 @@
         "REGION_RAINBOW_ROUTE/ROOM_1_15",
         "REGION_RAINBOW_ROUTE/ROOM_1_31"
       ],
-      "label": "REGION_RAINBOW_ROUTE/ROOM_1_HUB_1",
+      "label": "Area 1 - Hub Room 1",
       "parent_region": "REGION_RAINBOW_ROUTE",
       "room_sanity_location_id": 3961022
     },
@@ -5294,7 +5294,7 @@
         "REGION_DIMENSION_MIRROR/ROOM_10_18",
         "REGION_RAINBOW_ROUTE/ROOM_1_16"
       ],
-      "label": "REGION_RAINBOW_ROUTE/ROOM_1_HUB_2",
+      "label": "Area 1 - Hub Room 2",
       "parent_region": "REGION_RAINBOW_ROUTE",
       "room_sanity_location_id": 3961026
     },
@@ -5310,7 +5310,7 @@
         "REGION_RAINBOW_ROUTE/ROOM_1_10",
         "REGION_RAINBOW_ROUTE/ROOM_1_29"
       ],
-      "label": "REGION_RAINBOW_ROUTE/ROOM_1_HUB_3",
+      "label": "Area 1 - Hub Room 3",
       "parent_region": "REGION_RAINBOW_ROUTE",
       "room_sanity_location_id": 3961049
     },
@@ -5319,7 +5319,7 @@
         "REGION_RAINBOW_ROUTE/ROOM_1_30",
         "REGION_RAINBOW_ROUTE/ROOM_1_05"
       ],
-      "label": "REGION_RAINBOW_ROUTE/ROOM_1_HUB_4",
+      "label": "Area 1 - Hub Room 4",
       "parent_region": "REGION_RAINBOW_ROUTE",
       "room_sanity_location_id": 3961011
     },

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -588,6 +588,8 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
     client.initialize_client()
 
     moonlight = data.locations["HUB_SWITCH_MOONLIGHT"].location_id
+    moonlight_bit = data.locations["HUB_SWITCH_MOONLIGHT"].bit_index
+    assert moonlight_bit is not None
     rainbow_east = data.locations["HUB_SWITCH_RAINBOW_ROUTE_EAST"].location_id
     mock_bizhawk_context.checked_locations = set()
 
@@ -596,7 +598,7 @@ async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_c
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
         mock_read.side_effect = [
             [(0).to_bytes(4, 'little')],
-            [((1 << 10) | (1 << 1)).to_bytes(4, 'little')],
+            [((1 << moonlight_bit) | (1 << 1)).to_bytes(4, 'little')],
         ]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
@@ -638,13 +640,15 @@ async def test_poll_hub_switch_skips_already_server_acknowledged(mock_bizhawk_co
     client._debug_logging_enabled = True
 
     moonlight = data.locations["HUB_SWITCH_MOONLIGHT"].location_id
+    moonlight_bit = data.locations["HUB_SWITCH_MOONLIGHT"].bit_index
+    assert moonlight_bit is not None
     mock_bizhawk_context.checked_locations = {moonlight}
 
     with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
          patch('CommonClient.logger') as mock_logger:
-        mock_read.return_value = [((1 << 10)).to_bytes(4, 'little')]
+        mock_read.return_value = [((1 << moonlight_bit)).to_bytes(4, 'little')]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
 

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..data import _normalize_gba_rom_address, format_room_region_label
+from ..data import _normalize_gba_rom_address, data as kirby_data, format_room_region_label
 
 
 @pytest.mark.parametrize(
@@ -32,3 +32,13 @@ def test_normalize_gba_rom_address_passthrough_for_non_mapped_values():
 )
 def test_format_room_region_label(region_key: str, expected_label: str) -> None:
     assert format_room_region_label(region_key) == expected_label
+
+
+def test_hub_switch_moonlight_and_peppermint_east_mapping() -> None:
+    moonlight = kirby_data.locations["HUB_SWITCH_MOONLIGHT"]
+    peppermint_east = kirby_data.locations["HUB_SWITCH_PEPPERMINT_EAST"]
+
+    assert moonlight.bit_index == 11
+    assert moonlight.location_id == 3960411
+    assert peppermint_east.bit_index == 10
+    assert peppermint_east.location_id == 3960410

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..data import _normalize_gba_rom_address
+from ..data import _normalize_gba_rom_address, format_room_region_label
 
 
 @pytest.mark.parametrize(
@@ -18,3 +18,17 @@ def test_normalize_gba_rom_address_mapped_ranges(raw_addr, expected_offset):
 
 def test_normalize_gba_rom_address_passthrough_for_non_mapped_values():
     assert _normalize_gba_rom_address(0x00F00000) == 0x00F00000
+
+
+@pytest.mark.parametrize(
+    "region_key, expected_label",
+    [
+        ("REGION_MOONLIGHT_MANSION/ROOM_2_BOSS", "Area 2 - Boss Room"),
+        ("REGION_MOONLIGHT_MANSION/ROOM_2_HUB", "Area 2 - Hub Room"),
+        ("REGION_RAINBOW_ROUTE/ROOM_1_HUB_3", "Area 1 - Hub Room 3"),
+        ("REGION_MOONLIGHT_MANSION/ROOM_2_18", "REGION_MOONLIGHT_MANSION/ROOM_2_18"),
+        ("REGION_MOONLIGHT_MANSION/MAIN", "REGION_MOONLIGHT_MANSION/MAIN"),
+    ],
+)
+def test_format_room_region_label(region_key: str, expected_label: str) -> None:
+    assert format_room_region_label(region_key) == expected_label


### PR DESCRIPTION
## Summary\n- normalize room-sanity hub and boss labels to friendly area-based names\n- format room-entry/room payload labels for hub and boss room constants\n- correct the Peppermint East hub switch label to its Moonlight Mansion area context\n- add formatter unit coverage and refresh slot_data snapshot\n\n## Testing\n- python -m pytest worlds/kirbyam/test/test_data_normalization.py worlds/kirbyam/test/test_snapshot_outputs.py::test_slot_data_snapshot_matches_golden worlds/kirbyam/test/test_slot_data_contract.py\n\nCloses #710