### PR TITLE
Fix /locations output when Room Sanity is disabled

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -124,64 +124,65 @@ _ABILITY_REROLL_SOURCE_KIND_TO_LABEL: dict[int, str] = {
 }
 
 
-def _kirbyam_cmd_locations(self) -> bool:
-    """List active location names for theanales current KirbyAM seed when available."""
-    if getattr(self.ctx, "game", None) != KirbyAmClient.game:
-        return super(type(self), self)._cmd_locations()
+def _build_kirbyam_command_processor(base_command_processor: type) -> type:
+    _base_cls = base_command_processor
 
-    slot_data = getattr(self.ctx, "slot_data", None)
-    slot_locations = slot_data.get("locations") if isinstance(slot_data, dict) else None
-    if not isinstance(slot_locations, dict):
-        return super(type(self), self)._cmd_locations()
+    def _cmd_locations(self) -> bool:
+        """List active location names for the current KirbyAM seed when available."""
+        if getattr(self.ctx, "game", None) != KirbyAmClient.game:
+            return _base_cls._cmd_locations(self)
 
-    server_locations = getattr(self.ctx, "server_locations", None)
-    if not isinstance(server_locations, set):
-        missing_locations = getattr(self.ctx, "missing_locations", None)
-        checked_locations = getattr(self.ctx, "checked_locations", None)
-        if isinstance(missing_locations, set) and isinstance(checked_locations, set):
-            server_locations = missing_locations | checked_locations
-        else:
-            server_locations = None
+        slot_data = getattr(self.ctx, "slot_data", None)
+        slot_locations = slot_data.get("locations") if isinstance(slot_data, dict) else None
+        if not isinstance(slot_locations, dict):
+            return _base_cls._cmd_locations(self)
 
-    if not server_locations:
-        return super(type(self), self)._cmd_locations()
+        server_locations = getattr(self.ctx, "server_locations", None)
+        if not isinstance(server_locations, set):
+            missing_locations = getattr(self.ctx, "missing_locations", None)
+            checked_locations = getattr(self.ctx, "checked_locations", None)
+            if isinstance(missing_locations, set) and isinstance(checked_locations, set):
+                server_locations = missing_locations | checked_locations
+            else:
+                server_locations = None
 
-    location_names_lookup = getattr(self.ctx, "location_names", None)
-    try:
-        location_names = location_names_lookup[self.ctx.game] if location_names_lookup is not None else {}
-    except (KeyError, TypeError):
-        location_names = {}
-    active_location_labels: dict[int, str] = {}
-    for location_meta in slot_locations.values():
-        if not isinstance(location_meta, dict):
-            continue
-        location_id = location_meta.get("location_id")
-        label = location_meta.get("label")
-        if isinstance(location_id, int) and location_id in server_locations and isinstance(label, str):
-            active_location_labels[location_id] = label
+        if not server_locations:
+            return _base_cls._cmd_locations(self)
 
-    if not active_location_labels:
-        for location_id in server_locations:
-            if location_id < 0:
+        location_names_lookup = getattr(self.ctx, "location_names", None)
+        try:
+            location_names = location_names_lookup[self.ctx.game] if location_names_lookup is not None else {}
+        except (KeyError, TypeError):
+            location_names = {}
+        active_location_labels: dict[int, str] = {}
+        for location_meta in slot_locations.values():
+            if not isinstance(location_meta, dict):
                 continue
-            label = location_names.get(location_id)
-            if isinstance(label, str):
+            location_id = location_meta.get("location_id")
+            label = location_meta.get("label")
+            if isinstance(location_id, int) and location_id in server_locations and isinstance(label, str):
                 active_location_labels[location_id] = label
 
-    if not active_location_labels:
-        return super(type(self), self)._cmd_locations()
+        if not active_location_labels:
+            for location_id in server_locations:
+                if location_id < 0:
+                    continue
+                label = location_names.get(location_id)
+                if isinstance(label, str):
+                    active_location_labels[location_id] = label
 
