### PR TITLE
Issue #715: surface current room tracker updates

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -326,12 +326,23 @@ for doors_idx in mapped_room_sanity_doors_indices:
     if room_visits[doors_idx] & 0x8000:
         mapped_checked.add(room_sanity_location_id_for_doors_idx(doors_idx))
 
-# Room-entry diagnostics (best-effort; logging only)
+# Room-entry tracker updates (best-effort)
 current_room_native = RAM[0x02023B28] as u16
 if current_room_native changed:
     doors_idx = ROM[gRoomProps + current_room_native * gRoomPropsStride + doorsIdxOffset] as u16
+    room_region_key = rooms_json_region_key_for_doors_idx(doors_idx)
     room_label = rooms_json_label_for_doors_idx(doors_idx)
     log_room_entry(room_label, current_room_native, doors_idx)
+    send Bounce(
+        slots=[self_slot],
+        data={
+            "type": "RoomUpdate",
+            "nativeRoomId": current_room_native,
+            "doorsIdx": doors_idx,
+            "roomRegionKey": room_region_key,
+            "roomLabel": room_label,
+        },
+    )
 
 # Level-based, reconnect-safe resend:
 # Send only checks that RAM reports as collected but the server has not acknowledged.
@@ -356,6 +367,17 @@ Boss shard scrub timing contract (Issue #505):
 - No checks are sent for reserved/unmapped bits even when set.
 - Boss-defeat, major-chest, vitality-chest, sound-player-chest, hub-switch, and room-sanity polling follow the same resend/dedupe diagnostic contract.
 - Diagnostics are transition-based to avoid per-tick log spam when mapped state is unchanged.
+
+Tracker room update contract:
+- The BizHawk client sends a slot-targeted `Bounce` packet when `current_room_native` changes.
+- `data.type` is `RoomUpdate`.
+- Payload fields are:
+    - `nativeRoomId` (`u16` widened to int): current native room ID from `gCurLevelInfo[0].currentRoom`.
+    - `doorsIdx` (`u16` widened to int): room index read from `gRoomProps[current_room].doorsIdx`.
+    - `roomRegionKey` (`str`): KirbyAM room key from `rooms.json` for the resolved `doorsIdx` (empty string when unknown).
+    - `roomLabel` (`str`): formatted tracker-facing room label for the resolved `doorsIdx` (fallback `<unknown doorsIdx=N>` when unknown).
+- De-dupe rule: unchanged `nativeRoomId` does not emit additional `Bounce` packets.
+- Reconnect/session-reset rule: client reconnect transient reset clears the last-seen room so the first post-reconnect watcher tick re-emits the current room.
 
 ### 3. Item Delivery (Mailbox Protocol)
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -236,8 +236,9 @@ class KirbyAmClient(BizHawkClient):
 
         # Room entry logging (always to file; client display gated by debug flag)
         self._last_native_room_id: int | None = None
-        self._room_label_by_doors_idx: dict[int, str] = self._build_room_label_lookup()
-        self._room_region_key_by_doors_idx: dict[int, str] = self._build_room_region_key_lookup()
+        room_label_lookup, room_region_key_lookup = self._build_room_lookup_maps()
+        self._room_label_by_doors_idx = room_label_lookup
+        self._room_region_key_by_doors_idx = room_region_key_lookup
 
         # Notification pipeline state (Issue #83)
         self._notification_settings_loaded: bool = False
@@ -332,36 +333,23 @@ class KirbyAmClient(BizHawkClient):
         return common_logger
 
     @staticmethod
-    def _build_room_label_lookup() -> "dict[int, str]":
-        """Build a doorsIdx → room label mapping from all rooms in rooms.json."""
+    def _build_room_lookup_maps() -> "tuple[dict[int, str], dict[int, str]]":
+        """Build doorsIdx keyed room label and region-key maps from rooms.json in one pass."""
         rooms_json = load_json_data("regions/rooms.json")
-        result: dict[int, str] = {}
+        label_result: dict[int, str] = {}
+        region_result: dict[int, str] = {}
         if not isinstance(rooms_json, dict):
-            return result
+            return label_result, region_result
         for region_key, room in rooms_json.items():
             rs = room.get("room_sanity")
             if not isinstance(rs, dict):
                 continue
             bit_index = rs.get("bit_index")
             if bit_index is not None:
-                result[int(bit_index)] = format_room_region_label(str(region_key))
-        return result
-
-    @staticmethod
-    def _build_room_region_key_lookup() -> "dict[int, str]":
-        """Build a doorsIdx → room region key mapping from all rooms in rooms.json."""
-        rooms_json = load_json_data("regions/rooms.json")
-        result: dict[int, str] = {}
-        if not isinstance(rooms_json, dict):
-            return result
-        for region_key, room in rooms_json.items():
-            rs = room.get("room_sanity")
-            if not isinstance(rs, dict):
-                continue
-            bit_index = rs.get("bit_index")
-            if bit_index is not None:
-                result[int(bit_index)] = str(region_key)
-        return result
+                doors_idx = int(bit_index)
+                label_result[doors_idx] = format_room_region_label(str(region_key))
+                region_result[doors_idx] = str(region_key)
+        return label_result, region_result
 
     def _reset_reconnect_transient_state(self) -> None:
         """Reset transient watcher diagnostics/probes so reconnect starts from clean baselines."""

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -2155,9 +2155,9 @@ class KirbyAmClient(BizHawkClient):
         value changes, resolves the native room ID to a doorsIdx via gRoomProps[] in
         ROM, then maps doorsIdx to room metadata from rooms.json.
 
-        Always written to the log file; shown in the client only when debug logging
-        is enabled. On room change, emits a typed Bounce payload to this slot for
-        tracker consumers.
+        Room changes are written to the log file (shown in the client only when
+        debug logging is enabled). On room change, emits a typed Bounce payload to
+        this slot for tracker consumers.
         """
         from CommonClient import logger
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -2194,6 +2194,30 @@ class KirbyAmClient(BizHawkClient):
         doors_idx = unpack_from("<H", doors_raw)[0]
         room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
         room_region_key = self._room_region_key_by_doors_idx.get(doors_idx, "")
+        if ctx.slot is not None:
+            try:
+                await ctx.send_msgs([{
+                    "cmd": "Bounce",
+                    "slots": [ctx.slot],
+                    "data": {
+                        "type": _ROOM_UPDATE_BOUNCE_TYPE,
+                        "nativeRoomId": native_room_id,
+                        "doorsIdx": doors_idx,
+                        "roomRegionKey": room_region_key,
+                        "roomLabel": room_label,
+                    },
+                }])
+            except Exception as exc:
+                # Tracker room updates are best-effort and must not break watcher progression.
+                self._log_verbose(
+                    "warning",
+                    "KirbyAM: failed to send room update bounce (native=0x%04x, doorsIdx=%d): %s",
+                    native_room_id,
+                    doors_idx,
+                    exc,
+                )
+                return
+
         self._last_native_room_id = native_room_id
         logger.info(
             "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
@@ -2202,18 +2226,6 @@ class KirbyAmClient(BizHawkClient):
             doors_idx,
             extra={"NoStream": not self._debug_logging_enabled},
         )
-        if ctx.slot is not None:
-            await ctx.send_msgs([{
-                "cmd": "Bounce",
-                "slots": [ctx.slot],
-                "data": {
-                    "type": _ROOM_UPDATE_BOUNCE_TYPE,
-                    "nativeRoomId": native_room_id,
-                    "doorsIdx": doors_idx,
-                    "roomRegionKey": room_region_key,
-                    "roomLabel": room_label,
-                },
-            }])
 
     async def _poll_room_sanity_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -94,6 +94,7 @@ _TRAP_ITEM_IDS: frozenset[int] = frozenset(
 _ROOM_PROPS_ROM_BASE = 0x009331AC  # gRoomProps[] — ROM domain offset (GBA ROM 0x089331AC)
 _ROOM_PROPS_STRIDE = 0x28  # sizeof(struct RoomProps)
 _ROOM_PROPS_DOORS_IDX_OFFSET = 0x24  # offsetof(struct RoomProps, doorsIdx)
+_ROOM_UPDATE_BOUNCE_TYPE = "RoomUpdate"
 _MANAGED_NATIVE_MAP_BITMASK = 0
 for area_id in _MAP_ITEM_ID_TO_AREA_ID.values():
     _MANAGED_NATIVE_MAP_BITMASK |= 1 << area_id
@@ -236,6 +237,7 @@ class KirbyAmClient(BizHawkClient):
         # Room entry logging (always to file; client display gated by debug flag)
         self._last_native_room_id: int | None = None
         self._room_label_by_doors_idx: dict[int, str] = self._build_room_label_lookup()
+        self._room_region_key_by_doors_idx: dict[int, str] = self._build_room_region_key_lookup()
 
         # Notification pipeline state (Issue #83)
         self._notification_settings_loaded: bool = False
@@ -345,9 +347,26 @@ class KirbyAmClient(BizHawkClient):
                 result[int(bit_index)] = format_room_region_label(str(region_key))
         return result
 
+    @staticmethod
+    def _build_room_region_key_lookup() -> "dict[int, str]":
+        """Build a doorsIdx → room region key mapping from all rooms in rooms.json."""
+        rooms_json = load_json_data("regions/rooms.json")
+        result: dict[int, str] = {}
+        if not isinstance(rooms_json, dict):
+            return result
+        for region_key, room in rooms_json.items():
+            rs = room.get("room_sanity")
+            if not isinstance(rs, dict):
+                continue
+            bit_index = rs.get("bit_index")
+            if bit_index is not None:
+                result[int(bit_index)] = str(region_key)
+        return result
+
     def _reset_reconnect_transient_state(self) -> None:
         """Reset transient watcher diagnostics/probes so reconnect starts from clean baselines."""
         self._last_runtime_gate_reason = None
+        self._last_native_room_id = None
         self._last_shard_poll_log = None
         self._last_boss_poll_log = None
         self._last_major_chest_poll_log = None
@@ -2140,14 +2159,15 @@ class KirbyAmClient(BizHawkClient):
 
     async def _poll_room_entry_logging(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
-        Detect native room changes and log the current room on every entry.
+        Detect native room changes, log the current room, and broadcast tracker updates.
 
         Reads gCurLevelInfo[0].currentRoom (u16 at current_room_native). When the
         value changes, resolves the native room ID to a doorsIdx via gRoomProps[] in
-        ROM, then maps doorsIdx to a region key from rooms.json.
+        ROM, then maps doorsIdx to room metadata from rooms.json.
 
         Always written to the log file; shown in the client only when debug logging
-        is enabled.
+        is enabled. On room change, emits a typed Bounce payload to this slot for
+        tracker consumers.
         """
         from CommonClient import logger
 
@@ -2185,6 +2205,7 @@ class KirbyAmClient(BizHawkClient):
 
         doors_idx = unpack_from("<H", doors_raw)[0]
         room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
+        room_region_key = self._room_region_key_by_doors_idx.get(doors_idx, "")
         self._last_native_room_id = native_room_id
         logger.info(
             "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
@@ -2193,6 +2214,18 @@ class KirbyAmClient(BizHawkClient):
             doors_idx,
             extra={"NoStream": not self._debug_logging_enabled},
         )
+        if ctx.slot is not None:
+            await ctx.send_msgs([{
+                "cmd": "Bounce",
+                "slots": [ctx.slot],
+                "data": {
+                    "type": _ROOM_UPDATE_BOUNCE_TYPE,
+                    "nativeRoomId": native_room_id,
+                    "doorsIdx": doors_idx,
+                    "roomRegionKey": room_region_key,
+                    "roomLabel": room_label,
+                },
+            }])
 
     async def _poll_room_sanity_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -236,9 +236,10 @@ class KirbyAmClient(BizHawkClient):
 
         # Room entry logging (always to file; client display gated by debug flag)
         self._last_native_room_id: int | None = None
+        self._last_sent_room_update_native_room_id: int | None = None
         room_label_lookup, room_region_key_lookup = self._build_room_lookup_maps()
-        self._room_label_by_doors_idx = room_label_lookup
-        self._room_region_key_by_doors_idx = room_region_key_lookup
+        self._room_label_by_doors_idx: dict[int, str] = room_label_lookup
+        self._room_region_key_by_doors_idx: dict[int, str] = room_region_key_lookup
 
         # Notification pipeline state (Issue #83)
         self._notification_settings_loaded: bool = False
@@ -355,6 +356,7 @@ class KirbyAmClient(BizHawkClient):
         """Reset transient watcher diagnostics/probes so reconnect starts from clean baselines."""
         self._last_runtime_gate_reason = None
         self._last_native_room_id = None
+        self._last_sent_room_update_native_room_id = None
         self._last_shard_poll_log = None
         self._last_boss_poll_log = None
         self._last_major_chest_poll_log = None
@@ -2172,8 +2174,10 @@ class KirbyAmClient(BizHawkClient):
             return
 
         native_room_id = unpack_from("<H", raw)[0]
+        room_changed = native_room_id != self._last_native_room_id
+        send_pending = native_room_id != self._last_sent_room_update_native_room_id
 
-        if native_room_id == self._last_native_room_id:
+        if not room_changed and not send_pending:
             return
 
         # Resolve doorsIdx via gRoomProps[native_room_id].doorsIdx (ROM read).
@@ -2194,7 +2198,18 @@ class KirbyAmClient(BizHawkClient):
         doors_idx = unpack_from("<H", doors_raw)[0]
         room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
         room_region_key = self._room_region_key_by_doors_idx.get(doors_idx, "")
-        if ctx.slot is not None:
+
+        if room_changed:
+            self._last_native_room_id = native_room_id
+            logger.info(
+                "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
+                room_label,
+                native_room_id,
+                doors_idx,
+                extra={"NoStream": not self._debug_logging_enabled},
+            )
+
+        if ctx.slot is not None and send_pending:
             try:
                 await ctx.send_msgs([{
                     "cmd": "Bounce",
@@ -2217,15 +2232,7 @@ class KirbyAmClient(BizHawkClient):
                     exc,
                 )
                 return
-
-        self._last_native_room_id = native_room_id
-        logger.info(
-            "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
-            room_label,
-            native_room_id,
-            doors_idx,
-            extra={"NoStream": not self._debug_logging_enabled},
-        )
+            self._last_sent_room_update_native_room_id = native_room_id
 
     async def _poll_room_sanity_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -902,11 +902,13 @@ async def test_poll_room_entry_logging_retries_after_bounce_send_failure(mock_bi
         mock_send.side_effect = [RuntimeError("socket down"), None]
 
         await client._poll_room_entry_logging(mock_bizhawk_context)
-        assert client._last_native_room_id is None
+        assert client._last_native_room_id == 0x0020
+        assert client._last_sent_room_update_native_room_id is None
 
         await client._poll_room_entry_logging(mock_bizhawk_context)
 
     assert client._last_native_room_id == 0x0020
+    assert client._last_sent_room_update_native_room_id == 0x0020
     assert mock_send.await_count == 2
     mock_logger.info.assert_called_once_with(
         "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -884,6 +884,40 @@ async def test_poll_room_entry_logging_re_emits_on_reconnect_state_reset(mock_bi
 
 
 @pytest.mark.asyncio
+async def test_poll_room_entry_logging_retries_after_bounce_send_failure(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {12: "REGION_SEND_RETRY_ROOM"}
+    client._room_region_key_by_doors_idx = {12: "ROOM_SANITY_5_10"}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send, \
+         patch('CommonClient.logger') as mock_logger:
+        mock_read.side_effect = [
+            [(0x0020).to_bytes(2, 'little')],
+            [(12).to_bytes(2, 'little')],
+            [(0x0020).to_bytes(2, 'little')],
+            [(12).to_bytes(2, 'little')],
+        ]
+        mock_send.side_effect = [RuntimeError("socket down"), None]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        assert client._last_native_room_id is None
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert client._last_native_room_id == 0x0020
+    assert mock_send.await_count == 2
+    mock_logger.info.assert_called_once_with(
+        "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
+        "REGION_SEND_RETRY_ROOM",
+        0x0020,
+        12,
+        extra={"NoStream": True},
+    )
+
+
+@pytest.mark.asyncio
 async def test_poll_room_entry_logging_nostream_gating_respects_debug_flag(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -14,6 +14,7 @@ from ..client import (
     _ROOM_PROPS_DOORS_IDX_OFFSET,
     _ROOM_PROPS_ROM_BASE,
     _ROOM_PROPS_STRIDE,
+    _ROOM_UPDATE_BOUNCE_TYPE,
 )
 from ..options import OneHitMode
 from ..rom import KirbyAmProcedurePatch
@@ -713,6 +714,7 @@ async def test_poll_room_entry_logging_logs_only_on_room_change(mock_bizhawk_con
     client = KirbyAmClient()
     client.initialize_client()
     client._room_label_by_doors_idx = {42: "REGION_TEST_ROOM"}
+    client._room_region_key_by_doors_idx = {42: "ROOM_SANITY_1_20"}
 
     with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch('CommonClient.logger') as mock_logger:
@@ -726,6 +728,17 @@ async def test_poll_room_entry_logging_logs_only_on_room_change(mock_bizhawk_con
         await client._poll_room_entry_logging(mock_bizhawk_context)
 
     assert mock_read.await_count == 3
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([{
+        "cmd": "Bounce",
+        "slots": [mock_bizhawk_context.slot],
+        "data": {
+            "type": _ROOM_UPDATE_BOUNCE_TYPE,
+            "nativeRoomId": 0x0010,
+            "doorsIdx": 42,
+            "roomRegionKey": "ROOM_SANITY_1_20",
+            "roomLabel": "REGION_TEST_ROOM",
+        },
+    }])
     mock_logger.info.assert_called_once_with(
         "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
         "REGION_TEST_ROOM",
@@ -741,6 +754,7 @@ async def test_poll_room_entry_logging_reads_doors_idx_from_rom_lookup(mock_bizh
     client.initialize_client()
     client._debug_logging_enabled = True
     client._room_label_by_doors_idx = {7: "REGION_LOOKUP_ROOM"}
+    client._room_region_key_by_doors_idx = {7: "ROOM_SANITY_2_01"}
 
     native_room_id = 0x0021
     expected_rom_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
@@ -758,6 +772,17 @@ async def test_poll_room_entry_logging_reads_doors_idx_from_rom_lookup(mock_bizh
         mock_bizhawk_context.bizhawk_ctx,
         [(expected_rom_addr, 2, "ROM")],
     )
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([{
+        "cmd": "Bounce",
+        "slots": [mock_bizhawk_context.slot],
+        "data": {
+            "type": _ROOM_UPDATE_BOUNCE_TYPE,
+            "nativeRoomId": native_room_id,
+            "doorsIdx": 7,
+            "roomRegionKey": "ROOM_SANITY_2_01",
+            "roomLabel": "REGION_LOOKUP_ROOM",
+        },
+    }])
     mock_logger.info.assert_called_once_with(
         "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
         "REGION_LOOKUP_ROOM",
@@ -793,6 +818,7 @@ async def test_poll_room_entry_logging_retries_after_short_rom_read(mock_bizhawk
     client = KirbyAmClient()
     client.initialize_client()
     client._room_label_by_doors_idx = {11: "REGION_RETRY_ROOM"}
+    client._room_region_key_by_doors_idx = {11: "ROOM_SANITY_3_02"}
 
     with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch('CommonClient.logger') as mock_logger:
@@ -807,6 +833,17 @@ async def test_poll_room_entry_logging_retries_after_short_rom_read(mock_bizhawk
         await client._poll_room_entry_logging(mock_bizhawk_context)
 
     assert client._last_native_room_id == 0x0008
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([{
+        "cmd": "Bounce",
+        "slots": [mock_bizhawk_context.slot],
+        "data": {
+            "type": _ROOM_UPDATE_BOUNCE_TYPE,
+            "nativeRoomId": 0x0008,
+            "doorsIdx": 11,
+            "roomRegionKey": "ROOM_SANITY_3_02",
+            "roomLabel": "REGION_RETRY_ROOM",
+        },
+    }])
     mock_logger.info.assert_called_once_with(
         "KirbyAM: entered room %s (native=0x%04x, doorsIdx=%d)",
         "REGION_RETRY_ROOM",
@@ -814,6 +851,36 @@ async def test_poll_room_entry_logging_retries_after_short_rom_read(mock_bizhawk
         11,
         extra={"NoStream": True},
     )
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_re_emits_on_reconnect_state_reset(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {9: "REGION_RECONNECT_ROOM"}
+    client._room_region_key_by_doors_idx = {9: "ROOM_SANITY_4_01"}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        mock_read.side_effect = [
+            [(0x0015).to_bytes(2, 'little')],
+            [(9).to_bytes(2, 'little')],
+            [(0x0015).to_bytes(2, 'little')],
+            [(9).to_bytes(2, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        client._reset_reconnect_transient_state()
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert mock_bizhawk_context.send_msgs.await_count == 2
+    first_payload = mock_bizhawk_context.send_msgs.await_args_list[0].args[0][0]
+    second_payload = mock_bizhawk_context.send_msgs.await_args_list[1].args[0][0]
+    assert first_payload["cmd"] == "Bounce"
+    assert second_payload["cmd"] == "Bounce"
+    assert first_payload["data"]["type"] == _ROOM_UPDATE_BOUNCE_TYPE
+    assert second_payload["data"]["type"] == _ROOM_UPDATE_BOUNCE_TYPE
+    assert first_payload["data"]["nativeRoomId"] == 0x0015
+    assert second_payload["data"]["nativeRoomId"] == 0x0015
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Implements issue #715 by emitting tracker-facing current-room updates from the KirbyAM BizHawk client.

## Changes
- Emit slot-targeted `Bounce` payload on room transitions from `worlds/kirbyam/client.py`.
- Added typed payload contract with `type: "RoomUpdate"` and room identity fields:
  - `nativeRoomId`
  - `doorsIdx`
  - `roomRegionKey`
  - `roomLabel`
- Keep de-dupe behavior for unchanged room values.
- Make reconnect/session-reset resilient by clearing the last-seen room in reconnect transient reset so the first post-reconnect tick re-emits the current room.
- Added/updated tests in `worlds/kirbyam/test/test_client.py` for:
  - change detection + dedupe
  - payload content + slot routing
  - reconnect reset re-emit behavior
- Updated protocol contract docs in `worlds/kirbyam/PROTOCOL.md`.

## Validation
- `python -m pytest worlds/kirbyam/test/test_client.py -k "room_entry_logging or reconnect_entry_resets_transient_state_once"`
  - 7 passed

Closes #715