### PR TITLE
Issue #606: Add area-first-visit location checks

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -19,6 +19,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
   - Trap receive notifications are prefixed with "Received trap:" to distinguish them from regular items.
 - Added two new filler consumables with tiered healing: `Energy Drink` (HP +2) and `Hunk of Meat` (HP +3), alongside existing `Small Food` (HP +1).
 - Enabled the first concrete `MINOR_CHEST` AP checks (Rainbow Route 1-20, 1-22, 1-38).
+- Added area-first-visit checks for all nine gameplay areas so the first room entry in each area grants one AP location check (Issue #606).
 
 ### Improvements
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -151,11 +151,12 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 10 = Moonlight; others sequential) |
+| AREA_VISIT_* | 3960451 - 3960459 | First-visit checks for gameplay areas 1..9 (Rainbow Route through Candy Constellation), derived from first visited room per area via native `gVisitedDoors` |
 | MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-20 small chest (native small_chest_flags_native bit 1) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags_native bit 23) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags_native bit 41) |
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
-| *Reserved*    | 3960415+ | Future location families |
+| *Reserved*    | 3960460+ | Future location families |
 
 Minor chest status (Issue #540):
 - Initial MINOR_CHEST AP checks are active for Rainbow Route rooms 1-20, 1-22, and 1-38.
@@ -322,6 +323,11 @@ room_visits = RAM[0x02028CA0 : 0x02028CA0 + 0x240] as u16[0x120]
 for doors_idx in mapped_room_sanity_doors_indices:
     if room_visits[doors_idx] & 0x8000:
         mapped_checked.add(room_sanity_location_id_for_doors_idx(doors_idx))
+
+# Area-first-visit checks (native gVisitedDoors)
+for doors_idx, area_id in mapped_room_doors_idx_to_area_ids:
+    if room_visits[doors_idx] & 0x8000:
+        mapped_checked.add(area_first_visit_location_id_for_area(area_id))
 
 # Room-entry tracker updates (best-effort)
 current_room_native = RAM[0x02023B28] as u16

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -394,6 +394,7 @@ class KirbyAmWorld(World):
             hub_switch_locations: list[KirbyAmLocation] = []
             minor_chest_locations: list[KirbyAmLocation] = []
             room_sanity_locations: list[KirbyAmLocation] = []
+            area_visit_locations: list[KirbyAmLocation] = []
             location_by_key: dict[str, KirbyAmLocation] = {}
             for loc in fill_locations:
                 if loc.key is None:
@@ -416,6 +417,8 @@ class KirbyAmWorld(World):
                     minor_chest_locations.append(loc)
                 elif loc_meta.category == LocationCategory.ROOM_SANITY:
                     room_sanity_locations.append(loc)
+                elif loc_meta.category == LocationCategory.AREA_VISIT:
+                    area_visit_locations.append(loc)
 
             boss_locations.sort(key=lambda loc: loc.key or "")
             major_chest_locations.sort(key=lambda loc: loc.key or "")
@@ -424,10 +427,11 @@ class KirbyAmWorld(World):
             hub_switch_locations.sort(key=lambda loc: loc.key or "")
             minor_chest_locations.sort(key=lambda loc: loc.key or "")
             room_sanity_locations.sort(key=lambda loc: loc.key or "")
+            area_visit_locations.sort(key=lambda loc: loc.key or "")
 
             locked_shard_count = 0
             randomized_item_codes: list[int] = []
-            if boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or minor_chest_locations or room_sanity_locations:
+            if boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or minor_chest_locations or room_sanity_locations or area_visit_locations:
                 shard_label_to_code = {
                     item.label: item.item_id
                     for item in kirby_data.items.values()
@@ -481,7 +485,7 @@ class KirbyAmWorld(World):
                     )
 
                 open_physical_locations = [
-                    loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations + hub_switch_locations + minor_chest_locations + room_sanity_locations
+                    loc for loc in boss_locations + major_chest_locations + vitality_chest_locations + sound_player_chest_locations + hub_switch_locations + minor_chest_locations + room_sanity_locations + area_visit_locations
                     if loc.item is None
                 ]
                 needed_pool_size = len(open_physical_locations)
@@ -629,11 +633,11 @@ class KirbyAmWorld(World):
                         self.player,
                     )
 