-    self.output(f"Active Locations for {self.ctx.game}")
-    for location_id in sorted(active_location_labels):
-        self.output(active_location_labels[location_id])
-    return True
+        if not active_location_labels:
+            return _base_cls._cmd_locations(self)
 
+        self.output(f"Active Locations for {self.ctx.game}")
+        for location_id in sorted(active_location_labels):
+            self.output(active_location_labels[location_id])
+        return True
 
-def _build_kirbyam_command_processor(base_command_processor: type) -> type:
     return type(
         "KirbyAmCommandProcessor",
         (base_command_processor,),
-        {"_cmd_locations": _kirbyam_cmd_locations},
+        {"_cmd_locations": _cmd_locations, "_is_kirbyam_wrapper": True},
     )
 
 
@@ -1141,12 +1142,12 @@ class KirbyAmClient(BizHawkClient):
         ctx.items_handling = 0b001
         ctx.want_slot_data = True
         ctx.watcher_timeout = 0.125
-        base_command_processor = ctx.command_processor
-        if not isinstance(base_command_processor, type):
-            from worlds._bizhawk.context import BizHawkClientCommandProcessor
-
-            base_command_processor = BizHawkClientCommandProcessor
-        ctx.command_processor = _build_kirbyam_command_processor(base_command_processor)
+        base_command_processor = getattr(ctx, "command_processor", None)
+        if base_command_processor is not None:
+            if not isinstance(base_command_processor, type):
+                base_command_processor = base_command_processor.__class__
+            if not getattr(base_command_processor, "_is_kirbyam_wrapper", False):
+                ctx.command_processor = _build_kirbyam_command_processor(base_command_processor)
 
         self.initialize_client()
         self._log_client("info", "KirbyAM: ROM validated.")

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -146,7 +146,11 @@ def _kirbyam_cmd_locations(self) -> bool:
     if not server_locations:
         return super(type(self), self)._cmd_locations()
 
-    location_names = getattr(self.ctx, "location_names", {}).get(self.ctx.game, {})
+    location_names_lookup = getattr(self.ctx, "location_names", None)
+    try:
+        location_names = location_names_lookup[self.ctx.game] if location_names_lookup is not None else {}
+    except (KeyError, TypeError):
+        location_names = {}
     active_location_labels: dict[int, str] = {}
     for location_meta in slot_locations.values():
         if not isinstance(location_meta, dict):

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Optional
 import Utils
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
-from worlds._bizhawk.context import BizHawkClientCommandProcessor
 
 from .data import LocationCategory, data, format_room_region_label, load_json_data
 from .enemy_ability_data import ABILITY_SOURCES
@@ -125,54 +124,61 @@ _ABILITY_REROLL_SOURCE_KIND_TO_LABEL: dict[int, str] = {
 }
 
 
-class KirbyAmCommandProcessor(BizHawkClientCommandProcessor):
-    def _cmd_locations(self) -> bool:
-        """List active location names for the current KirbyAM seed when available."""
-        if getattr(self.ctx, "game", None) != KirbyAmClient.game:
-            return super()._cmd_locations()
+def _kirbyam_cmd_locations(self) -> bool:
+    """List active location names for theanales current KirbyAM seed when available."""
+    if getattr(self.ctx, "game", None) != KirbyAmClient.game:
+        return super(type(self), self)._cmd_locations()
 
-        slot_data = getattr(self.ctx, "slot_data", None)
-        slot_locations = slot_data.get("locations") if isinstance(slot_data, dict) else None
-        if not isinstance(slot_locations, dict):
-            return super()._cmd_locations()
+    slot_data = getattr(self.ctx, "slot_data", None)
+    slot_locations = slot_data.get("locations") if isinstance(slot_data, dict) else None
+    if not isinstance(slot_locations, dict):
+        return super(type(self), self)._cmd_locations()
 
