### PR TITLE
Remove enable_debug_logging and keep diagnostics file-only

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -13,6 +13,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### New Features
 
+- Added trap item support: `Enable Traps` and `Trap Fill Percentage` options let players include trap items in the randomized item pool.
   - `Health Down Trap`: reduces Kirby's current HP by 2 (but won't kill).
   - `Life Down Trap`: removes one extra life (if any remain).
   - `Bomb Trap`: sets Kirby's current HP to 0.

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -9,8 +9,6 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ## Unreleased
 
-- Removed the `Enable Debug Logging` / `enable_debug_logging` world option and corresponding slot_data debug toggle. Client diagnostics that were previously controlled by that option are now file-only logs and are never emitted to the AP client stream.
-
 ### New Features
 
 - Added trap item support: `Enable Traps` and `Trap Fill Percentage` options let players include trap items in the randomized item pool.
@@ -19,6 +17,8 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
   - `Bomb Trap`: sets Kirby's current HP to 0.
   - `Battery Drain Trap`: empties the cell phone battery to 0.
   - Trap receive notifications are prefixed with "Received trap:" to distinguish them from regular items.
+- Added two new filler consumables with tiered healing: `Energy Drink` (HP +2) and `Hunk of Meat` (HP +3), alongside existing `Small Food` (HP +1).
+- Enabled the first concrete `MINOR_CHEST` AP checks (Rainbow Route 1-20, 1-22, 1-38).
 
 ### Improvements
 
@@ -30,7 +30,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### Internal Changes
 
-- None.
+- Removed the `Enable Debug Logging` / `enable_debug_logging` world option and corresponding slot_data debug toggle. Client diagnostics that were previously controlled by that option are now file-only logs and are never emitted to the AP client stream.
 
 ## v0.2.0
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -9,16 +9,15 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ## Unreleased
 
+- Removed the `Enable Debug Logging` / `enable_debug_logging` world option and corresponding slot_data debug toggle. Client diagnostics that were previously controlled by that option are now file-only logs and are never emitted to the AP client stream.
+
 ### New Features
 
-- Added trap item support: `Enable Traps` and `Trap Fill Percentage` options let players include trap items in the randomized item pool.
   - `Health Down Trap`: reduces Kirby's current HP by 2 (but won't kill).
   - `Life Down Trap`: removes one extra life (if any remain).
   - `Bomb Trap`: sets Kirby's current HP to 0.
   - `Battery Drain Trap`: empties the cell phone battery to 0.
   - Trap receive notifications are prefixed with "Received trap:" to distinguish them from regular items.
-- Added two new filler consumables with tiered healing: `Energy Drink` (HP +2) and `Hunk of Meat` (HP +3), alongside existing `Small Food` (HP +1).
-- Enabled the first concrete `MINOR_CHEST` AP checks (Rainbow Route 1-20, 1-22, 1-38).
 
 ### Improvements
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -191,14 +191,11 @@ Server → Client: ConnectionRefused | Connected
 - `ability_randomization_passive_enemies` (bool): when true, enemies that natively grant no ability participate in copy-ability randomization. Default: `true`.
 - `ability_randomization_no_ability_weight` (int): percentage chance from `0` to `100` that an included randomized enemy grant resolves to no ability instead of a copy ability. Default: `55`.
 - `room_sanity` (bool): enables/disables room-visit locations (`Room X-<room code>`, 263 checks).
-- `enable_debug_logging` (bool): enables/disables debug-level client diagnostics.
 - `enemy_copy_ability_whitelist` (list[str]): validated ability pool (must exclude `Wait`).
 - `enemy_copy_ability_policy` (dict): deterministic policy payload used by runtime hooks.
 - `locations` (dict): tracker-facing location metadata keyed by KirbyAM location key.
 - `rooms` (dict): tracker-facing room metadata keyed by room region key, exported regardless of `room_sanity` option.
 - `unique_items` (list[str]): tracker-facing list of KirbyAM unique item labels.
