### PR TITLE
Fix #742: reject non-KirbyAM compatible ROMs

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1155,10 +1155,7 @@ class KirbyAmClient(BizHawkClient):
                     game_code,
                     maker_code,
                 )
-                return await _fail(
-                    "header_mismatch",
-                    "Unable to load ROM: invalid Kirby and the Amazing Mirror ROM.",
-                )
+                return await _fail("header_mismatch")
         except bizhawk.RequestFailedError as exc:
             self._log_verbose("info", "KirbyAM: ROM header read failed during validation: %s", exc)
             return await _fail("header_read_failed", "Unable to load ROM: could not read ROM header data.")

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1190,18 +1190,26 @@ class KirbyAmClient(BizHawkClient):
                 "Unable to load ROM: missing patch metadata. Rebuild your patched ROM.",
             )
 
-        # Diagnostics: verify the loaded ROM has a patched Thumb BL at the main hook site.
+        # Require the expected patched callsite so we only claim explicitly KirbyAM-patched ROMs.
         try:
             hook_bytes = (await bizhawk.read(ctx.bizhawk_ctx, [(_MAIN_HOOK_OFFSET, 4, "ROM")]))[0]
             if not is_thumb_bl_instruction(bytes(hook_bytes)):
                 self._log_client(
-                    "warning",
-                    "KirbyAM: main hook callsite at 0x%06X is not patched with a Thumb BL (found=%s). Loaded ROM may be incompatible with this payload build.",
+                    "error",
+                    "KirbyAM: main hook callsite at 0x%06X is not patched with a Thumb BL (found=%s). Refusing to claim this ROM.",
                     _MAIN_HOOK_OFFSET,
-                    bytes(hook_bytes).hex(" ")
+                    bytes(hook_bytes).hex(" "),
+                )
+                return await _fail(
+                    "main_hook_mismatch",
+                    "Unable to load ROM: this is not a compatible KirbyAM patched ROM.",
                 )
         except Exception as exc:
             self._log_verbose("info", "KirbyAM: main hook opcode probe failed during validation: %s", exc)
+            return await _fail(
+                "main_hook_probe_failed",
+                "Unable to load ROM: could not verify KirbyAM patch hook.",
+            )
 
         self._last_validation_failure_reason = None
 

