### PR TITLE
Fix boss probe fallback false positives

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -86,7 +86,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x02038970 | 1B | KIRBY_SHARD_FLAGS       | Native mirror shard bitfield (bits 0-7) |
 | 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This is the native map-ownership field. AP major-chest checks use `major_chest_flags` in the transport block, and the BizHawk client may reassert AP-owned map bits here from `start_with_all_maps` plus confirmed delivered map items to recover from reconnect/save-state drift. |
 | 0x02038960 - 0x02038969 | 10B | small_chest_flags_native | Native small-chest/switch bitfield block. Enabled MINOR_CHEST AP checks read this block directly and map `bit_index` to location IDs. |
-| 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped) |
+| 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped). The BizHawk client probes rising edges here, but only stages a boss-defeat fallback when the current resolved room explicitly carries a boss-defeat location in `rooms.json`. |
 | 0x02028CA0 | 576B | gVisitedDoors (`room_visit_flags_native`) | Native room-visit array (`u16[0x120]`); bit 15 marks visited state by `doorsIdx` |
 | 0x02023B28 | 2B | current_room_native | Current native room ID (`gCurLevelInfo[0].currentRoom`) used for room-entry diagnostics |
 | 0x0203AD2C | 4B | AI_KIRBY_STATE          | Runtime phase classifier (Issue #56 gameplay gate) |
@@ -267,7 +267,7 @@ Fail-open behavior:
 | Location checks | Level-based poll resends any RAM-derived checks missing from `checked_locations`. |
 | Item delivery | Cursor rewind still uses ROM `debug_item_counter`; forward reconciliation is only trusted as a pending-delivery ACK signal (`flag == 0` while delivery is pending). |
 | Goal reporting | Idempotent: for current shipped worlds, the client re-sends `CLIENT_GOAL` on reconnect when `finished_game` is set. If a future world exposes a numeric goal location, the client falls back to goal-location acknowledgement before `CLIENT_GOAL`. |
-| Boss probe | Probe snapshot re-baselines on BizHawk stream-identity change (reconnect safe). |
+| Boss probe | Probe snapshot and staged room-scoped fallback checks re-baseline on BizHawk stream-identity change (reconnect safe). |
 | Watcher transient state | On first tick after AP session becomes ready (`server/socket/slot_data`), reconnect diagnostics/probe caches are reset to clean baselines. |
 
 The watcher includes an AP session-readiness transition hook that resets
@@ -363,6 +363,7 @@ Boss shard scrub timing contract (Issue #505):
 - No checks are sent for bits already in `server_checked_locations`.
 - No checks are sent for reserved/unmapped bits even when set.
 - Boss-defeat, major-chest, vitality-chest, sound-player-chest, hub-switch, and room-sanity polling follow the same resend/dedupe diagnostic contract.
+- Boss-defeat fallback is intentionally room-scoped: `boss_mirror_table_native` probe rises never map directly to boss IDs. They only backfill a boss-defeat check when the current resolved room already carries that boss-defeat location in `rooms.json`.
 - Diagnostics are transition-based to avoid per-tick log spam when mapped state is unchanged.
 
 Tracker room update contract:

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -213,7 +213,7 @@ class KirbyAmClient(BizHawkClient):
         # Boss candidate probing state
         self._last_boss_probe_snapshot: bytes | None = None
         self._boss_probe_stream_marker: object = None
-        self._boss_probe_fallback_bits: set[int] = set()
+        self._boss_probe_fallback_location_ids: set[int] = set()
 
         # Runtime gameplay-state gate tracking
         self._last_runtime_gate_reason: str | None = None
@@ -237,9 +237,11 @@ class KirbyAmClient(BizHawkClient):
         # Room entry logging (always file-only via NoStream=True).
         self._last_native_room_id: int | None = None
         self._last_sent_room_update_native_room_id: int | None = None
+        self._last_room_region_key: str = ""
         room_label_lookup, room_region_key_lookup = self._build_room_lookup_maps()
         self._room_label_by_doors_idx: dict[int, str] = room_label_lookup
         self._room_region_key_by_doors_idx: dict[int, str] = room_region_key_lookup
+        self._boss_location_ids_by_room_region: dict[str, list[int]] = self._build_boss_room_lookup_map()
 
         # Notification pipeline state (Issue #83)
         self._notification_settings_loaded: bool = False
@@ -352,6 +354,33 @@ class KirbyAmClient(BizHawkClient):
                 region_result[doors_idx] = str(region_key)
         return label_result, region_result
 
+    @staticmethod
+    def _build_boss_room_lookup_map() -> "dict[str, list[int]]":
+        """Build a region-key -> boss-defeat location ID map from rooms.json."""
+        rooms_json = load_json_data("regions/rooms.json")
+        result: dict[str, list[int]] = {}
+        if not isinstance(rooms_json, dict):
+            return result
+
+        for region_key, room in rooms_json.items():
+            locations = room.get("locations")
+            if not isinstance(locations, list):
+                continue
+
+            boss_location_ids: list[int] = []
+            for location_key in locations:
+                if not isinstance(location_key, str):
+                    continue
+                loc_meta = data.locations.get(location_key)
+                if loc_meta is None or loc_meta.category != LocationCategory.BOSS_DEFEAT:
+                    continue
+                boss_location_ids.append(loc_meta.location_id)
+
+            if boss_location_ids:
+                result[str(region_key)] = sorted(boss_location_ids)
+
+        return result
+
     def _reset_reconnect_transient_state(self) -> None:
         """Reset transient watcher diagnostics/probes so reconnect starts from clean baselines."""
         self._last_runtime_gate_reason = None
@@ -367,7 +396,8 @@ class KirbyAmClient(BizHawkClient):
         self._last_room_sanity_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
-        self._boss_probe_fallback_bits.clear()
+        self._boss_probe_fallback_location_ids.clear()
+        self._last_room_region_key = ""
         self._unsafe_delivery_probe_stream_marker = None
         self._last_unsafe_delivery_counter_values = {}
         self._incoming_death_link_pending = False
@@ -1858,10 +1888,9 @@ class KirbyAmClient(BizHawkClient):
                 mapped_checked_locations.update(self._boss_location_ids_by_bit.get(bit, []))
 
         # Fallback source for Issue #573: if boss_defeat_flags does not rise because
-        # native CollectShard() was skipped (already-owned shard), use rising-edge
-        # observations from boss_mirror_table_native collected by probe polling.
-        for bit in sorted(self._boss_probe_fallback_bits):
-            mapped_checked_locations.update(self._boss_location_ids_by_bit.get(bit, []))
+        # native CollectShard() was skipped (already-owned shard), use room-scoped
+        # probe observations staged by _probe_boss_defeat_candidates().
+        mapped_checked_locations.update(self._boss_probe_fallback_location_ids)
 
         missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
         already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
@@ -2218,6 +2247,7 @@ class KirbyAmClient(BizHawkClient):
         doors_idx = unpack_from("<H", doors_raw)[0]
         room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
         room_region_key = self._room_region_key_by_doors_idx.get(doors_idx, "")
+        self._last_room_region_key = room_region_key
 
         if room_changed:
             self._last_native_room_id = native_room_id
@@ -2326,10 +2356,11 @@ class KirbyAmClient(BizHawkClient):
 
     async def _probe_boss_defeat_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """
-        Probe native candidate boss table bytes and log rising-edge bit transitions.
+        Probe native candidate boss table bytes and stage room-scoped fallback checks.
 
-        This is intentionally observational: it does not send AP location checks yet.
-        The logs are meant to support live BizHawk address verification for Issue #110.
+        Rising edges remain diagnostic first. They only backfill AP boss-defeat checks
+        when observed while the client is in a room that explicitly carries a
+        boss-defeat location in rooms.json.
         """
         base_addr = self._native_addr("boss_mirror_table_native")
         if base_addr is None:
@@ -2344,7 +2375,7 @@ class KirbyAmClient(BizHawkClient):
         elif stream_marker is not self._boss_probe_stream_marker:
             self._boss_probe_stream_marker = stream_marker
             self._last_boss_probe_snapshot = None
-            self._boss_probe_fallback_bits.clear()
+            self._boss_probe_fallback_location_ids.clear()
 
         raw = (await bizhawk.read(
             ctx.bizhawk_ctx,
@@ -2383,24 +2414,25 @@ class KirbyAmClient(BizHawkClient):
                 ", ".join(rising_edges),
             )
 
-        # Conservative fallback mapping: only byte 0 bits 0-7 are considered,
-        # and only when observed as rising edges. This preserves probe behavior
-        # while providing a low-risk backup for boss check signaling.
-        supported_bits = set(self._boss_location_ids_by_bit.keys())
-        if not supported_bits:
+        boss_location_ids = self._boss_location_ids_by_room_region.get(self._last_room_region_key, [])
+        if not boss_location_ids:
+            self._log_verbose(
+                "debug",
+                "KirbyAM: ignoring boss candidate probe fallback outside a boss-defeat room (room=%s, rising=%s)",
+                self._last_room_region_key or "<unknown>",
+                ", ".join(rising_edges),
+            )
             return
 
-        prev_byte0 = old[0] if old else 0
-        new_byte0 = raw[0] if raw else 0
-        rising_mask = (~prev_byte0 & 0xFF) & new_byte0
-        if rising_mask == 0:
-            return
-
-        for bit in supported_bits:
-            if bit < 0 or bit > 7:
-                continue
-            if (rising_mask >> bit) & 1:
-                self._boss_probe_fallback_bits.add(bit)
+        staged_before = set(self._boss_probe_fallback_location_ids)
+        self._boss_probe_fallback_location_ids.update(boss_location_ids)
+        if self._boss_probe_fallback_location_ids != staged_before:
+            self._log_verbose(
+                "info",
+                "KirbyAM: staged boss probe fallback from room-scoped observation (room=%s, locations=%s)",
+                self._last_room_region_key,
+                sorted(boss_location_ids),
+            )
 
     async def _probe_unsafe_delivery_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/data/native_address_policy.json
+++ b/worlds/kirbyam/data/native_address_policy.json
@@ -85,7 +85,7 @@
           "offset": "0x00",
           "width": "u8[32]",
           "source": "Protocol reverse-engineering candidate",
-          "verification": "Integrated as observational probe only; rising-edge transitions are logged in client for live mapping"
+          "verification": "Integrated as a diagnostic probe; rising-edge transitions are logged in client, and only room-scoped observations in rooms that explicitly carry a boss-defeat location may stage a fallback resend when boss_defeat_flags stays clear"
         }
       ]
     },

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2324,9 +2324,13 @@ async def test_probe_boss_candidates_logs_rising_edges(mock_bizhawk_context):
         await client._probe_boss_defeat_candidates(mock_bizhawk_context)
 
         assert mock_logger.debug.called
