### PR TITLE
Fix stale room-region-key fallback gating after room change

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -2229,6 +2229,10 @@ class KirbyAmClient(BizHawkClient):
         if not room_changed and not send_pending:
             return
 
+        if room_changed:
+            # Clear stale room context before any lookup that may fail.
+            self._last_room_region_key = ""
+
         # Resolve doorsIdx via gRoomProps[native_room_id].doorsIdx (ROM read).
         rom_doors_idx_addr = _ROOM_PROPS_ROM_BASE + native_room_id * _ROOM_PROPS_STRIDE + _ROOM_PROPS_DOORS_IDX_OFFSET
         try:

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -795,6 +795,8 @@ async def test_poll_room_entry_logging_reads_doors_idx_from_rom_lookup(mock_bizh
 async def test_poll_room_entry_logging_handles_rom_lookup_failure(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()
+    client._last_native_room_id = 0x0002
+    client._last_room_region_key = "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP"
 
     with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch('CommonClient.logger') as mock_logger:
@@ -810,6 +812,25 @@ async def test_poll_room_entry_logging_handles_rom_lookup_failure(mock_bizhawk_c
         0x0003,
         extra={"NoStream": True},
     )
+    assert client._last_room_region_key == ""
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_clears_room_region_key_on_short_rom_read(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._last_native_room_id = 0x0002
+    client._last_room_region_key = "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP"
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        mock_read.side_effect = [
+            [(0x0008).to_bytes(2, 'little')],
+            [b'\x0b'],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert client._last_room_region_key == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to merged PR #722 Copilot review thread (discussion_r3087976893).

## What this fixes
- clear `_last_room_region_key` immediately when a new native room id is observed, before doorsIdx ROM lookup
- ensures boss probe fallback gating cannot reuse stale room context if ROM lookup fails or short-reads

## Tests
- adds regression assertions for ROM lookup failure path clearing stale room-region key
- adds regression test for short ROM read path clearing stale room-region key
- re-runs focused room-entry and boss probe test groups

Refs: #722