-        server_locations = getattr(self.ctx, "server_locations", None)
-        if not isinstance(server_locations, set):
-            missing_locations = getattr(self.ctx, "missing_locations", None)
-            checked_locations = getattr(self.ctx, "checked_locations", None)
-            if isinstance(missing_locations, set) and isinstance(checked_locations, set):
-                server_locations = missing_locations | checked_locations
-            else:
-                server_locations = None
+    server_locations = getattr(self.ctx, "server_locations", None)
+    if not isinstance(server_locations, set):
+        missing_locations = getattr(self.ctx, "missing_locations", None)
+        checked_locations = getattr(self.ctx, "checked_locations", None)
+        if isinstance(missing_locations, set) and isinstance(checked_locations, set):
+            server_locations = missing_locations | checked_locations
+        else:
+            server_locations = None
 
-        if not server_locations:
-            return super()._cmd_locations()
+    if not server_locations:
+        return super(type(self), self)._cmd_locations()
 
-        location_names = getattr(self.ctx, "location_names", {}).get(self.ctx.game, {})
-        active_location_labels: dict[int, str] = {}
-        for location_meta in slot_locations.values():
-            if not isinstance(location_meta, dict):
+    location_names = getattr(self.ctx, "location_names", {}).get(self.ctx.game, {})
+    active_location_labels: dict[int, str] = {}
+    for location_meta in slot_locations.values():
+        if not isinstance(location_meta, dict):
+            continue
+        location_id = location_meta.get("location_id")
+        label = location_meta.get("label")
+        if isinstance(location_id, int) and location_id in server_locations and isinstance(label, str):
+            active_location_labels[location_id] = label
+
+    if not active_location_labels:
+        for location_id in server_locations:
+            if location_id < 0:
                 continue
-            location_id = location_meta.get("location_id")
-            label = location_meta.get("label")
-            if isinstance(location_id, int) and location_id in server_locations and isinstance(label, str):
+            label = location_names.get(location_id)
+            if isinstance(label, str):
                 active_location_labels[location_id] = label
 
-        if not active_location_labels:
-            for location_id in server_locations:
-                if location_id < 0:
-                    continue
-                label = location_names.get(location_id)
-                if isinstance(label, str):
-                    active_location_labels[location_id] = label
+    if not active_location_labels:
+        return super(type(self), self)._cmd_locations()
 
-        if not active_location_labels:
-            return super()._cmd_locations()
+    self.output(f"Active Locations for {self.ctx.game}")
+    for location_id in sorted(active_location_labels):
+        self.output(active_location_labels[location_id])
+    return True
 
-        self.output(f"Active Locations for {self.ctx.game}")
-        for location_id in sorted(active_location_labels):
-            self.output(active_location_labels[location_id])
-        return True
+
+def _build_kirbyam_command_processor(base_command_processor: type) -> type:
+    return type(
+        "KirbyAmCommandProcessor",
+        (base_command_processor,),
+        {"_cmd_locations": _kirbyam_cmd_locations},
+    )
 
 
 def _normalize_gba_rom_address(value: int) -> int:
@@ -1131,8 +1137,12 @@ class KirbyAmClient(BizHawkClient):
         ctx.items_handling = 0b001
         ctx.want_slot_data = True
         ctx.watcher_timeout = 0.125
-        ctx.command_processor = KirbyAmCommandProcessor
-        BizHawkClientCommandProcessor.commands["locations"] = KirbyAmCommandProcessor.commands["locations"]
+        base_command_processor = ctx.command_processor
+        if not isinstance(base_command_processor, type):
+            from worlds._bizhawk.context import BizHawkClientCommandProcessor
+
+            base_command_processor = BizHawkClientCommandProcessor
+        ctx.command_processor = _build_kirbyam_command_processor(base_command_processor)
 
         self.initialize_client()
         self._log_client("info", "KirbyAM: ROM validated.")

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import Utils
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import BizHawkClient
+from worlds._bizhawk.context import BizHawkClientCommandProcessor
 
 from .data import LocationCategory, data, format_room_region_label, load_json_data
 from .enemy_ability_data import ABILITY_SOURCES