-            if (boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or minor_chest_locations or room_sanity_locations) and not randomized_item_codes:
+            if (boss_locations or major_chest_locations or vitality_chest_locations or sound_player_chest_locations or hub_switch_locations or minor_chest_locations or room_sanity_locations or area_visit_locations) and not randomized_item_codes:
                 raise ValueError(
                     "KirbyAM item pool build failed: no randomized items were produced. "
                     "This likely indicates a problem with boss/major/vitality/sound-player/hub-switch/minor-chest locations, "
-                    "room-sanity locations, or region/location data."
+                    "room-sanity/area-visit locations, or region/location data."
                 )
 
             itempool: list[KirbyAmItem] = [

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 import time
 from struct import unpack_from
 from typing import TYPE_CHECKING, Optional
@@ -50,6 +51,18 @@ _ROOM_VISIT_FLAGS_ADDR_KEY = "room_visit_flags_native"
 _ROOM_VISIT_FLAGS_ENTRY_COUNT = 0x120
 _ROOM_VISIT_FLAGS_BIT_MASK = 0x8000
 _CURRENT_ROOM_ADDR_KEY = "current_room_native"
+_ROOM_REGION_AREA_TOKEN_PATTERN = re.compile(r"^REGION_([A-Z_]+)/ROOM_[A-Z0-9_]+$")
+_AREA_REGION_TOKEN_TO_AREA_ID: dict[str, int] = {
+    "RAINBOW_ROUTE": 1,
+    "MOONLIGHT_MANSION": 2,
+    "CABBAGE_CAVERN": 3,
+    "MUSTARD_MOUNTAIN": 4,
+    "CARROT_CASTLE": 5,
+    "OLIVE_OCEAN": 6,
+    "PEPPERMINT_PALACE": 7,
+    "RADISH_RUINS": 8,
+    "CANDY_CONSTELLATION": 9,
+}
 _STARTING_KIRBY_COLOR_MIN = 0
 _STARTING_KIRBY_COLOR_MAX = 13
 _STARTING_KIRBY_COLOR_REVALIDATE_TICKS = 4
@@ -202,6 +215,14 @@ class KirbyAmClient(BizHawkClient):
             self._room_sanity_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
         self._room_sanity_bits_sorted: list[int] = sorted(self._room_sanity_location_ids_by_bit.keys())
 
+        # Area-first-visit location map keyed by area id (1..9).
+        self._area_visit_location_ids_by_area_id: dict[int, list[int]] = {}
+        for loc in data.locations.values():
+            if loc.bit_index is None or loc.category != LocationCategory.AREA_VISIT:
+                continue
+            self._area_visit_location_ids_by_area_id.setdefault(loc.bit_index, []).append(loc.location_id)
+        self._area_visit_area_ids_sorted: list[int] = sorted(self._area_visit_location_ids_by_area_id.keys())
+
         # One-time RAM state load
         self._ram_state_loaded: bool = False
 
@@ -233,6 +254,7 @@ class KirbyAmClient(BizHawkClient):
         self._hub_switch_session_initialized: bool = False
         self._hub_switch_stream_marker: object = None
         self._last_room_sanity_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._last_area_visit_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
 
         # Room entry logging (always file-only via NoStream=True).
         self._last_native_room_id: int | None = None
@@ -241,6 +263,7 @@ class KirbyAmClient(BizHawkClient):
         room_label_lookup, room_region_key_lookup = self._build_room_lookup_maps()
         self._room_label_by_doors_idx: dict[int, str] = room_label_lookup
         self._room_region_key_by_doors_idx: dict[int, str] = room_region_key_lookup
+        self._room_area_id_by_doors_idx: dict[int, int] = self._build_room_area_lookup_map()
         self._boss_location_ids_by_room_region: dict[str, list[int]] = self._build_boss_room_lookup_map()
 
         # Notification pipeline state (Issue #83)
@@ -381,6 +404,36 @@ class KirbyAmClient(BizHawkClient):
 
         return result
 
+    @staticmethod
+    def _build_room_area_lookup_map() -> "dict[int, int]":
+        """Build doorsIdx -> gameplay area id map from rooms.json."""
+        rooms_json = load_json_data("regions/rooms.json")
+        result: dict[int, int] = {}
+        if not isinstance(rooms_json, dict):
+            return result
+
+        for region_key, room in rooms_json.items():
+            if not isinstance(region_key, str) or not isinstance(room, dict):
+                continue
+            match = _ROOM_REGION_AREA_TOKEN_PATTERN.match(region_key)
+            if match is None:
+                continue
+            area_id = _AREA_REGION_TOKEN_TO_AREA_ID.get(match.group(1))
+            if area_id is None:
+                continue
+
+            rs = room.get("room_sanity")
+            if not isinstance(rs, dict):
+                continue
+
+            bit_index = rs.get("bit_index")
+            if bit_index is None:
+                continue
+
+            result[int(bit_index)] = area_id
+
+        return result
+
     def _reset_reconnect_transient_state(self) -> None:
         """Reset transient watcher diagnostics/probes so reconnect starts from clean baselines."""
         self._last_runtime_gate_reason = None
@@ -394,6 +447,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_sound_player_chest_poll_log = None
         self._last_hub_switch_poll_log = None
         self._last_room_sanity_poll_log = None
+        self._last_area_visit_poll_log = None
         self._last_boss_probe_snapshot = None
         self._boss_probe_stream_marker = None
         self._boss_probe_fallback_location_ids.clear()
@@ -1136,6 +1190,9 @@ class KirbyAmClient(BizHawkClient):
 
             # Hub switch location polling via dedicated hub_switch_flags register
             await self._poll_hub_switch_locations(ctx)
+
+            # Area-first-visit location polling via native gVisitedDoors bit 15.
+            await self._poll_area_visit_locations(ctx)
 
             # Room-sanity location polling via native gVisitedDoors bit 15.
             await self._poll_room_sanity_locations(ctx)
@@ -2357,6 +2414,74 @@ class KirbyAmClient(BizHawkClient):
                 self._last_room_sanity_poll_log = room_log_state
         else:
             self._last_room_sanity_poll_log = None
+
+    async def _poll_area_visit_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Map first visited rooms to area-first-visit location checks.
+
+        Uses native gVisitedDoors[doorsIdx] bit 15 and a static doorsIdx -> area mapping
+        built from rooms.json. Polling is level-based and reconnect-safe: checks are
+        resent until server acknowledgement is present in ctx.checked_locations.
+        """
+        if not self._area_visit_location_ids_by_area_id or not self._room_area_id_by_doors_idx:
+            return
+
+        room_visit_addr = self._native_addr(_ROOM_VISIT_FLAGS_ADDR_KEY)
+        if room_visit_addr is None:
+            return
+
+        read_width = _ROOM_VISIT_FLAGS_ENTRY_COUNT * 2
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(room_visit_addr, read_width, "System Bus")]))[0]
+
+        if len(raw) != read_width:
+            self._log_client(
+                "warning",
+                "KirbyAM: area-visit poll expected %s bytes from gVisitedDoors, got %s; skipping tick",
+                read_width,
+                len(raw),
+            )
+            return
+
+        raw_view = memoryview(raw)
+
+        visited_area_ids: set[int] = set()
+        for doors_idx, area_id in self._room_area_id_by_doors_idx.items():
+            if doors_idx < 0 or doors_idx >= _ROOM_VISIT_FLAGS_ENTRY_COUNT:
+                continue
+            entry_value = unpack_from("<H", raw_view, doors_idx * 2)[0]
+            if entry_value & _ROOM_VISIT_FLAGS_BIT_MASK:
+                visited_area_ids.add(area_id)
+
+        mapped_checked_locations: set[int] = set()
+        for area_id in self._area_visit_area_ids_sorted:
+            if area_id in visited_area_ids:
+                mapped_checked_locations.update(self._area_visit_location_ids_by_area_id.get(area_id, []))
+
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+        already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
+        if missing_on_server:
+            area_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if area_log_state != self._last_area_visit_poll_log:
+                self._log_verbose(
+                    "info",
+                    "KirbyAM: resending area-first-visit LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                )
+                self._last_area_visit_poll_log = area_log_state
+
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+        elif mapped_checked_locations:
+            area_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if area_log_state != self._last_area_visit_poll_log:
+                self._log_verbose(
+                    "debug",
+                    "KirbyAM: dedupe suppressed area-first-visit LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_area_visit_poll_log = area_log_state
+        else:
+            self._last_area_visit_poll_log = None
 
     async def _probe_boss_defeat_candidates(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -260,11 +260,12 @@ class KirbyAmClient(BizHawkClient):
         self._last_native_room_id: int | None = None
         self._last_sent_room_update_native_room_id: int | None = None
         self._last_room_region_key: str = ""
-        room_label_lookup, room_region_key_lookup = self._build_room_lookup_maps()
+        room_label_lookup, room_region_key_lookup, room_area_lookup, boss_room_lookup = self._build_room_metadata_maps()
         self._room_label_by_doors_idx: dict[int, str] = room_label_lookup
         self._room_region_key_by_doors_idx: dict[int, str] = room_region_key_lookup
-        self._room_area_id_by_doors_idx: dict[int, int] = self._build_room_area_lookup_map()
-        self._boss_location_ids_by_room_region: dict[str, list[int]] = self._build_boss_room_lookup_map()
+        self._room_area_id_by_doors_idx: dict[int, int] = room_area_lookup
+        self._boss_location_ids_by_room_region: dict[str, list[int]] = boss_room_lookup
+        self._cached_room_visit_flags_view: memoryview | None = None
 
         # Notification pipeline state (Issue #83)
         self._notification_settings_loaded: bool = False
@@ -359,33 +360,35 @@ class KirbyAmClient(BizHawkClient):
         return common_logger
 
     @staticmethod
-    def _build_room_lookup_maps() -> "tuple[dict[int, str], dict[int, str]]":
-        """Build doorsIdx keyed room label and region-key maps from rooms.json in one pass."""
+    def _build_room_metadata_maps() -> "tuple[dict[int, str], dict[int, str], dict[int, int], dict[str, list[int]]]":
+        """Build all room-derived lookup maps from a single rooms.json pass."""
         rooms_json = load_json_data("regions/rooms.json")
-        label_result: dict[int, str] = {}
-        region_result: dict[int, str] = {}
+        room_label_result: dict[int, str] = {}
+        room_region_result: dict[int, str] = {}
+        room_area_result: dict[int, int] = {}
+        boss_room_result: dict[str, list[int]] = {}
         if not isinstance(rooms_json, dict):
-            return label_result, region_result
+            return room_label_result, room_region_result, room_area_result, boss_room_result
+
         for region_key, room in rooms_json.items():
+            if not isinstance(region_key, str) or not isinstance(room, dict):
+                continue
+
             rs = room.get("room_sanity")
             if not isinstance(rs, dict):
                 continue
             bit_index = rs.get("bit_index")
             if bit_index is not None:
                 doors_idx = int(bit_index)
-                label_result[doors_idx] = format_room_region_label(str(region_key))
-                region_result[doors_idx] = str(region_key)
-        return label_result, region_result
+                room_label_result[doors_idx] = format_room_region_label(region_key)
+                room_region_result[doors_idx] = region_key
 
-    @staticmethod
-    def _build_boss_room_lookup_map() -> "dict[str, list[int]]":
-        """Build a region-key -> boss-defeat location ID map from rooms.json."""
-        rooms_json = load_json_data("regions/rooms.json")
-        result: dict[str, list[int]] = {}
-        if not isinstance(rooms_json, dict):
-            return result
+                match = _ROOM_REGION_AREA_TOKEN_PATTERN.match(region_key)
+                if match is not None:
+                    area_id = _AREA_REGION_TOKEN_TO_AREA_ID.get(match.group(1))
+                    if area_id is not None:
+                        room_area_result[doors_idx] = area_id
 
-        for region_key, room in rooms_json.items():
             locations = room.get("locations")
             if not isinstance(locations, list):
                 continue
@@ -400,39 +403,9 @@ class KirbyAmClient(BizHawkClient):
                 boss_location_ids.append(loc_meta.location_id)
 
             if boss_location_ids:
-                result[str(region_key)] = sorted(boss_location_ids)
+                boss_room_result[region_key] = sorted(boss_location_ids)
 
-        return result
-
-    @staticmethod
-    def _build_room_area_lookup_map() -> "dict[int, int]":
-        """Build doorsIdx -> gameplay area id map from rooms.json."""
-        rooms_json = load_json_data("regions/rooms.json")
-        result: dict[int, int] = {}
-        if not isinstance(rooms_json, dict):
-            return result
-
-        for region_key, room in rooms_json.items():
-            if not isinstance(region_key, str) or not isinstance(room, dict):
-                continue
-            match = _ROOM_REGION_AREA_TOKEN_PATTERN.match(region_key)
-            if match is None:
-                continue
-            area_id = _AREA_REGION_TOKEN_TO_AREA_ID.get(match.group(1))
-            if area_id is None:
-                continue
-
-            rs = room.get("room_sanity")
-            if not isinstance(rs, dict):
-                continue
-
-            bit_index = rs.get("bit_index")
-            if bit_index is None:
-                continue
-
-            result[int(bit_index)] = area_id
-
-        return result
+        return room_label_result, room_region_result, room_area_result, boss_room_result
 
     def _reset_reconnect_transient_state(self) -> None:
         """Reset transient watcher diagnostics/probes so reconnect starts from clean baselines."""
@@ -475,6 +448,31 @@ class KirbyAmClient(BizHawkClient):
         self._cached_delivered_map_bits = 0
         self._cached_map_bits_index = 0
         self._cached_map_bits_items_len = 0
+        self._cached_room_visit_flags_view = None
+
+    async def _get_room_visit_flags_view(self, ctx: KirbyAmBizHawkClientContext) -> memoryview | None:
+        """Read gVisitedDoors once per watcher tick and return a shared memory view."""
+        if self._cached_room_visit_flags_view is not None:
+            return self._cached_room_visit_flags_view
+
+        room_visit_addr = self._native_addr(_ROOM_VISIT_FLAGS_ADDR_KEY)
+        if room_visit_addr is None:
+            return None
+
+        read_width = _ROOM_VISIT_FLAGS_ENTRY_COUNT * 2
+        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(room_visit_addr, read_width, "System Bus")]))[0]
+
+        if len(raw) != read_width:
+            self._log_client(
+                "warning",
+                "KirbyAM: visited-door poll expected %s bytes from gVisitedDoors, got %s; skipping tick",
+                read_width,
+                len(raw),
+            )
+            return None
+
+        self._cached_room_visit_flags_view = memoryview(raw)
+        return self._cached_room_visit_flags_view
 
     def _no_extra_lives_enabled(self, ctx: "BizHawkClientContext") -> bool:
         slot_data = getattr(ctx, "slot_data", None)
@@ -1190,6 +1188,9 @@ class KirbyAmClient(BizHawkClient):
 
             # Hub switch location polling via dedicated hub_switch_flags register
             await self._poll_hub_switch_locations(ctx)
+
+            # Share one gVisitedDoors read for area-first-visit and room-sanity polling.
+            self._cached_room_visit_flags_view = None
 
             # Area-first-visit location polling via native gVisitedDoors bit 15.
             await self._poll_area_visit_locations(ctx)
@@ -2362,23 +2363,9 @@ class KirbyAmClient(BizHawkClient):
         if not self._room_sanity_location_ids_by_bit:
             return
 
-        room_visit_addr = self._native_addr(_ROOM_VISIT_FLAGS_ADDR_KEY)
-        if room_visit_addr is None:
+        raw_view = await self._get_room_visit_flags_view(ctx)
+        if raw_view is None:
             return
-
-        read_width = _ROOM_VISIT_FLAGS_ENTRY_COUNT * 2
-        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(room_visit_addr, read_width, "System Bus")]))[0]
-
-        if len(raw) != read_width:
-            self._log_client(
-                "warning",
-                "KirbyAM: room-sanity poll expected %s bytes from gVisitedDoors, got %s; skipping tick",
-                read_width,
-                len(raw),
-            )
-            return
-
-        raw_view = memoryview(raw)
 
         mapped_checked_locations: set[int] = set()
         for doors_idx in self._room_sanity_bits_sorted:
@@ -2426,23 +2413,9 @@ class KirbyAmClient(BizHawkClient):
         if not self._area_visit_location_ids_by_area_id or not self._room_area_id_by_doors_idx:
             return
 
-        room_visit_addr = self._native_addr(_ROOM_VISIT_FLAGS_ADDR_KEY)
-        if room_visit_addr is None:
+        raw_view = await self._get_room_visit_flags_view(ctx)
+        if raw_view is None:
             return
-
-        read_width = _ROOM_VISIT_FLAGS_ENTRY_COUNT * 2
-        raw = (await bizhawk.read(ctx.bizhawk_ctx, [(room_visit_addr, read_width, "System Bus")]))[0]
-
-        if len(raw) != read_width:
-            self._log_client(
-                "warning",
-                "KirbyAM: area-visit poll expected %s bytes from gVisitedDoors, got %s; skipping tick",
-                read_width,
-                len(raw),
-            )
-            return
-
-        raw_view = memoryview(raw)
 
         visited_area_ids: set[int] = set()
         for doors_idx, area_id in self._room_area_id_by_doors_idx.items():

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -187,6 +187,7 @@ class LocationCategory(IntEnum):
     ROOM_SANITY = 12
     HUB_SWITCH = 13
     MINOR_CHEST = 14
+    AREA_VISIT = 15
 
 
 class ItemData(NamedTuple):

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -88,6 +88,105 @@
     "bit_index": 7,
     "category": "BOSS_DEFEAT"
   },
+  "AREA_VISIT_1_RAINBOW_ROUTE": {
+    "label": "Rainbow Route - First Visit",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "bit_index": 1,
+    "category": "AREA_VISIT",
+    "location_id": 3960451
+  },
+  "AREA_VISIT_2_MOONLIGHT_MANSION": {
+    "label": "Moonlight Mansion - First Visit",
+    "parent_region": "REGION_MOONLIGHT_MANSION/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_MOONLIGHT_MANSION"
+    ],
+    "bit_index": 2,
+    "category": "AREA_VISIT",
+    "location_id": 3960452
+  },
+  "AREA_VISIT_3_CABBAGE_CAVERN": {
+    "label": "Cabbage Cavern - First Visit",
+    "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 3,
+    "category": "AREA_VISIT",
+    "location_id": 3960453
+  },
+  "AREA_VISIT_4_MUSTARD_MOUNTAIN": {
+    "label": "Mustard Mountain - First Visit",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_MUSTARD_MOUNTAIN"
+    ],
+    "bit_index": 4,
+    "category": "AREA_VISIT",
+    "location_id": 3960454
+  },
+  "AREA_VISIT_5_CARROT_CASTLE": {
+    "label": "Carrot Castle - First Visit",
+    "parent_region": "REGION_CARROT_CASTLE/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_CARROT_CASTLE"
+    ],
+    "bit_index": 5,
+    "category": "AREA_VISIT",
+    "location_id": 3960455
+  },
+  "AREA_VISIT_6_OLIVE_OCEAN": {
+    "label": "Olive Ocean - First Visit",
+    "parent_region": "REGION_OLIVE_OCEAN/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_OLIVE_OCEAN"
+    ],
+    "bit_index": 6,
+    "category": "AREA_VISIT",
+    "location_id": 3960456
+  },
+  "AREA_VISIT_7_PEPPERMINT_PALACE": {
+    "label": "Peppermint Palace - First Visit",
+    "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_PEPPERMINT_PALACE"
+    ],
+    "bit_index": 7,
+    "category": "AREA_VISIT",
+    "location_id": 3960457
+  },
+  "AREA_VISIT_8_RADISH_RUINS": {
+    "label": "Radish Ruins - First Visit",
+    "parent_region": "REGION_RADISH_RUINS/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_RADISH_RUINS"
+    ],
+    "bit_index": 8,
+    "category": "AREA_VISIT",
+    "location_id": 3960458
+  },
+  "AREA_VISIT_9_CANDY_CONSTELLATION": {
+    "label": "Candy Constellation - First Visit",
+    "parent_region": "REGION_CANDY_CONSTELLATION/MAIN",
+    "tags": [
+      "AreaVisit",
+      "MAP_CANDY_CONSTELLATION"
+    ],
+    "bit_index": 9,
+    "category": "AREA_VISIT",
+    "location_id": 3960459
+  },
   "MAJOR_CHEST_CABBAGE_CAVERN": {
     "label": "Cabbage Cavern Map - Big Chest",
     "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_GOAL",

--- a/worlds/kirbyam/groups.py
+++ b/worlds/kirbyam/groups.py
@@ -45,6 +45,7 @@ _LOCATION_CATEGORY_TO_GROUP_NAME = {
     LocationCategory.MAJOR_CHEST: "Major Chests",
     LocationCategory.HUB_SWITCH: "Hub Switches",
     LocationCategory.MINOR_CHEST: "Minor Chests",
+    LocationCategory.AREA_VISIT: "Area First Visits",
 }
 
 # Pre-create category groups and map/area groups so they are always present during build.

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -73,6 +73,87 @@
   ],
   "goal": 0,
   "locations": {
+    "AREA_VISIT_1_RAINBOW_ROUTE": {
+      "category": "AREA_VISIT",
+      "label": "Rainbow Route - First Visit",
+      "location_id": 3960451,
+      "tags": [
+        "AreaVisit",
+        "MAP_RAINBOW_ROUTE"
+      ]
+    },
+    "AREA_VISIT_2_MOONLIGHT_MANSION": {
+      "category": "AREA_VISIT",
+      "label": "Moonlight Mansion - First Visit",
+      "location_id": 3960452,
+      "tags": [
+        "AreaVisit",
+        "MAP_MOONLIGHT_MANSION"
+      ]
+    },
+    "AREA_VISIT_3_CABBAGE_CAVERN": {
+      "category": "AREA_VISIT",
+      "label": "Cabbage Cavern - First Visit",
+      "location_id": 3960453,
+      "tags": [
+        "AreaVisit",
+        "MAP_CABBAGE_CAVERN"
+      ]
+    },
+    "AREA_VISIT_4_MUSTARD_MOUNTAIN": {
+      "category": "AREA_VISIT",
+      "label": "Mustard Mountain - First Visit",
+      "location_id": 3960454,
+      "tags": [
+        "AreaVisit",
+        "MAP_MUSTARD_MOUNTAIN"
+      ]
+    },
+    "AREA_VISIT_5_CARROT_CASTLE": {
+      "category": "AREA_VISIT",
+      "label": "Carrot Castle - First Visit",
+      "location_id": 3960455,
+      "tags": [
+        "AreaVisit",
+        "MAP_CARROT_CASTLE"
+      ]
+    },
+    "AREA_VISIT_6_OLIVE_OCEAN": {
+      "category": "AREA_VISIT",
+      "label": "Olive Ocean - First Visit",
+      "location_id": 3960456,
+      "tags": [
+        "AreaVisit",
+        "MAP_OLIVE_OCEAN"
+      ]
+    },
+    "AREA_VISIT_7_PEPPERMINT_PALACE": {
+      "category": "AREA_VISIT",
+      "label": "Peppermint Palace - First Visit",
+      "location_id": 3960457,
+      "tags": [
+        "AreaVisit",
+        "MAP_PEPPERMINT_PALACE"
+      ]
+    },
+    "AREA_VISIT_8_RADISH_RUINS": {
+      "category": "AREA_VISIT",
+      "label": "Radish Ruins - First Visit",
+      "location_id": 3960458,
+      "tags": [
+        "AreaVisit",
+        "MAP_RADISH_RUINS"
+      ]
+    },
+    "AREA_VISIT_9_CANDY_CONSTELLATION": {
+      "category": "AREA_VISIT",
+      "label": "Candy Constellation - First Visit",
+      "location_id": 3960459,
+      "tags": [
+        "AreaVisit",
+        "MAP_CANDY_CONSTELLATION"
+      ]
+    },
     "BOSS_DEFEAT_1": {
       "category": "BOSS_DEFEAT",
       "label": "Mustard Mountain - Boss Defeat",

--- a/worlds/kirbyam/test/test_area_first_visit_polling.py
+++ b/worlds/kirbyam/test/test_area_first_visit_polling.py
@@ -1,0 +1,102 @@
+"""Area-first-visit polling tests for native gVisitedDoors -> LocationChecks mapping."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ..client import KirbyAmClient
+from ..data import data
+
+
+def _room_visit_bytes(*visited_doors_idx: int) -> bytes:
+    payload = bytearray(0x120 * 2)
+    for doors_idx in visited_doors_idx:
+        if 0 <= doors_idx < 0x120:
+            offset = doors_idx * 2
+            payload[offset:offset + 2] = (0x8000).to_bytes(2, "little")
+    return bytes(payload)
+
+
+@pytest.mark.asyncio
+async def test_poll_area_visit_sends_one_check_per_visited_area(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.checked_locations = set()
+
+    area_1_location_id = data.locations["AREA_VISIT_1_RAINBOW_ROUTE"].location_id
+    area_2_location_id = data.locations["AREA_VISIT_2_MOONLIGHT_MANSION"].location_id
+
+    room_1_data = data.locations["ROOM_SANITY_1_01"]
+    room_1_alt_data = data.locations["ROOM_SANITY_1_02"]
+    room_2_data = data.locations["ROOM_SANITY_2_01"]
+    assert room_1_data.bit_index is not None
+    assert room_1_alt_data.bit_index is not None
+    assert room_2_data.bit_index is not None
+
+    with patch.dict(data.native_ram_addresses, {"room_visit_flags_native": 0x02028CA0}, clear=False), \
+         patch("worlds.kirbyam.client.bizhawk.read", new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, "send_msgs", new_callable=AsyncMock) as mock_send:
+        # Visiting multiple rooms in one area still yields only one area check.
+        mock_read.return_value = [
+            _room_visit_bytes(room_1_data.bit_index, room_1_alt_data.bit_index, room_2_data.bit_index)
+        ]
+
+        await client._poll_area_visit_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [area_1_location_id, area_2_location_id]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_poll_area_visit_dedupes_already_acknowledged(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    area_1_location_id = data.locations["AREA_VISIT_1_RAINBOW_ROUTE"].location_id
+    room_1_data = data.locations["ROOM_SANITY_1_01"]
+    assert room_1_data.bit_index is not None
+
+    mock_bizhawk_context.checked_locations = {area_1_location_id}
+
+    with patch.dict(data.native_ram_addresses, {"room_visit_flags_native": 0x02028CA0}, clear=False), \
+         patch("worlds.kirbyam.client.bizhawk.read", new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, "send_msgs", new_callable=AsyncMock) as mock_send, \
+         patch("CommonClient.logger") as mock_logger:
+        mock_read.return_value = [_room_visit_bytes(room_1_data.bit_index)]
+
+        await client._poll_area_visit_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
+    mock_logger.debug.assert_called_once()
+    debug_args = mock_logger.debug.call_args.args
+    assert "dedupe suppressed area-first-visit LocationChecks" in debug_args[0]
+    assert debug_args[1] == [area_1_location_id]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_area_visit_resends_once_then_dedupes(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    area_1_location_id = data.locations["AREA_VISIT_1_RAINBOW_ROUTE"].location_id
+    room_1_data = data.locations["ROOM_SANITY_1_01"]
+    assert room_1_data.bit_index is not None
+
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.native_ram_addresses, {"room_visit_flags_native": 0x02028CA0}, clear=False), \
+         patch("worlds.kirbyam.client.bizhawk.read", new_callable=AsyncMock) as mock_read:
+        mock_read.return_value = [_room_visit_bytes(room_1_data.bit_index)]
+        await client._poll_area_visit_locations(mock_bizhawk_context)
+
+        mock_bizhawk_context.checked_locations = {area_1_location_id}
+        mock_read.return_value = [_room_visit_bytes(room_1_data.bit_index)]
+        await client._poll_area_visit_locations(mock_bizhawk_context)
+
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [area_1_location_id]}
+    ])

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1025,6 +1025,23 @@ def test_hub_switch_data_sanity():
     assert len(bits) == len(set(bits))
 
 