-        logged_args = mock_logger.debug.call_args.args
-        assert "KirbyAM: boss candidate probe rising bits" in logged_args[0]
-        assert "0x02028C14[bit3]" in logged_args[1]
+        matching_calls = [
+            call
+            for call in mock_logger.debug.call_args_list
+            if call.args and isinstance(call.args[0], str) and "KirbyAM: boss candidate probe rising bits" in call.args[0]
+        ]
+        assert matching_calls
+        assert "0x02028C14[bit3]" in matching_calls[-1].args[1]
 
 
 @pytest.mark.asyncio
@@ -3708,12 +3712,13 @@ async def test_poll_boss_defeat_skips_already_server_acknowledged(mock_bizhawk_c
 
 @pytest.mark.asyncio
 async def test_poll_boss_defeat_uses_probe_fallback_when_transport_bit_missing(mock_bizhawk_context):
-    """Issue #573: probe-observed native boss bit should backfill missing transport signal."""
+    """Issue #573: boss-room probe observation should backfill missing transport signal."""
     client = KirbyAmClient()
     client.initialize_client()
 
     boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
     mock_bizhawk_context.checked_locations = set()
+    client._last_room_region_key = "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP"
 
     with patch.dict(
         data.transport_ram_addresses,
@@ -3725,7 +3730,7 @@ async def test_poll_boss_defeat_uses_probe_fallback_when_transport_bit_missing(m
         clear=False,
     ), patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
-        # Probe baseline then rising edge for bit 0 (boss 1), then poll transport=0.
+        # Probe baseline then a rising edge while the client is in the Mustard boss-defeat room.
         mock_read.side_effect = [
             [bytes(32)],
             [bytes([0x01]) + bytes(31)],
@@ -3739,6 +3744,38 @@ async def test_poll_boss_defeat_uses_probe_fallback_when_transport_bit_missing(m
     mock_send.assert_awaited_once_with([
         {"cmd": "LocationChecks", "locations": [boss1_loc]}
     ])
+
+
+@pytest.mark.asyncio
+async def test_poll_boss_defeat_ignores_probe_fallback_outside_boss_room(mock_bizhawk_context):
+    """Issue #708: probe rises outside boss-defeat rooms must not emit boss checks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.checked_locations = set()
+    client._last_room_region_key = "REGION_MOONLIGHT_MANSION/ROOM_2_10"
+
+    with patch.dict(
+        data.transport_ram_addresses,
+        {"boss_defeat_flags": 0x0203B024},
+        clear=False,
+    ), patch.dict(
+        data.native_ram_addresses,
+        {"boss_mirror_table_native": 0x02028C14},
+        clear=False,
+    ), patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.side_effect = [
+            [bytes(32)],
+            [bytes([0x01]) + bytes(31)],
+            [(0x00).to_bytes(4, 'little')],
+        ]
+
+        await client._probe_boss_defeat_candidates(mock_bizhawk_context)
+        await client._probe_boss_defeat_candidates(mock_bizhawk_context)
+        await client._poll_boss_defeat_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- gate boss probe fallback by current room region to prevent false-positive boss checks outside boss rooms
- preserve reconnect recovery behavior by staging fallback only when probe rise occurs in a known boss room
- document updated fallback contract in protocol and native address policy

## Testing
- python -m pytest worlds/kirbyam/test/test_client.py -k "boss_defeat or probe_boss_candidates"
- python -m pytest worlds/kirbyam/test/test_client.py -k "ignores_probe_fallback_outside_boss_room"
- python -m pytest worlds/kirbyam/test/test_reconnect_chaos.py -k boss_defeat

Closes #708