-- `debug` (dict): debug settings payload.
-    - `logging` (bool): when true, client emits diagnostics for gameplay-state/demo-flag transitions (including `hook_heartbeat`) and self-ItemSend fallback decisions.
 
 Compatibility note (Issue #398 option-key reorganization):
 - Legacy keys `enemy_copy_ability_randomization`, `randomize_boss_spawned_ability_grants`, and `randomize_miniboss_ability_grants` are intentionally not emitted in `slot_data` during the pre-public (`< v0.1.0`) phase.
@@ -216,7 +213,7 @@ DeathLink runtime behavior contract:
 `no_extra_lives` runtime behavior contract:
 - Generation removes `1 Up` from the active filler pool when the option is enabled.
 - During gameplay, the BizHawk client clamps `kirby_lives_native` to `0` so the player starts with zero extra lives and native/in-game life gains are overwritten.
-- Any `no_extra_lives` runtime diagnostics must remain gated behind `debug.logging`.
+- Any `no_extra_lives` runtime diagnostics are emitted as file-only logs (`NoStream=True`).
 
 `one_hit_mode` runtime behavior contract:
 - Generation removes all four Vitality Counter items from the non-filler item pool (replaced by filler) when `one_hit_mode == exclude_vitality_counters` (1). Vitality Chest locations are kept, but this mode does not guarantee location-specific filler placement on those chests.
@@ -224,7 +221,7 @@ DeathLink runtime behavior contract:
 - Generation leaves the item pool unchanged when `one_hit_mode == include_vitality_counters` (2).
 - During gameplay, when `one_hit_mode != off`, the BizHawk client reads `kirby_vitality_counter_native` (`u16`) and enforces `desired_max_hp = vitality_counter + 1` (capped to `0x7F`) onto `kirby_max_hp_native` and `kirby_hp_native` for player 0's struct. In `exclude_vitality_counters` mode it additionally scrubs `kirby_vitality_counter_native` back to `0` every gameplay tick so AP vitality grants cannot persist.
 - Dead/negative HP states (`current_hp <= 0`) are preserved; only alive Kirby's HP is clamped.
-- Any `one_hit_mode` runtime diagnostics must remain gated behind `debug.logging`.
+- Any `one_hit_mode` runtime diagnostics are emitted as file-only logs (`NoStream=True`).
 ```
 
 **Preconditions before gameplay watchers run:**

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -766,7 +766,6 @@ class KirbyAmWorld(World):
             "ability_randomization_passive_enemies",
             "ability_randomization_no_ability_weight",
             "room_sanity",
-            "enable_debug_logging",
             toggles_as_bools=True,
         )
         resolved_color_id, resolved_color_name = self._get_resolved_starting_kirby_color()
@@ -815,10 +814,6 @@ class KirbyAmWorld(World):
             }
         )
 
-        # Debug settings are grouped under one key to keep slot_data extensible.
-        slot_data["debug"] = {
-            "logging": bool(self.options.enable_debug_logging.value),
-        }
         return slot_data
 
     # Helper methods to create items and events

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -766,15 +766,14 @@ class KirbyAmClient(BizHawkClient):
         message = f"{prefix}{item_name} from {sender_name}"
 
 
-        if self._debug_logging_enabled:
-            self._log_verbose(
-                "info",
-                "KirbyAM: receive notification queued (index=%s, item=%s, sender=%s, lookup_slot=%s)",
-                delivered_index,
-                item_name,
-                sender_name,
-                lookup_slot,
-            )
+        self._log_verbose(
+            "info",
+            "KirbyAM: receive notification queued (index=%s, item=%s, sender=%s, lookup_slot=%s)",
+            delivered_index,
+            item_name,
+            sender_name,
+            lookup_slot,
+        )
         try:
             await bizhawk.display_message(ctx.bizhawk_ctx, message)
         except Exception:
@@ -852,15 +851,14 @@ class KirbyAmClient(BizHawkClient):
 
         self._send_notify_window_count += 1
 
-        if self._debug_logging_enabled:
-            self._log_verbose(
-                "info",
-                "KirbyAM: send notification queued (item=%s, sender=%s, receiver=%s, location=%s)",
-                item_name,
-                sender_name,
-                receiver_name,
-                location_name,
-            )
+        self._log_verbose(
+            "info",
+            "KirbyAM: send notification queued (item=%s, sender=%s, receiver=%s, location=%s)",
+            item_name,
+            sender_name,
+            receiver_name,
+            location_name,
+        )
         Utils.async_start(bizhawk.display_message(ctx.bizhawk_ctx, message))
 
     async def _display_client_message(self, ctx: "BizHawkClientContext", message: str) -> None:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -517,13 +517,21 @@ class KirbyAmClient(BizHawkClient):
 
         self._log_verbose(
             "info",
-            "KirbyAM debug: self ItemSend observed (item=%s, location=%s, player=%s, queue_len=%s, delivered_index=%s)" % (item_id, location_id, player_id, len(ctx.items_received), self._delivered_item_index)
+            "KirbyAM debug: self ItemSend observed (item=%s, location=%s, player=%s, queue_len=%s, delivered_index=%s)",
+            item_id,
+            location_id,
+            player_id,
+            len(ctx.items_received),
+            self._delivered_item_index,
         )
 
         if signature in self._self_send_fallback_keys:
             self._log_verbose(
                 "info",
-                "KirbyAM debug: self ItemSend fallback skipped (already queued signature item=%s location=%s player=%s)" % (item_id, location_id, player_id)
+                "KirbyAM debug: self ItemSend fallback skipped (already queued signature item=%s location=%s player=%s)",
+                item_id,
+                location_id,
+                player_id,
             )
             return
 
@@ -531,7 +539,10 @@ class KirbyAmClient(BizHawkClient):
             if self._item_signature(existing) == signature:
                 self._log_verbose(
                     "info",
-                    "KirbyAM debug: self ItemSend already present in items_received (item=%s, location=%s, player=%s)" % (item_id, location_id, player_id)
+                    "KirbyAM debug: self ItemSend already present in items_received (item=%s, location=%s, player=%s)",
+                    item_id,
+                    location_id,
+                    player_id,
                 )
                 return
 
@@ -542,7 +553,10 @@ class KirbyAmClient(BizHawkClient):
         ctx.watcher_event.set()
         self._log_verbose(
             "info",
-            "KirbyAM debug: queued self-send fallback item from ItemSend (item=%s, location=%s, player=%s)" % (item_id, location_id, player_id)
+            "KirbyAM debug: queued self-send fallback item from ItemSend (item=%s, location=%s, player=%s)",
+            item_id,
+            location_id,
+            player_id,
         )
 
     def _mark_bizhawk_watcher_transport_error(self, reason: str) -> bool:
@@ -1007,8 +1021,7 @@ class KirbyAmClient(BizHawkClient):
         await self._sync_challenge_runtime_config(ctx)
 
         if not self._watcher_server_ready:
-            if self._debug_logging_enabled:
-                self._log_verbose("info", "KirbyAM: AP session ready; reconnect-safe reconciliation active")
+            self._log_verbose("info", "KirbyAM: AP session ready; reconnect-safe reconciliation active")
             self._watcher_server_ready = True
             self._reset_reconnect_transient_state()
 
@@ -1035,13 +1048,12 @@ class KirbyAmClient(BizHawkClient):
             )
             if not gameplay_active:
                 if self._last_runtime_gate_reason != defer_reason:
-                    if self._debug_logging_enabled:
-                        self._log_verbose(
-                            "info",
-                            "KirbyAM: deferring location polling/new item writes (%s, ai_state=%s)",
-                            defer_reason,
-                            ai_state if ai_state is not None else "unavailable",
-                        )
+                    self._log_verbose(
+                        "info",
+                        "KirbyAM: deferring location polling/new item writes (%s, ai_state=%s)",
+                        defer_reason,
+                        ai_state if ai_state is not None else "unavailable",
+                    )
                     await self._display_client_message(ctx, "Item sending paused by game state")
                     self._last_runtime_gate_reason = defer_reason
 
@@ -1054,8 +1066,7 @@ class KirbyAmClient(BizHawkClient):
                 return
 
             if self._last_runtime_gate_reason is not None:
-                if self._debug_logging_enabled:
-                    self._log_verbose("info", "KirbyAM: gameplay-active state restored; resuming normal watcher flow")
+                self._log_verbose("info", "KirbyAM: gameplay-active state restored; resuming normal watcher flow")
                 await self._display_client_message(ctx, "Item sending resumed")
                 self._last_runtime_gate_reason = None
 
@@ -1284,12 +1295,11 @@ class KirbyAmClient(BizHawkClient):
 
         await bizhawk.write(ctx.bizhawk_ctx, [(lives_addr, (0).to_bytes(1, "little"), "System Bus")])
 
-        if self._debug_logging_enabled:
-            self._log_verbose(
-                "info",
-                "KirbyAM debug: no-extra-lives clamped native lives from %s to 0",
-                current_lives,
-            )
+        self._log_verbose(
+            "info",
+            "KirbyAM debug: no-extra-lives clamped native lives from %s to 0",
+            current_lives,
+        )
 
     async def _enforce_one_hit_mode(self, ctx: "BizHawkClientContext") -> None:
         """Clamp Kirby's max HP (and current HP) to vitality_counter + 1 while one-hit mode is active.
@@ -1354,11 +1364,12 @@ class KirbyAmClient(BizHawkClient):
                 parts.append(f"max_hp {current_max_hp}->{desired_max_hp}")
             if clamped_hp:
                 parts.append(f"hp {current_hp}->{desired_max_hp}")
-            if self._debug_logging_enabled and parts:
+            if parts:
                 self._log_verbose(
                     "info",
-                    "KirbyAM debug: one-hit mode clamped %s (desired_vitality_count=%s)"
-                    % (", ".join(parts), desired_vitality_count)
+                    "KirbyAM debug: one-hit mode clamped %s (desired_vitality_count=%s)",
+                    ", ".join(parts),
+                    desired_vitality_count,
                 )
 
     @staticmethod

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -234,7 +234,7 @@ class KirbyAmClient(BizHawkClient):
         self._hub_switch_stream_marker: object = None
         self._last_room_sanity_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
-        # Room entry logging (always to file; client display gated by debug flag)
+        # Room entry logging (always file-only via NoStream=True).
         self._last_native_room_id: int | None = None
         self._last_sent_room_update_native_room_id: int | None = None
         room_label_lookup, room_region_key_lookup = self._build_room_lookup_maps()
@@ -475,7 +475,11 @@ class KirbyAmClient(BizHawkClient):
 
         self._log_verbose(
             "info",
-            "KirbyAM: reconciled native map ownership (current=0x%08X, desired=0x%08X, start_with_all_maps=%s, delivered_item_index=%s)" % (current_bits, desired_bits, self._start_with_all_maps_enabled(ctx), self._delivered_item_index)
+            "KirbyAM: reconciled native map ownership (current=0x%08X, desired=0x%08X, start_with_all_maps=%s, delivered_item_index=%s)",
+            current_bits,
+            desired_bits,
+            self._start_with_all_maps_enabled(ctx),
+            self._delivered_item_index,
         )
 
     @staticmethod
@@ -613,14 +617,24 @@ class KirbyAmClient(BizHawkClient):
         self._notification_settings_loaded = True
 
     def _load_debug_settings(self, ctx: "BizHawkClientContext") -> None:
-        slot_data = getattr(ctx, "slot_data", None)
-        if isinstance(slot_data, dict):
-            debug_config = slot_data.get("debug", {})
-            if isinstance(debug_config, dict):
-                self._debug_logging_enabled = self._coerce_bool(
-                    debug_config.get("logging", False),
-                    False,
-                )
+        # Debug diagnostics are no longer configured via slot_data.
+        # Keep this hook so existing call sites remain stable while relying on
+        # standard logger configuration for verbose diagnostic gating.
+        _ = ctx
+        logger_obj = self._get_logger()
+        logger_level = getattr(logger_obj, "level", logging.NOTSET)
+        if isinstance(logger_level, int):
+            self._debug_logging_enabled = (
+                logger_level != logging.NOTSET
+                and logger_level <= logging.DEBUG
+            )
+            return
+
+        try:
+            enabled = logger_obj.isEnabledFor(logging.DEBUG)
+            self._debug_logging_enabled = enabled if isinstance(enabled, bool) else False
+        except Exception:
+            self._debug_logging_enabled = False
 
     def _get_starting_kirby_color_config(self, ctx: "BizHawkClientContext") -> tuple[int, str] | None:
         slot_data = getattr(ctx, "slot_data", None)
@@ -779,7 +793,8 @@ class KirbyAmClient(BizHawkClient):
         except Exception:
             self._log_client(
                 "warning",
-                "KirbyAM: failed to emit receive notification (index=%s)" % (delivered_index,)
+                "KirbyAM: failed to emit receive notification (index=%s)",
+                delivered_index,
             )
 
     def _maybe_emit_send_notification(self, ctx: "BizHawkClientContext", args: dict) -> None:
@@ -920,7 +935,10 @@ class KirbyAmClient(BizHawkClient):
             ):
                 self._log_verbose(
                     "info",
-                    "KirbyAM: ROM validation failed (title=%r, game_code=%r, maker=%r)" % (rom_title, game_code, maker_code,)
+                    "KirbyAM: ROM validation failed (title=%r, game_code=%r, maker=%r)",
+                    rom_title,
+                    game_code,
+                    maker_code,
                 )
                 return await _fail(
                     "header_mismatch",
@@ -1095,7 +1113,7 @@ class KirbyAmClient(BizHawkClient):
             # Room-sanity location polling via native gVisitedDoors bit 15.
             await self._poll_room_sanity_locations(ctx)
 
-            # Room entry logging (always to file; client display gated by debug flag).
+            # Room entry logging (always file-only via NoStream=True).
             await self._poll_room_entry_logging(ctx)
 
             # Candidate discovery for non-shard boss defeat signals.
@@ -1463,7 +1481,8 @@ class KirbyAmClient(BizHawkClient):
         if skipped_without_placeholder:
             self._log_client(
                 "warning",
-                "KirbyAM: skipped %d DeathLink flavor text template(s) without '{player}' placeholder" % (skipped_without_placeholder,)
+                "KirbyAM: skipped %d DeathLink flavor text template(s) without '{player}' placeholder",
+                skipped_without_placeholder,
             )
 
         if not valid_templates:
@@ -2159,9 +2178,9 @@ class KirbyAmClient(BizHawkClient):
         value changes, resolves the native room ID to a doorsIdx via gRoomProps[] in
         ROM, then maps doorsIdx to room metadata from rooms.json.
 
-        Room changes are written to the log file (shown in the client only when
-        debug logging is enabled). On room change, emits a typed Bounce payload to
-        this slot for tracker consumers.
+        Room changes are written as file-only diagnostics (never shown in the
+        AP client stream). On room change, emits a typed Bounce payload to this
+        slot for tracker consumers.
         """
         from CommonClient import logger
 
@@ -2265,7 +2284,9 @@ class KirbyAmClient(BizHawkClient):
         if len(raw) != read_width:
             self._log_client(
                 "warning",
-                "KirbyAM: room-sanity poll expected %s bytes from gVisitedDoors, got %s; skipping tick" % (read_width, len(raw))
+                "KirbyAM: room-sanity poll expected %s bytes from gVisitedDoors, got %s; skipping tick",
+                read_width,
+                len(raw),
             )
             return
 
@@ -2610,7 +2631,9 @@ class KirbyAmClient(BizHawkClient):
                 self._delivery_timeout_streak += 1
                 self._log_client(
                     "warning",
-                    "KirbyAM: Mailbox ACK timeout at item index %s; clearing flag and retrying (%s)" % (self._delivered_item_index, timeout_reason)
+                    "KirbyAM: Mailbox ACK timeout at item index %s; clearing flag and retrying (%s)",
+                    self._delivered_item_index,
+                    timeout_reason,
                 )
                 if (
                     not self._delivery_payload_stall_warned
@@ -2621,12 +2644,14 @@ class KirbyAmClient(BizHawkClient):
                     if hook_heartbeat is not None and self._hook_heartbeat_stale_ticks >= 3:
                         self._log_client(
                             "warning",
-                            "KirbyAM: Repeated mailbox ACK timeouts with frame_counter stuck at 0 and hook_heartbeat not advancing (value=%s); payload hook appears inactive" % (hook_heartbeat,)
+                            "KirbyAM: Repeated mailbox ACK timeouts with frame_counter stuck at 0 and hook_heartbeat not advancing (value=%s); payload hook appears inactive",
+                            hook_heartbeat,
                         )
                     elif hook_heartbeat is not None:
                         self._log_client(
                             "warning",
-                            "KirbyAM: Repeated mailbox ACK timeouts with frame_counter stuck at 0 while hook_heartbeat advances (value=%s); frame_counter slot may be unstable" % (hook_heartbeat,)
+                            "KirbyAM: Repeated mailbox ACK timeouts with frame_counter stuck at 0 while hook_heartbeat advances (value=%s); frame_counter slot may be unstable",
+                            hook_heartbeat,
                         )
                     else:
                         self._log_client(
@@ -2665,7 +2690,9 @@ class KirbyAmClient(BizHawkClient):
             if item_fields is None:
                 self._log_client(
                     "warning",
-                    "KirbyAM: Skipping malformed ReceivedItems entry at index %s: %r" % (self._delivered_item_index, itm)
+                    "KirbyAM: Skipping malformed ReceivedItems entry at index %s: %r",
+                    self._delivered_item_index,
+                    itm,
                 )
                 self._delivered_item_index += 1
                 self._delivery_pending = False

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -315,13 +315,13 @@ class KirbyAmClient(BizHawkClient):
 
     def _log_verbose(self, level: str, msg: str, *args: object, **kwargs: object) -> None:
         """
-        Level 3 (Verbose): Log file only (hidden from client output unless debug mode is on).
+        Level 3 (Verbose): Log file only (never emitted to AP client output).
         Use for detailed traces, per-tick updates, and debug info.
         """
         logger_obj = self._get_logger()
         logger_func = getattr(logger_obj, level, logger_obj.info)
         extra = dict(kwargs.pop("extra", {}))
-        extra["NoStream"] = not getattr(self, "_debug_logging_enabled", False)
+        extra["NoStream"] = True
         kwargs["extra"] = extra
         logger_func(msg, *args, **kwargs)
 
@@ -515,27 +515,24 @@ class KirbyAmClient(BizHawkClient):
             return
 
 
-        if self._debug_logging_enabled:
-            self._log_verbose(
-                "info",
-                "KirbyAM debug: self ItemSend observed (item=%s, location=%s, player=%s, queue_len=%s, delivered_index=%s)" % (item_id, location_id, player_id, len(ctx.items_received), self._delivered_item_index)
-            )
+        self._log_verbose(
+            "info",
+            "KirbyAM debug: self ItemSend observed (item=%s, location=%s, player=%s, queue_len=%s, delivered_index=%s)" % (item_id, location_id, player_id, len(ctx.items_received), self._delivered_item_index)
+        )
 
         if signature in self._self_send_fallback_keys:
-            if self._debug_logging_enabled:
-                self._log_verbose(
-                    "info",
-                    "KirbyAM debug: self ItemSend fallback skipped (already queued signature item=%s location=%s player=%s)" % (item_id, location_id, player_id)
-                )
+            self._log_verbose(
+                "info",
+                "KirbyAM debug: self ItemSend fallback skipped (already queued signature item=%s location=%s player=%s)" % (item_id, location_id, player_id)
+            )
             return
 
         for existing in ctx.items_received:
             if self._item_signature(existing) == signature:
-                if self._debug_logging_enabled:
-                    self._log_verbose(
-                        "info",
-                        "KirbyAM debug: self ItemSend already present in items_received (item=%s, location=%s, player=%s)" % (item_id, location_id, player_id)
-                    )
+                self._log_verbose(
+                    "info",
+                    "KirbyAM debug: self ItemSend already present in items_received (item=%s, location=%s, player=%s)" % (item_id, location_id, player_id)
+                )
                 return
 
         from NetUtils import NetworkItem
@@ -543,11 +540,10 @@ class KirbyAmClient(BizHawkClient):
         ctx.items_received.append(NetworkItem(item_id, location_id, player_id, flags))
         self._self_send_fallback_keys.add(signature)
         ctx.watcher_event.set()
-        if self._debug_logging_enabled:
-            self._log_verbose(
-                "info",
-                "KirbyAM debug: queued self-send fallback item from ItemSend (item=%s, location=%s, player=%s)" % (item_id, location_id, player_id)
-            )
+        self._log_verbose(
+            "info",
+            "KirbyAM debug: queued self-send fallback item from ItemSend (item=%s, location=%s, player=%s)" % (item_id, location_id, player_id)
+        )
 
     def _mark_bizhawk_watcher_transport_error(self, reason: str) -> bool:
         """Prepare handler state for a clean BizHawk-side recovery on the next successful tick."""
@@ -757,7 +753,7 @@ class KirbyAmClient(BizHawkClient):
 
 
         if self._debug_logging_enabled:
-            self._log_client(
+            self._log_verbose(
                 "info",
                 "KirbyAM: receive notification queued (index=%s, item=%s, sender=%s, lookup_slot=%s)",
                 delivered_index,
@@ -843,7 +839,7 @@ class KirbyAmClient(BizHawkClient):
         self._send_notify_window_count += 1
 
         if self._debug_logging_enabled:
-            self._log_client(
+            self._log_verbose(
                 "info",
                 "KirbyAM: send notification queued (item=%s, sender=%s, receiver=%s, location=%s)",
                 item_name,
@@ -1012,7 +1008,7 @@ class KirbyAmClient(BizHawkClient):
 
         if not self._watcher_server_ready:
             if self._debug_logging_enabled:
-                self._log_client("info", "KirbyAM: AP session ready; reconnect-safe reconciliation active")
+                self._log_verbose("info", "KirbyAM: AP session ready; reconnect-safe reconciliation active")
             self._watcher_server_ready = True
             self._reset_reconnect_transient_state()
 
@@ -1040,7 +1036,7 @@ class KirbyAmClient(BizHawkClient):
             if not gameplay_active:
                 if self._last_runtime_gate_reason != defer_reason:
                     if self._debug_logging_enabled:
-                        self._log_client(
+                        self._log_verbose(
                             "info",
                             "KirbyAM: deferring location polling/new item writes (%s, ai_state=%s)",
                             defer_reason,
@@ -1059,7 +1055,7 @@ class KirbyAmClient(BizHawkClient):
 
             if self._last_runtime_gate_reason is not None:
                 if self._debug_logging_enabled:
-                    self._log_client("info", "KirbyAM: gameplay-active state restored; resuming normal watcher flow")
+                    self._log_verbose("info", "KirbyAM: gameplay-active state restored; resuming normal watcher flow")
                 await self._display_client_message(ctx, "Item sending resumed")
                 self._last_runtime_gate_reason = None
 
@@ -1289,7 +1285,7 @@ class KirbyAmClient(BizHawkClient):
         await bizhawk.write(ctx.bizhawk_ctx, [(lives_addr, (0).to_bytes(1, "little"), "System Bus")])
 
         if self._debug_logging_enabled:
-            self._log_client(
+            self._log_verbose(
                 "info",
                 "KirbyAM debug: no-extra-lives clamped native lives from %s to 0",
                 current_lives,
@@ -1349,22 +1345,21 @@ class KirbyAmClient(BizHawkClient):
         if writes:
             await bizhawk.write(ctx.bizhawk_ctx, writes)
 
-            if self._debug_logging_enabled:
-                clamped_max_hp = current_max_hp > desired_max_hp
-                clamped_hp = current_hp > 0 and current_hp > desired_max_hp
-                parts = []
-                if vitality_count != desired_vitality_count:
-                    parts.append(f"vitality_count {vitality_count}->{desired_vitality_count}")
-                if clamped_max_hp:
-                    parts.append(f"max_hp {current_max_hp}->{desired_max_hp}")
-                if clamped_hp:
-                    parts.append(f"hp {current_hp}->{desired_max_hp}")
-                if parts:
-                    self._log_verbose(
-                        "info",
-                        "KirbyAM debug: one-hit mode clamped %s (desired_vitality_count=%s)"
-                        % (", ".join(parts), desired_vitality_count)
-                    )
+            clamped_max_hp = current_max_hp > desired_max_hp
+            clamped_hp = current_hp > 0 and current_hp > desired_max_hp
+            parts = []
+            if vitality_count != desired_vitality_count:
+                parts.append(f"vitality_count {vitality_count}->{desired_vitality_count}")
+            if clamped_max_hp:
+                parts.append(f"max_hp {current_max_hp}->{desired_max_hp}")
+            if clamped_hp:
+                parts.append(f"hp {current_hp}->{desired_max_hp}")
+            if self._debug_logging_enabled and parts:
+                self._log_verbose(
+                    "info",
+                    "KirbyAM debug: one-hit mode clamped %s (desired_vitality_count=%s)"
+                    % (", ".join(parts), desired_vitality_count)
+                )
 
     @staticmethod
     def _s8(value: bytes) -> int:
@@ -2188,7 +2183,7 @@ class KirbyAmClient(BizHawkClient):
             logger.info(
                 "KirbyAM: room entry — native=0x%04x (doorsIdx lookup failed)",
                 native_room_id,
-                extra={"NoStream": not self._debug_logging_enabled},
+                extra={"NoStream": True},
             )
             return
 
@@ -2206,7 +2201,7 @@ class KirbyAmClient(BizHawkClient):
                 room_label,
                 native_room_id,
                 doors_idx,
-                extra={"NoStream": not self._debug_logging_enabled},
+                extra={"NoStream": True},
             )
 
         if ctx.slot is not None and send_pending:
@@ -2285,7 +2280,7 @@ class KirbyAmClient(BizHawkClient):
                     "KirbyAM: resending room-sanity LocationChecks missing on server (missing=%s, acked=%s)",
                     missing_on_server,
                     already_acknowledged,
-                    extra={"NoStream": not self._debug_logging_enabled},
+                    extra={"NoStream": True},
                 )
                 self._last_room_sanity_poll_log = room_log_state
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -622,15 +622,12 @@ class KirbyAmClient(BizHawkClient):
         # standard logger configuration for verbose diagnostic gating.
         _ = ctx
         logger_obj = self._get_logger()
-        logger_level = getattr(logger_obj, "level", logging.NOTSET)
-        if isinstance(logger_level, int):
-            self._debug_logging_enabled = (
-                logger_level != logging.NOTSET
-                and logger_level <= logging.DEBUG
-            )
-            return
-
         try:
+            effective_level = logger_obj.getEffectiveLevel()
+            if isinstance(effective_level, int):
+                self._debug_logging_enabled = effective_level <= logging.DEBUG
+                return
+
             enabled = logger_obj.isEnabledFor(logging.DEBUG)
             self._debug_logging_enabled = enabled if isinstance(enabled, bool) else False
         except Exception:

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -136,15 +136,6 @@ class AbilityRandomizationNoAbilityWeight(Range):
     default = 55
 
 
-class EnableDebugLogging(Toggle):
-    """
-    Enable extra BizHawk client diagnostics for gameplay-state and mailbox delivery troubleshooting.
-      Useful if you want to report a bug to the world developers. Off by default.
-    """
-    display_name = "Enable Debug Logging"
-    default = 0
-
-
 class NoExtraLives(Toggle):
     """
     Start with zero lives and clamp all extra-life gains to zero during gameplay.
@@ -284,8 +275,6 @@ class KirbyAmOptions(PerGameCommonOptions):
     ability_randomization_no_ability_weight: AbilityRandomizationNoAbilityWeight
 
     room_sanity: RoomSanity
-
-    enable_debug_logging: EnableDebugLogging
 
     death_link: KirbyAmDeathLink
 

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -6,9 +6,6 @@
   "ability_randomization_no_ability_weight": 55,
   "ability_randomization_passive_enemies": false,
   "death_link": true,
-  "debug": {
-    "logging": true
-  },
   "enable_traps": false,
   "enemy_copy_ability_policy": {
     "ability_randomization_boss_spawns": true,

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2435,7 +2435,7 @@ def test_load_debug_settings_defaults_to_disabled(mock_bizhawk_context):
     client.initialize_client()
 
     with patch('CommonClient.logger') as mock_logger:
-        mock_logger.level = logging.NOTSET
+        mock_logger.getEffectiveLevel.return_value = logging.INFO
         client._load_debug_settings(mock_bizhawk_context)
 
     assert client._debug_logging_enabled is False
@@ -2446,21 +2446,28 @@ def test_load_debug_settings_honors_logger_debug_level(mock_bizhawk_context):
     client.initialize_client()
 
     with patch('CommonClient.logger') as mock_logger:
-        mock_logger.level = logging.DEBUG
+        mock_logger.getEffectiveLevel.return_value = logging.DEBUG
         client._load_debug_settings(mock_bizhawk_context)
 
     assert client._debug_logging_enabled is True
 
 
-def test_load_debug_settings_ignores_inherited_root_level(mock_bizhawk_context):
+def test_load_debug_settings_honors_inherited_root_debug_level(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
+    inherited_logger = logging.getLogger("worlds.kirbyam.test.inherited_debug")
+    inherited_logger.setLevel(logging.NOTSET)
 
-    with patch('CommonClient.logger') as mock_logger:
-        mock_logger.level = logging.NOTSET
-        client._load_debug_settings(mock_bizhawk_context)
+    root_logger = logging.getLogger()
+    original_root_level = root_logger.level
+    try:
+        root_logger.setLevel(logging.DEBUG)
+        with patch.object(client, '_get_logger', return_value=inherited_logger):
+            client._load_debug_settings(mock_bizhawk_context)
+    finally:
+        root_logger.setLevel(original_root_level)
 
-    assert client._debug_logging_enabled is False
+    assert client._debug_logging_enabled is True
 
 
 def test_no_extra_lives_enabled_defaults_to_false(mock_bizhawk_context):
@@ -2932,6 +2939,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
     with patch.object(client, '_reset_reconnect_transient_state') as mock_reset, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
          patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock) as mock_reconcile_maps, \
+            patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock) as mock_apply_death_link, \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock) as mock_send_death_link, \
@@ -3308,6 +3316,7 @@ async def test_game_watcher_defers_polling_and_new_writes_when_non_gameplay(mock
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock) as mock_load, \
+            patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_poll_locations', new_callable=AsyncMock) as mock_poll_locations, \
          patch.object(client, '_poll_boss_defeat_locations', new_callable=AsyncMock) as mock_poll_boss, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe, \
@@ -3337,6 +3346,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
@@ -3440,6 +3450,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
             patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \
@@ -3469,6 +3480,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
             patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
             patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -752,7 +752,6 @@ async def test_poll_room_entry_logging_logs_only_on_room_change(mock_bizhawk_con
 async def test_poll_room_entry_logging_reads_doors_idx_from_rom_lookup(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
-    client._debug_logging_enabled = True
     client._room_label_by_doors_idx = {7: "REGION_LOOKUP_ROOM"}
     client._room_region_key_by_doors_idx = {7: "ROOM_SANITY_2_01"}
 
@@ -920,7 +919,7 @@ async def test_poll_room_entry_logging_retries_after_bounce_send_failure(mock_bi
 
 
 @pytest.mark.asyncio
-async def test_poll_room_entry_logging_nostream_gating_respects_debug_flag(mock_bizhawk_context):
+async def test_poll_room_entry_logging_is_always_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
     client._room_label_by_doors_idx = {9: "REGION_NOSTREAM_ROOM"}
@@ -929,20 +928,6 @@ async def test_poll_room_entry_logging_nostream_gating_respects_debug_flag(mock_
          patch('CommonClient.logger') as mock_logger:
         mock_read.side_effect = [
             [(0x0012).to_bytes(2, 'little')],
-            [(9).to_bytes(2, 'little')],
-        ]
-        await client._poll_room_entry_logging(mock_bizhawk_context)
-
-    mock_logger.info.assert_called_once()
-    assert mock_logger.info.call_args.kwargs.get("extra", {}).get("NoStream") is True
-
-    client._last_native_room_id = None
-    client._debug_logging_enabled = True
-
-    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch('CommonClient.logger') as mock_logger:
-        mock_read.side_effect = [
-            [(0x0013).to_bytes(2, 'little')],
             [(9).to_bytes(2, 'little')],
         ]
         await client._poll_room_entry_logging(mock_bizhawk_context)
@@ -1443,7 +1428,7 @@ async def test_deliver_items_fast_forward_on_pending_ack(mock_bizhawk_context):
 
 
 @pytest.mark.asyncio
-async def test_deliver_items_fast_forward_log_gated_by_debug(mock_bizhawk_context):
+async def test_deliver_items_fast_forward_log_is_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
     client._delivered_item_index = 0
@@ -1473,24 +1458,6 @@ async def test_deliver_items_fast_forward_log_gated_by_debug(mock_bizhawk_contex
     ]
     assert matching_disabled
     assert all(call.kwargs.get("extra", {}).get("NoStream") is True for call in matching_disabled)
-
-    client = KirbyAmClient()
-    client.initialize_client()
-    client._debug_logging_enabled = True
-    client._delivered_item_index = 0
-    client._delivery_pending = True
-    client._delivery_pending_item_index = 0
-
-    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock), \
-         patch('CommonClient.logger') as mock_logger:
-        mock_read.return_value = [
-            (0).to_bytes(4, 'little'),
-            (2).to_bytes(4, 'little'),
-        ]
-
-        await client._deliver_items(mock_bizhawk_context)
-
     mock_logger.info.assert_any_call(
         "KirbyAM: ROM delivery counter moved forward from %s to %s on pending ACK; fast-forwarding client delivery cursor",
         0,
@@ -1500,7 +1467,7 @@ async def test_deliver_items_fast_forward_log_gated_by_debug(mock_bizhawk_contex
 
 
 @pytest.mark.asyncio
-async def test_deliver_items_mailbox_write_log_gated_by_debug(mock_bizhawk_context):
+async def test_deliver_items_mailbox_write_log_is_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -1526,25 +1493,6 @@ async def test_deliver_items_mailbox_write_log_gated_by_debug(mock_bizhawk_conte
     ]
     assert matching_disabled
     assert all(call.kwargs.get("extra", {}).get("NoStream") is True for call in matching_disabled)
-
-    client = KirbyAmClient()
-    client.initialize_client()
-    client._debug_logging_enabled = True
-    mock_bizhawk_context.items_received = [
-        Mock(item=3860001, player=1),
-    ]
-
-    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock), \
-         patch('CommonClient.logger') as mock_logger:
-        mock_read.return_value = [
-            (0).to_bytes(4, 'little'),
-            (0).to_bytes(4, 'little'),
-            (1234).to_bytes(4, 'little'),
-        ]
-
-        await client._deliver_items(mock_bizhawk_context)
-
     mock_logger.info.assert_any_call(
         "KirbyAM: Delivering mailbox item index %s (%s from %s)",
         0,
@@ -2328,7 +2276,7 @@ def test_send_notification_queue_log_emitted_file_only(mock_bizhawk_context):
 
 
 @pytest.mark.asyncio
-async def test_room_sanity_resend_log_gated_by_debug(mock_bizhawk_context):
+async def test_room_sanity_resend_log_is_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
     mock_bizhawk_context.slot_data["room_sanity"] = True
@@ -2354,30 +2302,6 @@ async def test_room_sanity_resend_log_gated_by_debug(mock_bizhawk_context):
     ]
     assert matching_disabled
     assert all(call.kwargs.get("extra", {}).get("NoStream") is True for call in matching_disabled)
-
-    client = KirbyAmClient()
-    client.initialize_client()
-    client._debug_logging_enabled = True
-    mock_bizhawk_context.slot_data["room_sanity"] = True
-    client._room_sanity_location_ids_by_bit = {0: [3961000]}
-    client._room_sanity_bits_sorted = [0]
-    mock_bizhawk_context.checked_locations = set()
-
-    with patch.dict(data.native_ram_addresses, {"room_visit_flags_native": 0x02028CA0}, clear=False), \
-         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock), \
-         patch('CommonClient.logger') as mock_logger:
-        mock_read.return_value = [bytes(raw)]
-
-        await client._poll_room_sanity_locations(mock_bizhawk_context)
-
-    matching_enabled = [
-        call
-        for call in mock_logger.info.call_args_list
-        if call.args and isinstance(call.args[0], str) and "resending room-sanity LocationChecks missing on server" in call.args[0]
-    ]
-    assert matching_enabled
-    assert all(call.kwargs.get("extra", {}).get("NoStream") is True for call in matching_enabled)
 
 
 @pytest.mark.asyncio
@@ -2510,27 +2434,31 @@ def test_load_debug_settings_defaults_to_disabled(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
 
-    client._load_debug_settings(mock_bizhawk_context)
+    with patch('CommonClient.logger') as mock_logger:
+        mock_logger.level = logging.NOTSET
+        client._load_debug_settings(mock_bizhawk_context)
 
     assert client._debug_logging_enabled is False
 
 
-def test_load_debug_settings_honors_slot_data_toggle_true(mock_bizhawk_context):
+def test_load_debug_settings_honors_logger_debug_level(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
-    mock_bizhawk_context.slot_data["debug"] = {"logging": True}
 
-    client._load_debug_settings(mock_bizhawk_context)
+    with patch('CommonClient.logger') as mock_logger:
+        mock_logger.level = logging.DEBUG
+        client._load_debug_settings(mock_bizhawk_context)
 
     assert client._debug_logging_enabled is True
 
 
-def test_load_debug_settings_ignores_removed_gameplay_state_key(mock_bizhawk_context):
+def test_load_debug_settings_ignores_inherited_root_level(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
-    mock_bizhawk_context.slot_data["debug"] = {"gameplay_state_logging": True}
 
-    client._load_debug_settings(mock_bizhawk_context)
+    with patch('CommonClient.logger') as mock_logger:
+        mock_logger.level = logging.NOTSET
+        client._load_debug_settings(mock_bizhawk_context)
 
     assert client._debug_logging_enabled is False
 
@@ -2586,10 +2514,9 @@ async def test_enforce_no_extra_lives_skips_write_when_already_zero(mock_bizhawk
 
 
 @pytest.mark.asyncio
-async def test_enforce_no_extra_lives_logs_only_when_debug_enabled(mock_bizhawk_context):
+async def test_enforce_no_extra_lives_log_is_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
-    client._debug_logging_enabled = True
     mock_bizhawk_context.slot_data["no_extra_lives"] = True
 
     with patch.dict(data.native_ram_addresses, {"kirby_lives_native": 0x02020FE2}, clear=False), \
@@ -2736,8 +2663,7 @@ async def test_enforce_one_hit_mode_skips_writes_when_already_within_cap(mock_bi
 async def test_runtime_gameplay_state_logs_ai_and_demo_changes_with_heartbeat(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
-    mock_bizhawk_context.slot_data["debug"] = {"logging": True}
-    client._load_debug_settings(mock_bizhawk_context)
+    client._debug_logging_enabled = True
 
     with patch.dict(
         data.native_ram_addresses,
@@ -3118,7 +3044,6 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
     """First watcher tick after AP session readiness should reset transient reconnect state and log once."""
     client = KirbyAmClient()
     client.initialize_client()
-    mock_bizhawk_context.slot_data["debug"] = {"logging": True}
 
     client._last_runtime_gate_reason = "non_gameplay_cutscene"
     client._last_shard_poll_log = ("resend", (1,), ())
@@ -3463,10 +3388,9 @@ async def test_game_watcher_emits_file_only_runtime_gate_logs(mock_bizhawk_conte
 
 
 @pytest.mark.asyncio
-async def test_game_watcher_emits_runtime_gate_logs_when_debug_enabled(mock_bizhawk_context):
+async def test_game_watcher_emits_runtime_gate_logs_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
-    mock_bizhawk_context.slot_data["debug"] = {"logging": True}
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -788,7 +788,7 @@ async def test_poll_room_entry_logging_reads_doors_idx_from_rom_lookup(mock_bizh
         "REGION_LOOKUP_ROOM",
         native_room_id,
         7,
-        extra={"NoStream": False},
+        extra={"NoStream": True},
     )
 
 
@@ -948,7 +948,7 @@ async def test_poll_room_entry_logging_nostream_gating_respects_debug_flag(mock_
         await client._poll_room_entry_logging(mock_bizhawk_context)
 
     mock_logger.info.assert_called_once()
-    assert mock_logger.info.call_args.kwargs.get("extra", {}).get("NoStream") is False
+    assert mock_logger.info.call_args.kwargs.get("extra", {}).get("NoStream") is True
 
 
 def test_major_chest_data_sanity():
@@ -1495,7 +1495,7 @@ async def test_deliver_items_fast_forward_log_gated_by_debug(mock_bizhawk_contex
         "KirbyAM: ROM delivery counter moved forward from %s to %s on pending ACK; fast-forwarding client delivery cursor",
         0,
         2,
-        extra={"NoStream": False},
+        extra={"NoStream": True},
     )
 
 
@@ -1550,7 +1550,7 @@ async def test_deliver_items_mailbox_write_log_gated_by_debug(mock_bizhawk_conte
         0,
         "1 Up",
         "Player 1",
-        extra={"NoStream": False},
+        extra={"NoStream": True},
     )
 
 
@@ -2016,6 +2016,7 @@ async def test_receive_notification_queue_log_gated_by_debug(mock_bizhawk_contex
         "Mirror Shard",
         "PlayerTwo",
         1,
+        extra={"NoStream": True},
     )
 
 
@@ -2350,6 +2351,7 @@ def test_send_notification_queue_log_gated_by_debug(mock_bizhawk_context):
         "Player 1",
         "PlayerTwo",
         "Location 123",
+        extra={"NoStream": True},
     )
 
 
@@ -2403,7 +2405,7 @@ async def test_room_sanity_resend_log_gated_by_debug(mock_bizhawk_context):
         if call.args and isinstance(call.args[0], str) and "resending room-sanity LocationChecks missing on server" in call.args[0]
     ]
     assert matching_enabled
-    assert all(call.kwargs.get("extra", {}).get("NoStream") is False for call in matching_enabled)
+    assert all(call.kwargs.get("extra", {}).get("NoStream") is True for call in matching_enabled)
 
 
 @pytest.mark.asyncio
@@ -2630,6 +2632,7 @@ async def test_enforce_no_extra_lives_logs_only_when_debug_enabled(mock_bizhawk_
     mock_logger.info.assert_any_call(
         "KirbyAM debug: no-extra-lives clamped native lives from %s to 0",
         1,
+        extra={"NoStream": True},
     )
 
 
@@ -3196,7 +3199,10 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         assert client._boss_probe_stream_marker is None
         assert client._unsafe_delivery_probe_stream_marker is None
         assert client._last_unsafe_delivery_counter_values == {}
-        mock_logger.info.assert_any_call("KirbyAM: AP session ready; reconnect-safe reconciliation active")
+        mock_logger.info.assert_any_call(
+            "KirbyAM: AP session ready; reconnect-safe reconciliation active",
+            extra={"NoStream": True},
+        )
         mock_load.assert_awaited_once()
         mock_reconcile_maps.assert_awaited()
         mock_poll_locations.assert_not_awaited()
@@ -3521,9 +3527,11 @@ async def test_game_watcher_emits_runtime_gate_logs_when_debug_enabled(mock_bizh
         "KirbyAM: deferring location polling/new item writes (%s, ai_state=%s)",
         "non_gameplay_tutorial_or_menu",
         0,
+        extra={"NoStream": True},
     )
     mock_logger.info.assert_any_call(
-        "KirbyAM: gameplay-active state restored; resuming normal watcher flow"
+        "KirbyAM: gameplay-active state restored; resuming normal watcher flow",
+        extra={"NoStream": True},
     )
 
 
@@ -3909,7 +3917,7 @@ async def test_poll_enemy_ability_reroll_events_treats_counter_rollback_as_reset
         "Kirby swallowed a %s. Ability was rerolled to %s.",
         "UNKNOWN_0x123456",
         "Burning",
-        extra={"NoStream": False},
+        extra={"NoStream": True},
     )
 
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -3223,7 +3223,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
 
 
 @pytest.mark.asyncio
-async def test_game_watcher_reconnect_entry_suppresses_session_ready_log_when_debug_disabled(mock_bizhawk_context):
+async def test_game_watcher_reconnect_entry_emits_file_only_session_ready_log(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -3249,9 +3249,9 @@ async def test_game_watcher_reconnect_entry_suppresses_session_ready_log_when_de
 
         await client.game_watcher(mock_bizhawk_context)
 
-    assert not any(
-        call.args and call.args[0] == "KirbyAM: AP session ready; reconnect-safe reconciliation active"
-        for call in mock_logger.info.call_args_list
+    mock_logger.info.assert_any_call(
+        "KirbyAM: AP session ready; reconnect-safe reconciliation active",
+        extra={"NoStream": True},
     )
 
 
@@ -3468,7 +3468,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
 
 
 @pytest.mark.asyncio
-async def test_game_watcher_suppresses_runtime_gate_logs_when_debug_disabled(mock_bizhawk_context):
+async def test_game_watcher_emits_file_only_runtime_gate_logs(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -3482,12 +3482,12 @@ async def test_game_watcher_suppresses_runtime_gate_logs_when_debug_disabled(moc
 
         await client.game_watcher(mock_bizhawk_context)
 
-    defer_logs = [
-        call for call in mock_logger.info.call_args_list
-        if call.args and isinstance(call.args[0], str)
-        and "deferring location polling/new item writes" in call.args[0]
-    ]
-    assert defer_logs == []
+    mock_logger.info.assert_any_call(
+        "KirbyAM: deferring location polling/new item writes (%s, ai_state=%s)",
+        "non_gameplay_tutorial_or_menu",
+        0,
+        extra={"NoStream": True},
+    )
 
 
 @pytest.mark.asyncio

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1982,7 +1982,7 @@ async def test_receive_notification_uses_local_slot_for_item_name_lookup(mock_bi
 
 
 @pytest.mark.asyncio
-async def test_receive_notification_queue_log_gated_by_debug(mock_bizhawk_context):
+async def test_receive_notification_queue_log_emitted_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -1991,20 +1991,6 @@ async def test_receive_notification_queue_log_gated_by_debug(mock_bizhawk_contex
     mock_bizhawk_context.player_names = {2: "PlayerTwo"}
     mock_bizhawk_context.item_names = Mock()
     mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
-
-    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock), \
-         patch('CommonClient.logger') as mock_logger:
-        await client._emit_receive_notification(mock_bizhawk_context, 0)
-
-    assert not any(
-        call.args and isinstance(call.args[0], str) and "receive notification queued" in call.args[0]
-        for call in mock_logger.info.call_args_list
-    )
-
-    client = KirbyAmClient()
-    client.initialize_client()
-    client._debug_logging_enabled = True
-    mock_bizhawk_context.items_received = [Mock(item=3860001, player=2)]
 
     with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock), \
          patch('CommonClient.logger') as mock_logger:
@@ -2311,7 +2297,7 @@ def test_send_notification_rate_limit_suppresses_burst(mock_bizhawk_context):
     assert mock_async_start.call_count == 7
 
 
-def test_send_notification_queue_log_gated_by_debug(mock_bizhawk_context):
+def test_send_notification_queue_log_emitted_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -2325,20 +2311,6 @@ def test_send_notification_queue_log_gated_by_debug(mock_bizhawk_context):
         "receiving": 2,
     }
 
-    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock), \
-         patch('worlds.kirbyam.client.Utils.async_start') as mock_async_start, \
-         patch('CommonClient.logger') as mock_logger:
-        mock_async_start.side_effect = lambda coro: coro.close()
-        client.on_package(mock_bizhawk_context, "PrintJSON", payload)
-
-    assert not any(
-        call.args and isinstance(call.args[0], str) and "send notification queued" in call.args[0]
-        for call in mock_logger.info.call_args_list
-    )
-
-    client = KirbyAmClient()
-    client.initialize_client()
-    client._debug_logging_enabled = True
     with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock), \
          patch('worlds.kirbyam.client.Utils.async_start') as mock_async_start, \
          patch('CommonClient.logger') as mock_logger:

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -125,6 +125,7 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
 
     with patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock) as mock_gate, \
          patch.object(client, '_load_persistent_state', new_callable=AsyncMock), \
+            patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock), \
          patch.object(client, '_apply_pending_death_link', new_callable=AsyncMock), \
          patch.object(client, '_reconcile_native_map_ownership', new_callable=AsyncMock), \
          patch.object(client, '_poll_and_send_local_death_link', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_slot_data_contract.py
+++ b/worlds/kirbyam/test/test_slot_data_contract.py
@@ -52,7 +52,6 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
         "ability_randomization_passive_enemies": False,
         "ability_randomization_no_ability_weight": 55,
         "room_sanity": False,
-        "enable_debug_logging": False,
     }
 
     world.options = options
@@ -97,13 +96,6 @@ def test_starting_kirby_color_contract_fields_present_with_expected_shapes() -> 
     assert isinstance(slot_data["starting_kirby_color"], int)
     assert isinstance(slot_data["starting_kirby_color_name"], str)
     assert slot_data["starting_kirby_color_name"]
-
-
-def test_debug_settings_contract_fields_present_with_expected_shapes() -> None:
-    slot_data = _emit_slot_data_for_contract_test()
-
-    assert isinstance(slot_data["debug"], dict)
-    assert isinstance(slot_data["debug"]["logging"], bool)
 
 
 def test_tracker_surface_contract_fields_present_with_expected_shapes() -> None:

--- a/worlds/kirbyam/test/test_starting_kirby_color.py
+++ b/worlds/kirbyam/test/test_starting_kirby_color.py
@@ -186,13 +186,12 @@ def test_reset_reconnect_transient_state_clears_starting_color_log_signature() -
 def test_client_starting_color_config_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = False
     mock_bizhawk_context.slot_data = {
-        "debug": {"logging": False},
         "starting_kirby_color": 0,
         "starting_kirby_color_name": "Pink",
     }
 
-    client._load_debug_settings(mock_bizhawk_context)
     with patch("CommonClient.logger.info") as mock_info:
         client._log_starting_kirby_color_config_once(mock_bizhawk_context)
         client._log_starting_kirby_color_config_once(mock_bizhawk_context)
@@ -203,13 +202,12 @@ def test_client_starting_color_config_log_hidden_when_debug_disabled(mock_bizhaw
 def test_client_starting_color_config_log_emits_once_when_debug_enabled(mock_bizhawk_context) -> None:
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = True
     mock_bizhawk_context.slot_data = {
-        "debug": {"logging": True},
         "starting_kirby_color": 0,
         "starting_kirby_color_name": "Pink",
     }
 
-    client._load_debug_settings(mock_bizhawk_context)
     with patch("CommonClient.logger.info") as mock_info:
         client._log_starting_kirby_color_config_once(mock_bizhawk_context)
         client._log_starting_kirby_color_config_once(mock_bizhawk_context)
@@ -221,18 +219,16 @@ def test_client_starting_color_config_log_emits_once_when_debug_enabled(mock_biz
 def test_client_starting_color_config_log_emits_after_debug_toggle_on(mock_bizhawk_context) -> None:
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = False
     mock_bizhawk_context.slot_data = {
-        "debug": {"logging": False},
         "starting_kirby_color": 0,
         "starting_kirby_color_name": "Pink",
     }
 
     with patch("CommonClient.logger.info") as mock_info:
-        client._load_debug_settings(mock_bizhawk_context)
         client._log_starting_kirby_color_config_once(mock_bizhawk_context)
 
-        mock_bizhawk_context.slot_data["debug"]["logging"] = True
-        client._load_debug_settings(mock_bizhawk_context)
+        client._debug_logging_enabled = True
         client._log_starting_kirby_color_config_once(mock_bizhawk_context)
 
     assert mock_info.call_count == 1
@@ -280,7 +276,6 @@ async def test_client_game_watcher_logs_starting_color_once_after_initial_ready_
     client.initialize_client()
     client._ram_state_loaded = True
     mock_bizhawk_context.slot_data = {
-        "debug": {"logging": True},
         "starting_kirby_color": 0,
         "starting_kirby_color_name": "Pink",
     }
@@ -291,6 +286,7 @@ async def test_client_game_watcher_logs_starting_color_once_after_initial_ready_
     with (
         patch.object(client, "_sync_death_link_setting", new=AsyncMock()),
         patch.object(client, "_sync_enemy_copy_ability_runtime_config", new=AsyncMock()),
+        patch.object(client, "_load_debug_settings", side_effect=lambda _ctx: setattr(client, "_debug_logging_enabled", True)),
         patch.object(client, "_sync_starting_kirby_color_runtime_config", new=AsyncMock()),
         patch.object(client, "_runtime_gameplay_state", new=AsyncMock(return_value=(False, "menu", None))),
         patch.object(client, "_log_boss_shard_debug_window", new=AsyncMock()),

--- a/worlds/kirbyam/test/test_starting_kirby_color.py
+++ b/worlds/kirbyam/test/test_starting_kirby_color.py
@@ -239,8 +239,8 @@ def test_client_starting_color_config_log_emits_after_debug_toggle_on(mock_bizha
 async def test_client_starting_color_sync_log_hidden_when_debug_disabled(mock_bizhawk_context) -> None:
     client = KirbyAmClient()
     client.initialize_client()
+    client._debug_logging_enabled = False
     mock_bizhawk_context.slot_data = {
-        "debug": {"logging": False},
         "starting_kirby_color": 7,
         "starting_kirby_color_name": "Sapphire",
     }
@@ -262,7 +262,6 @@ async def test_client_starting_color_sync_log_hidden_when_debug_disabled(mock_bi
         ),
         patch("CommonClient.logger.info") as mock_info,
     ):
-        client._load_debug_settings(mock_bizhawk_context)
         await client._sync_starting_kirby_color_runtime_config(mock_bizhawk_context)
 
     assert mock_info.call_count == 0

--- a/worlds/kirbyam/test/test_starting_kirby_color.py
+++ b/worlds/kirbyam/test/test_starting_kirby_color.py
@@ -285,7 +285,11 @@ async def test_client_game_watcher_logs_starting_color_once_after_initial_ready_
     with (
         patch.object(client, "_sync_death_link_setting", new=AsyncMock()),
         patch.object(client, "_sync_enemy_copy_ability_runtime_config", new=AsyncMock()),
-        patch.object(client, "_load_debug_settings", side_effect=lambda _ctx: setattr(client, "_debug_logging_enabled", True)),
+        patch.object(
+            client,
+            "_load_debug_settings",
+            side_effect=lambda _ctx: setattr(client, "_debug_logging_enabled", True),
+        ),
         patch.object(client, "_sync_starting_kirby_color_runtime_config", new=AsyncMock()),
         patch.object(client, "_runtime_gameplay_state", new=AsyncMock(return_value=(False, "menu", None))),
         patch.object(client, "_log_boss_shard_debug_window", new=AsyncMock()),


### PR DESCRIPTION
## Summary
- remove the enable_debug_logging world option from options and slot_data
- keep verbose diagnostics file-only via NoStream=True whenever emitted
- update protocol/changelog documentation and affected tests

## Testing
- .venv\Scripts\python.exe -m pytest worlds/kirbyam/test/test_slot_data_contract.py worlds/kirbyam/test/test_starting_kirby_color.py worlds/kirbyam/test/test_client.py

Closes #718