--- a/worlds/kirbyam/test/test_bizhawk_connector_integration.py
+++ b/worlds/kirbyam/test/test_bizhawk_connector_integration.py
@@ -10,6 +10,7 @@ import pytest
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.client import AutoBizHawkClientRegister
 from worlds.kirbyam.client import (
+    _MAIN_HOOK_OFFSET,
     EXPECTED_ROM_GAME_CODE,
     EXPECTED_ROM_HEADER_TITLE,
     EXPECTED_ROM_MAKER_CODE,
@@ -33,6 +34,7 @@ def _seed_kirby_rom_header(connector: FakeBizHawkConnector) -> None:
     connector.set_bytes("ROM", 0xA0, EXPECTED_ROM_HEADER_TITLE.upper().encode("ascii"))
     connector.set_bytes("ROM", 0xAC, EXPECTED_ROM_GAME_CODE.upper().encode("ascii"))
     connector.set_bytes("ROM", 0xB0, EXPECTED_ROM_MAKER_CODE.encode("ascii"))
+    connector.set_bytes("ROM", _MAIN_HOOK_OFFSET, b"\x00\xF0\x00\xF8")
 
 
 @pytest.mark.asyncio
@@ -81,6 +83,33 @@ async def test_fake_connector_rejects_unpatched_base_rom_hash(monkeypatch: pytes
 
     connector = FakeBizHawkConnector(system="GBA", rom_hash=KirbyAmProcedurePatch.hash)
     _seed_kirby_rom_header(connector)
+    connector.set_bytes("ROM", auth_addr, bytes(range(1, 17)))
+    await connector.start()
+
+    monkeypatch.setattr(bizhawk, "BIZHAWK_SOCKET_PORT_RANGE_START", connector.port)
+    monkeypatch.setattr(bizhawk, "BIZHAWK_SOCKET_PORT_RANGE_SIZE", 1)
+
+    ctx = bizhawk.BizHawkContext()
+    try:
+        assert await bizhawk.connect(ctx)
+        client_ctx = SimpleNamespace(bizhawk_ctx=ctx, rom_hash=await bizhawk.get_hash(ctx))
+        handler = await AutoBizHawkClientRegister.get_handler(client_ctx, "GBA")
+        assert handler is None
+    finally:
+        bizhawk.disconnect(ctx)
+        await connector.close()
+
+
+@pytest.mark.asyncio
+async def test_fake_connector_does_not_claim_non_kirby_gba_rom(monkeypatch: pytest.MonkeyPatch) -> None:
+    auth_addr = data.rom_addresses.get("gArchipelagoInfo")
+    assert isinstance(auth_addr, int)
+    auth_addr = _normalize_gba_rom_address(auth_addr)
+
+    connector = FakeBizHawkConnector(system="GBA", rom_hash="firered-rom")
+    connector.set_bytes("ROM", 0xA0, b"POKEMON FIRE")
+    connector.set_bytes("ROM", 0xAC, b"BPRE")
+    connector.set_bytes("ROM", 0xB0, b"01")
     connector.set_bytes("ROM", auth_addr, bytes(range(1, 17)))
     await connector.start()
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -281,10 +281,7 @@ async def test_validate_rom_rejects_non_kirby_header(mock_bizhawk_context, caplo
         with caplog.at_level(logging.INFO):
             assert await client.validate_rom(mock_bizhawk_context) is False
 
-    mock_display.assert_awaited_once_with(
-        mock_bizhawk_context.bizhawk_ctx,
-        "Unable to load ROM: invalid Kirby and the Amazing Mirror ROM.",
-    )
+    mock_display.assert_not_awaited()
     assert "ROM validation failed" in caplog.text
 
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -33,6 +33,7 @@ async def test_validate_rom_accepts_patched_kirby_header(mock_bizhawk_context):
         mock_read.side_effect = [
             [b'AGB KIRBY AM', b'B8KE', b'01'],
             [b'\x01' + (b'\x00' * 15)],
+            [b'\x00\xF0\x00\xF8'],
         ]
 
         assert await client.validate_rom(mock_bizhawk_context) is True
@@ -191,6 +192,7 @@ async def test_validate_rom_reads_auth_from_rom_domain_offset(mock_bizhawk_conte
             mock_read.side_effect = [
                 [b'AGB KIRBY AM', b'B8KE', b'01'],
                 [b'\x01' + (b'\x00' * 15)],
+                [b'\x00\xF0\x00\xF8'],
             ]
 
             assert await client.validate_rom(mock_bizhawk_context) is True
@@ -305,6 +307,28 @@ async def test_validate_rom_rejects_empty_patch_metadata(mock_bizhawk_context, c
         "Unable to load ROM: missing patch metadata. Rebuild your patched ROM.",
     )
     assert "KirbyAM patch metadata was missing" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_validate_rom_rejects_missing_main_hook_patch(mock_bizhawk_context, caplog):
+    client = KirbyAmClient()
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display:
+        mock_read.side_effect = [
+            [b'AGB KIRBY AM', b'B8KE', b'01'],
+            [b'\x01' + (b'\x00' * 15)],
+            [b'\x00\x00\x00\x00'],
+        ]
+
+        with caplog.at_level(logging.INFO):
+            assert await client.validate_rom(mock_bizhawk_context) is False
+
+    mock_display.assert_awaited_once_with(
+        mock_bizhawk_context.bizhawk_ctx,
+        "Unable to load ROM: this is not a compatible KirbyAM patched ROM.",
+    )
+    assert "main hook callsite" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make main-hook opcode verification a required KirbyAM ROM validation gate
- reject ROMs when the expected KirbyAM hook is missing instead of only warning
- add ROM validation regression test coverage for missing-hook rejection

## Testing
- .\.venv\Scripts\python.exe -m pytest worlds/kirbyam/test/test_client.py -k "validate_rom"