@@ -122,6 +123,56 @@ _ABILITY_REROLL_SOURCE_KIND_TO_LABEL: dict[int, str] = {
     2: "NULL_SOURCE_PTR",
     3: "NON_EWRAM_SOURCE_PTR",
 }
+
+
+class KirbyAmCommandProcessor(BizHawkClientCommandProcessor):
+    def _cmd_locations(self) -> bool:
+        """List active location names for the current KirbyAM seed when available."""
+        if getattr(self.ctx, "game", None) != KirbyAmClient.game:
+            return super()._cmd_locations()
+
+        slot_data = getattr(self.ctx, "slot_data", None)
+        slot_locations = slot_data.get("locations") if isinstance(slot_data, dict) else None
+        if not isinstance(slot_locations, dict):
+            return super()._cmd_locations()
+
+        server_locations = getattr(self.ctx, "server_locations", None)
+        if not isinstance(server_locations, set):
+            missing_locations = getattr(self.ctx, "missing_locations", None)
+            checked_locations = getattr(self.ctx, "checked_locations", None)
+            if isinstance(missing_locations, set) and isinstance(checked_locations, set):
+                server_locations = missing_locations | checked_locations
+            else:
+                server_locations = None
+
+        if not server_locations:
+            return super()._cmd_locations()
+
+        location_names = getattr(self.ctx, "location_names", {}).get(self.ctx.game, {})
+        active_location_labels: dict[int, str] = {}
+        for location_meta in slot_locations.values():
+            if not isinstance(location_meta, dict):
+                continue
+            location_id = location_meta.get("location_id")
+            label = location_meta.get("label")
+            if isinstance(location_id, int) and location_id in server_locations and isinstance(label, str):
+                active_location_labels[location_id] = label
+
+        if not active_location_labels:
+            for location_id in server_locations:
+                if location_id < 0:
+                    continue
+                label = location_names.get(location_id)
+                if isinstance(label, str):
+                    active_location_labels[location_id] = label
+
+        if not active_location_labels:
+            return super()._cmd_locations()
+
+        self.output(f"Active Locations for {self.ctx.game}")
+        for location_id in sorted(active_location_labels):
+            self.output(active_location_labels[location_id])
+        return True
 
 
 def _normalize_gba_rom_address(value: int) -> int:
@@ -1080,6 +1131,8 @@ class KirbyAmClient(BizHawkClient):
         ctx.items_handling = 0b001
         ctx.want_slot_data = True
         ctx.watcher_timeout = 0.125
+        ctx.command_processor = KirbyAmCommandProcessor
+        BizHawkClientCommandProcessor.commands["locations"] = KirbyAmCommandProcessor.commands["locations"]
 
         self.initialize_client()
         self._log_client("info", "KirbyAM: ROM validated.")

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -186,6 +186,26 @@ def _build_kirbyam_command_processor(base_command_processor: type) -> type:
     )
 
 
+def _patch_kirbyam_command_processor(base_command_processor: type) -> type:
+    if getattr(base_command_processor, "_kirbyam_runtime_patched", False):
+        return base_command_processor
+
+    wrapped_command_processor = _build_kirbyam_command_processor(base_command_processor)
+    for attr_name, attr_value in wrapped_command_processor.__dict__.items():
+        if attr_name in {"__dict__", "__doc__", "__module__", "__weakref__"}:
+            continue
+        if attr_name == "_is_kirbyam_wrapper":
+            continue
+        if hasattr(base_command_processor, attr_name):
+            original_attr_name = f"_kirbyam_original_{attr_name}"
+            if not hasattr(base_command_processor, original_attr_name):
+                setattr(base_command_processor, original_attr_name, getattr(base_command_processor, attr_name))
+        setattr(base_command_processor, attr_name, attr_value)
+
+    setattr(base_command_processor, "_kirbyam_runtime_patched", True)
+    return base_command_processor
+
+
 def _normalize_gba_rom_address(value: int) -> int:
     if 0x08000000 <= value < 0x0A000000:
         return value - 0x08000000
