### PR TITLE
Remove KirbyAM Area Key runtime and payload gating code

### DIFF
--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -78,9 +78,8 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x80   | 0x0203B080 | 4B | ability_reroll_source_addr_runtime | u32 | ROM → Client | ROM address of the ability-source byte for the **most recent** per-swallow reroll event only. This is a single-slot mailbox field; if multiple rerolls happen between client polls, earlier source addresses are overwritten and cannot be reconstructed. Used by the client to map the most recent source to an enemy name in telemetry (best-effort). |
 | 0x84   | 0x0203B084 | 4B | ability_reroll_ability_id_runtime | u32 | ROM → Client | Ability ID selected by the **most recent** per-swallow reroll event only. Pairs with `ability_reroll_source_addr_runtime` as a best-effort snapshot; if multiple rerolls happen between polls, intermediate ability IDs are overwritten. The client logs how many events were missed when `ability_reroll_event_counter_runtime` advances by more than 1. |
 | 0x88   | 0x0203B088 | 4B | ability_reroll_kirby_index_runtime | u32 | ROM → Client | Current player/Kirby slot index (`0..3`) for the **most recent** reroll event. The payload writes the active player index directly to this field and initializes it to `0`. |
-| 0x8C   | 0x0203B08C | 4B | area_key_bitfield_runtime | u32 | ROM ← Client | Bits 2–9 mirror permanently granted Area Key items. The Python client recomputes and rewrites this bitfield from already-delivered item history so special-door gating recovers after soft reset / fresh EWRAM initialization without waiting for mailbox replay order. |
 
-**Total: 144 bytes (0x0203B000 - 0x0203B08F)**
+**Total: 140 bytes (0x0203B000 - 0x0203B08B)**
 
 ### Native Game State (Referenced by AP; some fields are client-reconciled)
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -68,10 +68,6 @@ _STARTING_KIRBY_COLOR_MAX = 13
 _STARTING_KIRBY_COLOR_REVALIDATE_TICKS = 4
 _ABILITY_RUNTIME_CONFIG_REVALIDATE_TICKS = 4
 _CHALLENGE_RUNTIME_CONFIG_REVALIDATE_TICKS = 4
-_AREA_KEY_RUNTIME_REVALIDATE_TICKS = 4
-_AREA_KEY_FIRST_ITEM_ID = 3860036
-_AREA_KEY_LAST_ITEM_ID = 3860043
-_AREA_KEY_FIRST_AREA_ID = 2
 _OPTIONAL_UNSAFE_DELIVERY_COUNTERS = (
     ("shadow_kirby_encounters_native", "shadow_kirby_encounters"),
     ("mirra_encounters_native", "mirra_encounters"),
@@ -404,8 +400,6 @@ class KirbyAmClient(BizHawkClient):
         self._starting_kirby_color_synced_id: int | None = None
         self._starting_kirby_color_logged_signature: tuple[int, str] | None = None
         self._starting_kirby_color_revalidate_counter: int = 0
-        self._last_area_key_runtime_bitfield: int | None = None
-        self._area_key_runtime_revalidate_counter: int = 0
         self._last_challenge_runtime_config_signature: tuple[int, int] | None = None
         self._challenge_runtime_config_revalidate_counter: int = 0
 
@@ -548,8 +542,6 @@ class KirbyAmClient(BizHawkClient):
         self._starting_kirby_color_synced_id = None
         self._starting_kirby_color_logged_signature = None
         self._starting_kirby_color_revalidate_counter = 0
-        self._last_area_key_runtime_bitfield = None
-        self._area_key_runtime_revalidate_counter = 0
         self._last_challenge_runtime_config_signature = None
         self._challenge_runtime_config_revalidate_counter = 0
         self._cached_delivered_map_bits = 0
@@ -901,45 +893,6 @@ class KirbyAmClient(BizHawkClient):
             color_name,
             color_id,
         )