+def test_area_visit_data_sanity():
+    """Area-first-visit entries should have explicit unique IDs and area IDs 1..9."""
+    area_visits = [
+        loc for loc in data.locations.values()
+        if loc.category.name == "AREA_VISIT"
+    ]
+
+    assert len(area_visits) == 9
+
+    ids = [loc.location_id for loc in area_visits]
+    assert all(loc_id is not None for loc_id in ids)
+    assert len(ids) == len(set(ids))
+
+    bits = sorted(loc.bit_index for loc in area_visits if loc.bit_index is not None)
+    assert bits == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
 def test_client_initialization():
     """Test client state is properly initialized."""
     client = KirbyAmClient()
@@ -2974,6 +2991,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality, \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player, \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switch, \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock) as mock_poll_area_visit, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe_boss, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
          patch.object(client, '_deliver_items', new_callable=AsyncMock) as mock_deliver, \
@@ -2993,6 +3011,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
     mock_poll_vitality.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_sound_player.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_hub_switch.assert_awaited_once_with(mock_bizhawk_context)
+    mock_poll_area_visit.assert_awaited_once_with(mock_bizhawk_context)
     mock_probe_boss.assert_awaited_once_with(mock_bizhawk_context)
     mock_probe_unsafe.assert_awaited_once_with(mock_bizhawk_context)
     mock_deliver.assert_awaited_once_with(mock_bizhawk_context)