@@ -1146,8 +1166,7 @@ class KirbyAmClient(BizHawkClient):
         if base_command_processor is not None:
             if not isinstance(base_command_processor, type):
                 base_command_processor = base_command_processor.__class__
-            if not getattr(base_command_processor, "_is_kirbyam_wrapper", False):
-                ctx.command_processor = _build_kirbyam_command_processor(base_command_processor)
+            ctx.command_processor = _patch_kirbyam_command_processor(base_command_processor)
 
         self.initialize_client()
         self._log_client("info", "KirbyAM: ROM validated.")

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -10,7 +10,7 @@ from worlds._bizhawk.context import _game_watcher, AuthStatus
 from ..data import LocationCategory, data
 from ..client import (
     KirbyAmClient,
-    KirbyAmCommandProcessor,
+    _build_kirbyam_command_processor,
     _MAP_ITEM_ID_TO_AREA_ID,
     _ROOM_PROPS_DOORS_IDX_OFFSET,
     _ROOM_PROPS_ROM_BASE,
@@ -34,11 +34,22 @@ async def test_validate_rom_accepts_patched_kirby_header(mock_bizhawk_context):
         assert await client.validate_rom(mock_bizhawk_context) is True
         assert mock_bizhawk_context.game == client.game
         assert mock_bizhawk_context.want_slot_data is True
-        assert mock_bizhawk_context.command_processor is KirbyAmCommandProcessor
+        assert mock_bizhawk_context.command_processor.__name__ == "KirbyAmCommandProcessor"
 
 
 def test_locations_command_lists_only_active_server_locations_for_kirbyam(mock_bizhawk_context):
-    processor = KirbyAmCommandProcessor(mock_bizhawk_context)
+    class BaseCommandProcessor:
+        def __init__(self, ctx):
+            self.ctx = ctx
+
+        def _cmd_locations(self):
+            return False
+
+        def output(self, text):
+            return None
+
+    processor_cls = _build_kirbyam_command_processor(BaseCommandProcessor)
+    processor = processor_cls(mock_bizhawk_context)
     room_sanity_location = next(
         loc for loc in data.locations.values() if loc.category == LocationCategory.ROOM_SANITY
     )
@@ -82,7 +93,21 @@ def test_locations_command_lists_only_active_server_locations_for_kirbyam(mock_b
 
 
 def test_locations_command_falls_back_to_datapackage_without_server_state(mock_bizhawk_context):
-    processor = KirbyAmCommandProcessor(mock_bizhawk_context)
+    class BaseCommandProcessor:
+        def __init__(self, ctx):
+            self.ctx = ctx
+
+        def _cmd_locations(self):
+            self.output(f"Location Names for {self.ctx.game}")
+            for name in self.ctx.location_names[self.ctx.game].values():
+                self.output(name)
+            return True
+
+        def output(self, text):
+            return None
+
+    processor_cls = _build_kirbyam_command_processor(BaseCommandProcessor)
+    processor = processor_cls(mock_bizhawk_context)
     room_sanity_location = next(
         loc for loc in data.locations.values() if loc.category == LocationCategory.ROOM_SANITY
     )

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -5,7 +5,7 @@ import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import worlds._bizhawk as bizhawk
-from worlds._bizhawk.context import _game_watcher, AuthStatus
+from worlds._bizhawk.context import _game_watcher, AuthStatus, BizHawkClientCommandProcessor
 
 from ..data import LocationCategory, data
 from ..client import (
@@ -24,6 +24,7 @@ from ..rom import KirbyAmProcedurePatch
 @pytest.mark.asyncio
 async def test_validate_rom_accepts_patched_kirby_header(mock_bizhawk_context):
     client = KirbyAmClient()
+    mock_bizhawk_context.command_processor = BizHawkClientCommandProcessor
 
     with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
         mock_read.side_effect = [

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -135,6 +135,46 @@ def test_locations_command_falls_back_to_datapackage_without_server_state(mock_b
     assert room_sanity_location.label in outputs
 
 
+def test_locations_command_supports_name_lookup_dict_style_access(mock_bizhawk_context):
+    class BaseCommandProcessor:
+        def __init__(self, ctx):
+            self.ctx = ctx
+
+        def _cmd_locations(self):
+            return False
+
+        def output(self, text):
+            return None
+
+    class NameLookupStub:
+        def __init__(self, mapping):
+            self._mapping = mapping
+
+        def __getitem__(self, key):
+            return self._mapping[key]
+
+    processor_cls = _build_kirbyam_command_processor(BaseCommandProcessor)
+    processor = processor_cls(mock_bizhawk_context)
+    active_location = next(
+        loc
+        for loc in data.locations.values()
+        if loc.location_id is not None and loc.category == LocationCategory.BOSS_DEFEAT
+    )
+    mock_bizhawk_context.game = KirbyAmClient.game
+    mock_bizhawk_context.server_locations = {active_location.location_id}
+    mock_bizhawk_context.location_names = NameLookupStub({
+        KirbyAmClient.game: {active_location.location_id: active_location.label}
+    })
+    mock_bizhawk_context.slot_data = {"locations": {}}
+
+    with patch.object(processor, "output") as mock_output:
+        assert processor._cmd_locations() is True
+
+    outputs = [call.args[0] for call in mock_output.call_args_list]
+    assert outputs[0] == f"Active Locations for {KirbyAmClient.game}"
+    assert active_location.label in outputs
+
+
 @pytest.mark.asyncio
 async def test_validate_rom_reads_auth_from_rom_domain_offset(mock_bizhawk_context):
     client = KirbyAmClient()

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -10,6 +10,7 @@ from worlds._bizhawk.context import _game_watcher, AuthStatus
 from ..data import LocationCategory, data
 from ..client import (
     KirbyAmClient,
+    KirbyAmCommandProcessor,
     _MAP_ITEM_ID_TO_AREA_ID,
     _ROOM_PROPS_DOORS_IDX_OFFSET,
     _ROOM_PROPS_ROM_BASE,
@@ -33,6 +34,80 @@ async def test_validate_rom_accepts_patched_kirby_header(mock_bizhawk_context):
         assert await client.validate_rom(mock_bizhawk_context) is True
         assert mock_bizhawk_context.game == client.game
         assert mock_bizhawk_context.want_slot_data is True
+        assert mock_bizhawk_context.command_processor is KirbyAmCommandProcessor
+
+
+def test_locations_command_lists_only_active_server_locations_for_kirbyam(mock_bizhawk_context):
+    processor = KirbyAmCommandProcessor(mock_bizhawk_context)
+    room_sanity_location = next(
+        loc for loc in data.locations.values() if loc.category == LocationCategory.ROOM_SANITY
+    )
+    active_location = next(
+        loc
+        for loc in data.locations.values()
+        if loc.location_id is not None and loc.category == LocationCategory.BOSS_DEFEAT
+    )
+    mock_bizhawk_context.game = KirbyAmClient.game
+    mock_bizhawk_context.server_locations = {active_location.location_id}
+    mock_bizhawk_context.location_names = {
+        KirbyAmClient.game: {
+            active_location.location_id: active_location.label,
+            room_sanity_location.location_id: room_sanity_location.label,
+        }
+    }
+    mock_bizhawk_context.slot_data = {
+        "locations": {
+            "active": {
+                "label": active_location.label,
+                "location_id": active_location.location_id,
+                "category": active_location.category.name,
+                "tags": [],
+            },
+            "inactive_room": {
+                "label": room_sanity_location.label,
+                "location_id": room_sanity_location.location_id,
+                "category": room_sanity_location.category.name,
+                "tags": [],
+            },
+        }
+    }
+
+    with patch.object(processor, "output") as mock_output:
+        assert processor._cmd_locations() is True
+
+    outputs = [call.args[0] for call in mock_output.call_args_list]
+    assert outputs[0] == f"Active Locations for {KirbyAmClient.game}"
+    assert active_location.label in outputs
+    assert room_sanity_location.label not in outputs
+
+
+def test_locations_command_falls_back_to_datapackage_without_server_state(mock_bizhawk_context):
+    processor = KirbyAmCommandProcessor(mock_bizhawk_context)
+    room_sanity_location = next(
+        loc for loc in data.locations.values() if loc.category == LocationCategory.ROOM_SANITY
+    )
+    active_location = next(
+        loc
+        for loc in data.locations.values()
+        if loc.location_id is not None and loc.category == LocationCategory.BOSS_DEFEAT
+    )
+    mock_bizhawk_context.game = KirbyAmClient.game
+    mock_bizhawk_context.server_locations = set()
+    mock_bizhawk_context.location_names = {
+        KirbyAmClient.game: {
+            active_location.location_id: active_location.label,
+            room_sanity_location.location_id: room_sanity_location.label,
+        }
+    }
+    mock_bizhawk_context.slot_data = {"locations": {}}
+
+    with patch.object(processor, "output") as mock_output:
+        assert processor._cmd_locations() is True
+
+    outputs = [call.args[0] for call in mock_output.call_args_list]
+    assert outputs[0] == f"Location Names for {KirbyAmClient.game}"
+    assert active_location.label in outputs
+    assert room_sanity_location.label in outputs
 
 
 @pytest.mark.asyncio

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -23,8 +23,11 @@ from ..rom import KirbyAmProcedurePatch
 
 @pytest.mark.asyncio
 async def test_validate_rom_accepts_patched_kirby_header(mock_bizhawk_context):
+    class TestBizHawkClientCommandProcessor(BizHawkClientCommandProcessor):
+        pass
+
     client = KirbyAmClient()
-    mock_bizhawk_context.command_processor = BizHawkClientCommandProcessor
+    mock_bizhawk_context.command_processor = TestBizHawkClientCommandProcessor
 
     with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
         mock_read.side_effect = [
@@ -35,7 +38,8 @@ async def test_validate_rom_accepts_patched_kirby_header(mock_bizhawk_context):
         assert await client.validate_rom(mock_bizhawk_context) is True
         assert mock_bizhawk_context.game == client.game
         assert mock_bizhawk_context.want_slot_data is True
-        assert mock_bizhawk_context.command_processor.__name__ == "KirbyAmCommandProcessor"
+        assert mock_bizhawk_context.command_processor is TestBizHawkClientCommandProcessor
+        assert getattr(mock_bizhawk_context.command_processor, "_kirbyam_runtime_patched", False) is True
 
 
 def test_locations_command_lists_only_active_server_locations_for_kirbyam(mock_bizhawk_context):


### PR DESCRIPTION
## Summary
- override KirbyAM BizHawk `/locations` to list only locations active in the connected seed
- fall back to the generic datapackage listing when seed-specific server state is unavailable
- add command coverage for the Room Sanity disabled case and the fallback path

## Testing
- `d:/KirbyProject/local-files/.venv-kirbyam-313/Scripts/python.exe -m pytest worlds/kirbyam/test/test_client.py -k "locations_command or validate_rom_accepts_patched_kirby_header"`
- `d:/KirbyProject/local-files/.venv-kirbyam-313/Scripts/python.exe -m pytest worlds/kirbyam/test/test_room_sanity_polling.py`

Closes #731