-
-    def _build_delivered_area_key_bitfield(self, ctx: "BizHawkClientContext") -> int:
-        delivered_items = getattr(ctx, "items_received", ())
-        delivered_count = min(self._max_delivered_item_index_seen, len(delivered_items))
-        area_key_bits = 0
-        for item in delivered_items[:delivered_count]:
-            item_fields = self._extract_delivery_item_fields(item)
-            if item_fields is None:
-                continue
-            item_id, _player_id = item_fields
-            if _AREA_KEY_FIRST_ITEM_ID <= item_id <= _AREA_KEY_LAST_ITEM_ID:
-                area_id = _AREA_KEY_FIRST_AREA_ID + (item_id - _AREA_KEY_FIRST_ITEM_ID)
-                area_key_bits |= 1 << area_id
-        return area_key_bits & 0xFFFFFFFF
-
-    async def _sync_area_key_runtime_config(self, ctx: "BizHawkClientContext") -> None:
-        area_key_addr = self._transport_addr("area_key_bitfield_runtime")
-        if area_key_addr is None:
-            return
-
-        desired_bitfield = self._build_delivered_area_key_bitfield(ctx)
-        if desired_bitfield == 0 and self._last_area_key_runtime_bitfield is None:
-            return
-        if self._last_area_key_runtime_bitfield == desired_bitfield:
-            self._area_key_runtime_revalidate_counter += 1
-            if self._area_key_runtime_revalidate_counter < _AREA_KEY_RUNTIME_REVALIDATE_TICKS:
-                return
-        self._area_key_runtime_revalidate_counter = 0
-
-        current_raw = (await bizhawk.read(ctx.bizhawk_ctx, [(area_key_addr, 4, "System Bus")]))[0]
-        if self._u32_le(current_raw) == desired_bitfield:
-            self._last_area_key_runtime_bitfield = desired_bitfield
-            return
-
-        await bizhawk.write(
-            ctx.bizhawk_ctx,
-            [(area_key_addr, int(desired_bitfield).to_bytes(4, "little"), "System Bus")],
-        )
-        self._last_area_key_runtime_bitfield = desired_bitfield
 
     @staticmethod
     def _player_name(ctx: "BizHawkClientContext", player_id: int) -> str:
@@ -1295,7 +1248,6 @@ class KirbyAmClient(BizHawkClient):
                 self._ram_state_loaded = True
 
             await self._sync_starting_kirby_color_runtime_config(ctx)