@@ -3106,6 +3125,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
             patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality_chests, \
             patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player_chests, \
                 patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switches, \
+                patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock) as mock_poll_area_visits, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
          patch.object(client, '_deliver_items', new_callable=AsyncMock) as mock_deliver, \
@@ -3142,6 +3162,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         mock_poll_vitality_chests.assert_awaited_once()
         mock_poll_sound_player_chests.assert_awaited_once()
         mock_poll_hub_switches.assert_awaited_once()
+        mock_poll_area_visits.assert_awaited_once()
         mock_probe.assert_awaited_once()
         mock_probe_unsafe.assert_awaited_once()
         mock_deliver.assert_awaited_once_with(mock_bizhawk_context)
@@ -3170,6 +3191,7 @@ async def test_game_watcher_reconnect_entry_emits_file_only_session_ready_log(mo
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
@@ -3382,6 +3404,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \
@@ -3439,6 +3462,7 @@ async def test_game_watcher_emits_runtime_gate_logs_file_only(mock_bizhawk_conte
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
@@ -3486,6 +3510,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \
@@ -3516,6 +3541,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -390,6 +390,7 @@ def test_vanilla_shards_are_locked_to_boss_defeats() -> None:
     _minor_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MINOR_CHEST)
     _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
+    _area_visit_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.AREA_VISIT)
     _expected_pool_size = (
         _major_chest_count
         + _vitality_chest_count
@@ -397,6 +398,7 @@ def test_vanilla_shards_are_locked_to_boss_defeats() -> None:
         + _minor_chest_count
         + _hub_switch_count
         + _room_sanity_count
+        + _area_visit_count
     )
     assert len(world.multiworld.itempool) == _expected_pool_size
     assert all("Mirror Shard" not in item.name for item in world.multiworld.itempool)
