### PR TITLE
Prepare KirbyAM v0.2.1 changelog and manifest sync

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -11,6 +11,24 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### New Features
 
+- None.
+
+### Improvements
+
+- None.
+
+### Bug Fixes
+
+- None.
+
+### Internal Changes
+
+- None.
+
+## v0.2.1
+
+### New Features
+
 - Added trap item support: `Enable Traps` and `Trap Fill Percentage` options let players include trap items in the randomized item pool.
   - `Health Down Trap`: reduces Kirby's current HP by 2 (but won't kill).
   - `Life Down Trap`: removes one extra life (if any remain).

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.0",
+  "world_version": "0.2.1",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- promote current Unreleased KirbyAM notes into 0.2.1
- reset Unreleased placeholders back to None
- sync worlds/kirbyam/archipelago.json world_version to 