-            await self._sync_area_key_runtime_config(ctx)
 
             gameplay_active, defer_reason, ai_state = await self._runtime_gameplay_state(ctx)
             await self._log_boss_shard_debug_window(

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -35,8 +35,7 @@
       "ability_reroll_event_counter_runtime": "0x0203B07C",
       "ability_reroll_source_addr_runtime": "0x0203B080",
       "ability_reroll_ability_id_runtime": "0x0203B084",
-      "ability_reroll_kirby_index_runtime": "0x0203B088",
-      "area_key_bitfield_runtime": "0x0203B08C"
+      "ability_reroll_kirby_index_runtime": "0x0203B088"
     },
     "native": {
       "small_chest_flags_native": "0x02038960",

--- a/worlds/kirbyam/kirby_ap_payload/ap_payload.c
+++ b/worlds/kirbyam/kirby_ap_payload/ap_payload.c
@@ -52,7 +52,6 @@
 #define AP_ABILITY_REROLL_SOURCE_KIND (*(volatile uint32_t*)(AP_BASE + 0x5Cu))
 #define AP_ABILITY_REROLL_CALLSITE_PC (*(volatile uint32_t*)(AP_BASE + 0x60u))
 #define AP_ABILITY_REROLL_KIRBY_INDEX (*(volatile uint32_t*)(AP_BASE + 0x88u))
-#define AP_AREA_KEY_BITFIELD_RUNTIME (*(volatile uint32_t*)(AP_BASE + 0x8Cu))
 // Boss Defeat Transport Register (Issue #35: Boss-defeat locations with shard-delivery decoupling)
 // Written by ROM payload when an area boss is defeated; polled by Python client for location checks.
 // Bit N set <=> boss of area N was defeated (same bit ordering as shard_bitfield, bits 0-7 used).
@@ -219,82 +218,11 @@ typedef uint32_t (*KirbySpecialDoorVisitedFn)(uint16_t, uint16_t, uint8_t, uint8
 #define KIRBY_CURRENT_ROOM_ADDR 0x02023B28u
 #define KIRBY_CURRENT_ROOM      (*(volatile uint16_t*)(KIRBY_CURRENT_ROOM_ADDR))
 
-// doorsIdx -> area ID lookup for native room metadata.
-//
-// DERIVATION AND SYNCHRONIZATION:
-// This table maps each gRoomProps.doorsIdx value to its corresponding area ID (0-9).
-// The mapping is derived from:
-//  1. worlds/kirbyam/data/regions/rooms.json - room definitions and area assignments
-//  2. worlds/kirbyam/client.py - runtime rooms.json metadata lookups keyed by doorsIdx
-//  3. Matching each room's doorsIdx field against gRoomProps in the ROM
-//
-// DRIFT RISK:
-// If the native gRoomProps structure or doorsIdx assignments change between ROM
-// versions (or if room definitions are updated on the Python side), this table
-// can silently become stale. Stale entries cause incorrect Area Key gating in the
-// payload: mirrors to gated areas may be incorrectly allowed/denied.
-//
-// VALIDATION/REGENERATION:
-// - During AP validation: Python-side checks in worlds/kirbyam/client.py and
-//   worlds/kirbyam/test/test_area_first_visit_polling.py verify doorsIdx-driven
-//   room metadata and area visit behavior remain consistent with rooms.json.
-// - During ROM patch: patch_rom.py could generate a checksum of this table and
-//   embed it in the ROM payload, then have runtime code validate on cold boot.
-// - Manual inspection: Compare table entries against current gRoomProps definitions
-//   in the active ROM base, then against the Python-side rooms.json definitions.
-//
-// TODO: Implement table generation as a build artifact (C header generated from
-// rooms.json plus native-room metadata tooling) or add compile-time/runtime
-// checksum validation to detect drift.
-static const uint8_t gApDoorsIdxAreaIds[0x120] = {
-    /* 0x00 */  1,  0,  0,  0,  0,  0,  0,  0,  2,  5,  1,  1,  1,  1,  1,  1,
-    /* 0x10 */  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-    /* 0x20 */  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-    /* 0x30 */  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  2,  2,  2,
-    /* 0x40 */  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    /* 0x50 */  2,  2,  2,  2,  2,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,
-    /* 0x60 */  7,  5,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,
-    /* 0x70 */  7,  7,  7,  7,  7,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
-    /* 0x80 */  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  9,  9,
-    /* 0x90 */  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,
-    /* 0xA0 */  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  3,  3,  3,  3,  3,  3,
-    /* 0xB0 */  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  6,  6,
-    /* 0xC0 */  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,
-    /* 0xD0 */  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  3,  8,  8,  8,  8,
-    /* 0xE0 */  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,
-    /* 0xF0 */  8,  8,  8,  8,  8,  8,  8,  8,  8,  5,  5,  5,  5,  5,  5,  5,
-    /* 0x100 */  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  0,  0,
-    /* 0x110 */  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-};
-
 static uint16_t ap_room_doors_idx(uint16_t room_id) {
     if ((uint32_t)room_id >= ROOM_PROPS_ROOM_ID_LIMIT) {
         return 0xFFFFu;
     }
     return *(volatile uint16_t*)(ROOM_PROPS_BASE_ADDR + ((uint32_t)room_id * ROOM_PROPS_STRIDE) + ROOM_PROPS_DOORS_IDX_OFFSET);
-}
-
-static uint8_t ap_doors_idx_area_id(uint16_t doors_idx) {
-    uint8_t area_id;
-    if (doors_idx >= 0x120u) {
-        return 0u;
-    }
-    area_id = gApDoorsIdxAreaIds[doors_idx];
-    if (area_id > 9u) {
-        return 0u;
-    }
-    return area_id;
-}
-
-static uint8_t ap_room_area_id(uint16_t room_id) {
-    return ap_doors_idx_area_id(ap_room_doors_idx(room_id));
-}
-
-static uint8_t ap_has_area_key(uint8_t area_id) {
-    if (area_id < 2u || area_id > 9u) {
-        return 1u;
-    }
-    return (uint8_t)((AP_AREA_KEY_BITFIELD_RUNTIME >> area_id) & 1u);
 }
 
 static uint8_t ap_is_warp_room_doors_idx(uint16_t doors_idx) {
@@ -314,12 +242,6 @@ static uint8_t ap_is_warp_room_doors_idx(uint16_t doors_idx) {
 
 __attribute__((used)) uint32_t ap_on_query_special_door_state(uint16_t room_id, uint16_t arg1, uint8_t arg2, uint8_t arg3) {
     uint32_t native_result = KIRBY_SPECIAL_DOOR_VISITED_FN(room_id, arg1, arg2, arg3);
-    uint8_t runtime_source_area;
-    uint8_t room_id_area;
-    uint8_t arg1_area;
-    uint8_t room_id_doors_area;
-    uint8_t arg1_doors_area;
-    uint8_t destination_area = 0u;
     uint16_t runtime_source_doors_idx;
 
     if (native_result == 0u) {
@@ -327,45 +249,9 @@ __attribute__((used)) uint32_t ap_on_query_special_door_state(uint16_t room_id, 
     }
 
     // Warp Star access is intentionally disabled in AP mode because these
-    // transitions bypass Area Key sequencing and can cause progression leaks.
+    // transitions can bypass intended progression routing.
     runtime_source_doors_idx = ap_room_doors_idx(KIRBY_CURRENT_ROOM);
     if (ap_is_warp_room_doors_idx(runtime_source_doors_idx)) {
-        return 0u;
-    }
-
-    runtime_source_area = ap_room_area_id(KIRBY_CURRENT_ROOM);
-    room_id_area = ap_room_area_id(room_id);
-    arg1_area = ap_room_area_id(arg1);
-    room_id_doors_area = ap_doors_idx_area_id(room_id);
-    arg1_doors_area = ap_doors_idx_area_id(arg1);
-
-    // Callers are not guaranteed to pass (source_room, destination_room) in a
-    // stable argument order across all transition sites. Derive the destination
-    // as whichever candidate differs from the runtime current area.
-    if (room_id_area >= 2u && room_id_area <= 9u && room_id_area != runtime_source_area) {
-        destination_area = room_id_area;
-    }
-    if (arg1_area >= 2u && arg1_area <= 9u && arg1_area != runtime_source_area) {
-        destination_area = arg1_area;
-    }
-    // Some callsites appear to pass doorsIdx-like values instead of canonical
-    // room IDs; treat those as fallback area candidates for regular mirrors.
-    if ((destination_area < 2u || destination_area > 9u)
-        && room_id_doors_area >= 2u && room_id_doors_area <= 9u
-        && room_id_doors_area != runtime_source_area) {
-        destination_area = room_id_doors_area;
-    }
-    if ((destination_area < 2u || destination_area > 9u)
-        && arg1_doors_area >= 2u && arg1_doors_area <= 9u
-        && arg1_doors_area != runtime_source_area) {
-        destination_area = arg1_doors_area;
-    }
-
-    if (destination_area < 2u || destination_area > 9u) {
-        return native_result;
-    }
-
-    if (ap_has_area_key(destination_area) == 0u) {
         return 0u;
     }
 
@@ -891,13 +777,6 @@ static uint8_t ap_apply_item(uint32_t ap_item_id) {
         return 1u;
     }
 
-    // AREA_KEY_2..AREA_KEY_9 = BASE+36 .. BASE+43
-    if (ap_item_id >= (KIRBY_ITEM_ID_BASE_OFFSET + 36u) && ap_item_id <= (KIRBY_ITEM_ID_BASE_OFFSET + 43u)) {
-        uint32_t area_id = 2u + (ap_item_id - (KIRBY_ITEM_ID_BASE_OFFSET + 36u));
-        AP_AREA_KEY_BITFIELD_RUNTIME |= (1u << area_id);
-        return 1u;
-    }
-
     // Unhandled item - return 0 to signal that the flag should NOT be cleared
     return 0u;
 }
@@ -925,7 +804,6 @@ void ap_poll_mailbox_c(void) {
         AP_STARTING_KIRBY_COLOR_ID = 0xFFFFFFFFu;
         AP_ONE_HIT_MODE_RUNTIME = 0xFFFFFFFFu;
         AP_NO_EXTRA_LIVES_RUNTIME = 0xFFFFFFFFu;
-        AP_AREA_KEY_BITFIELD_RUNTIME = 0u;
         ap_starting_kirby_color_applied = 0u;
         AP_ABILITY_RANDOMIZATION_MODE = 0u;
         AP_ABILITY_RANDOMIZATION_SEED_LO = 0u;

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -4391,40 +4391,6 @@ async def test_sync_enemy_copy_ability_runtime_config_rewrites_when_revalidation
     )
 
 
-@pytest.mark.asyncio
-async def test_sync_area_key_runtime_config_reseeds_delivered_keys_after_cursor_rewind(mock_bizhawk_context):
-    client = KirbyAmClient()
-    client.initialize_client()
-
-    client._delivered_item_index = 0
-    client._max_delivered_item_index_seen = 4
-    mock_bizhawk_context.items_received = [
-        Mock(item=3860036, player=1),
-        Mock(item=3860001, player=1),
-        Mock(item=3860041, player=1),
-        Mock(item=3860030, player=1),
-        Mock(item=3860043, player=1),
-    ]
-
-    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
-         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
-        mock_read.return_value = [(0).to_bytes(4, 'little')]
-
-        await client._sync_area_key_runtime_config(mock_bizhawk_context)
-
-    area_key_addr = data.transport_ram_addresses["area_key_bitfield_runtime"]
-    expected_bitfield = (1 << 2) | (1 << 7)
-    mock_read.assert_awaited_once_with(
-        mock_bizhawk_context.bizhawk_ctx,
-        [(area_key_addr, 4, "System Bus")],
-    )
-    mock_write.assert_awaited_once_with(
-        mock_bizhawk_context.bizhawk_ctx,
-        [(area_key_addr, expected_bitfield.to_bytes(4, "little"), "System Bus")],
-    )
-    assert client._last_area_key_runtime_bitfield == expected_bitfield
-
-
 def test_vitality_chest_locations_defined_in_regions():
     """Regression test: all VITALITY_CHEST locations must be registered in their regions.
 


### PR DESCRIPTION
## Summary
- remove KirbyAM client Area Key runtime sync constants, state, and watcher sync calls
- remove payload-side Area Key bitfield register usage and Area Key item handling
- simplify special-door hook by dropping Area Key destination gating while keeping warp-room guard
- remove the area_key_bitfield_runtime transport entry from addresses.json and protocol docs
- delete obsolete client test that validated Area Key runtime bitfield reseeding

## Validation
- ./.venv/Scripts/python -m pytest worlds/kirbyam/test/test_client.py -k 'sync_enemy_copy_ability_runtime_config or vitality_chest_locations_defined_in_regions or hub_switch_locations_defined_in_regions'