@@ -418,6 +420,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
     _minor_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MINOR_CHEST)
     _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
+    _area_visit_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.AREA_VISIT)
     _shard_item_count = len(KirbyAmWorld._SHARD_ITEM_LABEL_ORDER)
     _open_non_goal_location_count = (
         _boss_defeat_count
@@ -427,6 +430,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
         + _minor_chest_count
         + _hub_switch_count
         + _room_sanity_count
+        + _area_visit_count
     )
     _expected_pool_size = _open_non_goal_location_count
     assert len(world.multiworld.itempool) == _expected_pool_size

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -136,6 +136,9 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_room_entry_logging', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
          patch.object(client, '_deliver_items', new_callable=AsyncMock), \


### PR DESCRIPTION
## Summary
- add 9 AREA_VISIT locations (Areas 1-9) with stable IDs and map tags
- poll native gVisitedDoors to emit one first-visit LocationCheck per area with reconnect-safe dedupe
- include AREA_VISIT locations in item pool generation and location groups
- add targeted tests for area-first-visit polling and update existing pool/watcher/client tests
- update PROTOCOL and Unreleased changelog entries

## Validation
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_area_first_visit_polling.py worlds/kirbyam/test/test_room_sanity_polling.py worlds/kirbyam/test/test_item_pool.py worlds/kirbyam/test/test_client.py -k "area_visit or room_sanity or game_watcher_reloads_state_after_transport_recovery or game_watcher_reconnect_entry or area_visit_data_sanity or vanilla_shards_are_locked_to_boss_defeats or completely_random_pool_contains_all_shards_but_bosses_are_unlocked"