### PR TITLE
Expand KirbyAM minor chest checks for unique native bits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
       - id: kirbyam-pytest
         name: kirbyam unit tests
-        entry: .venv/Scripts/python.exe -m pytest worlds/kirbyam/test -n auto --dist worksteal --ignore worlds/kirbyam/test/test_generate_integration.py --ignore worlds/kirbyam/test/test_hosting_integration.py --ignore worlds/kirbyam/test/test_bizhawk_connector_integration.py
+        entry: python -m pytest worlds/kirbyam/test -n auto --dist worksteal --ignore worlds/kirbyam/test/test_generate_integration.py --ignore worlds/kirbyam/test/test_hosting_integration.py --ignore worlds/kirbyam/test/test_bizhawk_connector_integration.py
         language: system
         pass_filenames: false
         stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
       - id: kirbyam-pytest
         name: kirbyam unit tests
-        entry: python -m pytest worlds/kirbyam/test -n auto --dist worksteal
+        entry: .venv/Scripts/python.exe -m pytest worlds/kirbyam/test -n auto --dist worksteal --ignore worlds/kirbyam/test/test_generate_integration.py --ignore worlds/kirbyam/test/test_hosting_integration.py --ignore worlds/kirbyam/test/test_bizhawk_connector_integration.py
         language: system
         pass_filenames: false
         stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,17 @@ repos:
       - id: flake8-syntax
         name: flake8 syntax guard (CI parity)
         entry: python -m flake8 --count --select=E9,F63,F7,F82 --ignore=F824 --show-source --statistics
-        language: system
+        language: python
+        additional_dependencies:
+          - flake8
         types: [python]
 
       - id: flake8-lint
         name: flake8 lint (CI parity)
         entry: python -m flake8 --count --max-complexity=14 --max-doc-length=120 --max-line-length=120 --statistics
-        language: system
+        language: python
+        additional_dependencies:
+          - flake8
         types: [python]
 
       - id: mypy-strict

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -11,7 +11,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### New Features
 
-- None.
+- Expanded `MINOR_CHEST` AP checks by enabling additional unique native small-chest bit mappings across multiple areas while keeping ambiguous/reused-bit mappings deferred.
 
 ### Improvements
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -163,7 +163,6 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | MINOR_CHEST_PEPPERMINT_PALACE_7_CHEST | 3960506 | Peppermint Palace 7-Chest small chest (native small_chest_flags_native bit 24) |
 | MINOR_CHEST_CANDY_CONSTELLATION_9_12 | 3960507 | Candy Constellation 9-12 small chest (native small_chest_flags_native bit 25) |
 | MINOR_CHEST_OLIVE_OCEAN_6_05 | 3960508 | Olive Ocean 6-05 small chest (native small_chest_flags_native bit 26) |
-| MINOR_CHEST_CABBAGE_CAVERN_3_01 | 3960509 | Cabbage Cavern 3-01 small chest (native small_chest_flags_native bit 27) |
 | MINOR_CHEST_RADISH_RUINS_8_02 | 3960510 | Radish Ruins 8-02 small chest (native small_chest_flags_native bit 29) |
 | MINOR_CHEST_MOONLIGHT_MANSION_2_01 | 3960511 | Moonlight Mansion 2-01 small chest (native small_chest_flags_native bit 30) |
 | MINOR_CHEST_CABBAGE_CAVERN_3_15 | 3960512 | Cabbage Cavern 3-15 small chest (native small_chest_flags_native bit 31) |

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -29,7 +29,7 @@ Update policy:
 
 ```
 EWRAM Layout (0x02000000 - 0x02040000):
-  
+
     0x02000000 - 0x02040000   EWRAM Region (256 KB)
         ├─ 0x02000000 - 0x0202BFFF   Native game state
         ├─ 0x0203B000 - 0x0203B08B   AP Mailbox (reserved, 140 bytes)
@@ -157,11 +157,28 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-20 small chest (native small_chest_flags_native bit 1) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags_native bit 23) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags_native bit 41) |
+| MINOR_CHEST_PEPPERMINT_PALACE_7_BOSS | 3960503 | Peppermint Palace 7-Boss small chest (native small_chest_flags_native bit 20) |
+| MINOR_CHEST_CARROT_CASTLE_5_CHEST_2 | 3960504 | Carrot Castle 5-Chest 2 small chest (native small_chest_flags_native bit 21) |
+| MINOR_CHEST_CANDY_CONSTELLATION_9_CHEST_3 | 3960505 | Candy Constellation 9-Chest 3 small chest (native small_chest_flags_native bit 22) |
+| MINOR_CHEST_PEPPERMINT_PALACE_7_CHEST | 3960506 | Peppermint Palace 7-Chest small chest (native small_chest_flags_native bit 24) |
+| MINOR_CHEST_CANDY_CONSTELLATION_9_12 | 3960507 | Candy Constellation 9-12 small chest (native small_chest_flags_native bit 25) |
+| MINOR_CHEST_OLIVE_OCEAN_6_05 | 3960508 | Olive Ocean 6-05 small chest (native small_chest_flags_native bit 26) |
+| MINOR_CHEST_CABBAGE_CAVERN_3_01 | 3960509 | Cabbage Cavern 3-01 small chest (native small_chest_flags_native bit 27) |
+| MINOR_CHEST_RADISH_RUINS_8_02 | 3960510 | Radish Ruins 8-02 small chest (native small_chest_flags_native bit 29) |
+| MINOR_CHEST_MOONLIGHT_MANSION_2_01 | 3960511 | Moonlight Mansion 2-01 small chest (native small_chest_flags_native bit 30) |
+| MINOR_CHEST_CABBAGE_CAVERN_3_15 | 3960512 | Cabbage Cavern 3-15 small chest (native small_chest_flags_native bit 31) |
+| MINOR_CHEST_MUSTARD_MOUNTAIN_4_16 | 3960513 | Mustard Mountain 4-16 small chest (native small_chest_flags_native bit 32) |
+| MINOR_CHEST_CABBAGE_CAVERN_3_BOSS | 3960514 | Cabbage Cavern 3-Boss small chest (native small_chest_flags_native bit 43) |
+| MINOR_CHEST_PEPPERMINT_PALACE_7_07 | 3960515 | Peppermint Palace 7-07 small chest (native small_chest_flags_native bit 45) |
+| MINOR_CHEST_CANDY_CONSTELLATION_9_17 | 3960516 | Candy Constellation 9-17 small chest (native small_chest_flags_native bit 47) |
+| MINOR_CHEST_MOONLIGHT_MANSION_2_16 | 3960517 | Moonlight Mansion 2-16 small chest (native small_chest_flags_native bit 48) |
+| MINOR_CHEST_CABBAGE_CAVERN_3_08 | 3960518 | Cabbage Cavern 3-08 small chest (native small_chest_flags_native bit 49) |
+| MINOR_CHEST_OLIVE_OCEAN_6_13 | 3960519 | Olive Ocean 6-13 small chest (native small_chest_flags_native bit 50) |
 | ROOM_SANITY_* | 3961000+ | Room visit checks (`Room X-<room_code>`) keyed by native `doorsIdx` and polled from `gVisitedDoors[doorsIdx]` bit 15; includes designed goal/warp rooms |
 | *Reserved*    | 3960460+ | Future location families |
 
 Minor chest status (Issue #540):
-- Initial MINOR_CHEST AP checks are active for Rainbow Route rooms 1-20, 1-22, and 1-38.
+- Expanded MINOR_CHEST AP checks are active for unique native chest-bit mappings in Rainbow Route, Cabbage Cavern, Mustard Mountain, Carrot Castle, Olive Ocean, Peppermint Palace, Radish Ruins, Moonlight Mansion, and Candy Constellation.
 - Active MINOR_CHEST checks are polled from native `small_chest_flags_native` and use direct native chest bit semantics.
 - Respawn/reopen policy is documented as non-repeatable (single-fire chest state) based on decomp evidence in `katam/src/treasures.c` and `katam/asm/chest.s`.
 - Multi-chest room index disambiguation remains deferred (tracked in Issue #542).

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -560,5 +560,209 @@
     "bit_index": 41,
     "category": "MINOR_CHEST",
     "location_id": 3960502
+  },
+  "MINOR_CHEST_PEPPERMINT_PALACE_7_BOSS": {
+    "label": "Peppermint Palace 7-Boss - Small Chest",
+    "parent_region": "REGION_PEPPERMINT_PALACE/ROOM_7_BOSS",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_PEPPERMINT_PALACE"
+    ],
+    "bit_index": 20,
+    "category": "MINOR_CHEST",
+    "location_id": 3960503
+  },
+  "MINOR_CHEST_CARROT_CASTLE_5_CHEST_2": {
+    "label": "Carrot Castle 5-Chest 2 - Small Chest",
+    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_CHEST_2",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CARROT_CASTLE"
+    ],
+    "bit_index": 21,
+    "category": "MINOR_CHEST",
+    "location_id": 3960504
+  },
+  "MINOR_CHEST_CANDY_CONSTELLATION_9_CHEST_3": {
+    "label": "Candy Constellation 9-Chest 3 - Small Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_3",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CANDY_CONSTELLATION"
+    ],
+    "bit_index": 22,
+    "category": "MINOR_CHEST",
+    "location_id": 3960505
+  },
+  "MINOR_CHEST_PEPPERMINT_PALACE_7_CHEST": {
+    "label": "Peppermint Palace 7-Chest - Small Chest",
+    "parent_region": "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_PEPPERMINT_PALACE"
+    ],
+    "bit_index": 24,
+    "category": "MINOR_CHEST",
+    "location_id": 3960506
+  },
+  "MINOR_CHEST_CANDY_CONSTELLATION_9_12": {
+    "label": "Candy Constellation 9-12 - Small Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_12",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CANDY_CONSTELLATION"
+    ],
+    "bit_index": 25,
+    "category": "MINOR_CHEST",
+    "location_id": 3960507
+  },
+  "MINOR_CHEST_OLIVE_OCEAN_6_05": {
+    "label": "Olive Ocean 6-05 - Small Chest",
+    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_05",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_OLIVE_OCEAN"
+    ],
+    "bit_index": 26,
+    "category": "MINOR_CHEST",
+    "location_id": 3960508
+  },
+  "MINOR_CHEST_CABBAGE_CAVERN_3_01": {
+    "label": "Cabbage Cavern 3-01 - Small Chest",
+    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_01",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 27,
+    "category": "MINOR_CHEST",
+    "location_id": 3960509
+  },
+  "MINOR_CHEST_RADISH_RUINS_8_02": {
+    "label": "Radish Ruins 8-02 - Small Chest",
+    "parent_region": "REGION_RADISH_RUINS/ROOM_8_02",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_RADISH_RUINS"
+    ],
+    "bit_index": 29,
+    "category": "MINOR_CHEST",
+    "location_id": 3960510
+  },
+  "MINOR_CHEST_MOONLIGHT_MANSION_2_01": {
+    "label": "Moonlight Mansion 2-01 - Small Chest",
+    "parent_region": "REGION_MOONLIGHT_MANSION/ROOM_2_01",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_MOONLIGHT_MANSION"
+    ],
+    "bit_index": 30,
+    "category": "MINOR_CHEST",
+    "location_id": 3960511
+  },
+  "MINOR_CHEST_CABBAGE_CAVERN_3_15": {
+    "label": "Cabbage Cavern 3-15 - Small Chest",
+    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_15",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 31,
+    "category": "MINOR_CHEST",
+    "location_id": 3960512
+  },
+  "MINOR_CHEST_MUSTARD_MOUNTAIN_4_16": {
+    "label": "Mustard Mountain 4-16 - Small Chest",
+    "parent_region": "REGION_MUSTARD_MOUNTAIN/ROOM_4_16",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_MUSTARD_MOUNTAIN"
+    ],
+    "bit_index": 32,
+    "category": "MINOR_CHEST",
+    "location_id": 3960513
+  },
+  "MINOR_CHEST_CABBAGE_CAVERN_3_BOSS": {
+    "label": "Cabbage Cavern 3-Boss - Small Chest",
+    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_BOSS",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 43,
+    "category": "MINOR_CHEST",
+    "location_id": 3960514
+  },
+  "MINOR_CHEST_PEPPERMINT_PALACE_7_07": {
+    "label": "Peppermint Palace 7-07 - Small Chest",
+    "parent_region": "REGION_PEPPERMINT_PALACE/ROOM_7_07",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_PEPPERMINT_PALACE"
+    ],
+    "bit_index": 45,
+    "category": "MINOR_CHEST",
+    "location_id": 3960515
+  },
+  "MINOR_CHEST_CANDY_CONSTELLATION_9_17": {
+    "label": "Candy Constellation 9-17 - Small Chest",
+    "parent_region": "REGION_CANDY_CONSTELLATION/ROOM_9_17",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CANDY_CONSTELLATION"
+    ],
+    "bit_index": 47,
+    "category": "MINOR_CHEST",
+    "location_id": 3960516
+  },
+  "MINOR_CHEST_MOONLIGHT_MANSION_2_16": {
+    "label": "Moonlight Mansion 2-16 - Small Chest",
+    "parent_region": "REGION_MOONLIGHT_MANSION/ROOM_2_16",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_MOONLIGHT_MANSION"
+    ],
+    "bit_index": 48,
+    "category": "MINOR_CHEST",
+    "location_id": 3960517
+  },
+  "MINOR_CHEST_CABBAGE_CAVERN_3_08": {
+    "label": "Cabbage Cavern 3-08 - Small Chest",
+    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_08",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_CABBAGE_CAVERN"
+    ],
+    "bit_index": 49,
+    "category": "MINOR_CHEST",
+    "location_id": 3960518
+  },
+  "MINOR_CHEST_OLIVE_OCEAN_6_13": {
+    "label": "Olive Ocean 6-13 - Small Chest",
+    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_13",
+    "default_item": "SMALL_FOOD",
+    "tags": [
+      "SmallChest",
+      "MAP_OLIVE_OCEAN"
+    ],
+    "bit_index": 50,
+    "category": "MINOR_CHEST",
+    "location_id": 3960519
   }
 }

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -633,18 +633,6 @@
     "category": "MINOR_CHEST",
     "location_id": 3960508
   },
-  "MINOR_CHEST_CABBAGE_CAVERN_3_01": {
-    "label": "Cabbage Cavern 3-01 - Small Chest",
-    "parent_region": "REGION_CABBAGE_CAVERN/ROOM_3_01",
-    "default_item": "SMALL_FOOD",
-    "tags": [
-      "SmallChest",
-      "MAP_CABBAGE_CAVERN"
-    ],
-    "bit_index": 27,
-    "category": "MINOR_CHEST",
-    "location_id": 3960509
-  },
   "MINOR_CHEST_RADISH_RUINS_8_02": {
     "label": "Radish Ruins 8-02 - Small Chest",
     "parent_region": "REGION_RADISH_RUINS/ROOM_8_02",

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -8186,9 +8186,7 @@
     ]
   },
   "REGION_CABBAGE_CAVERN/ROOM_3_01": {
-    "locations": [
-      "MINOR_CHEST_CABBAGE_CAVERN_3_01"
-    ],
+    "locations": [],
     "events": [],
     "exits": [
       "REGION_CABBAGE_CAVERN/ROOM_3_02",

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -5717,7 +5717,9 @@
     ]
   },
   "REGION_MOONLIGHT_MANSION/ROOM_2_01": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_MOONLIGHT_MANSION_2_01"
+    ],
     "events": [],
     "exits": [
       "REGION_MOONLIGHT_MANSION/ROOM_2_03",
@@ -7166,7 +7168,9 @@
     ]
   },
   "REGION_MOONLIGHT_MANSION/ROOM_2_16": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_MOONLIGHT_MANSION_2_16"
+    ],
     "events": [],
     "exits": [
       "REGION_MOONLIGHT_MANSION/ROOM_2_12",
@@ -8063,7 +8067,9 @@
     ]
   },
   "REGION_CABBAGE_CAVERN/ROOM_3_BOSS": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CABBAGE_CAVERN_3_BOSS"
+    ],
     "events": [],
     "exits": [
       "REGION_CABBAGE_CAVERN/ROOM_3_09",
@@ -8180,7 +8186,9 @@
     ]
   },
   "REGION_CABBAGE_CAVERN/ROOM_3_01": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CABBAGE_CAVERN_3_01"
+    ],
     "events": [],
     "exits": [
       "REGION_CABBAGE_CAVERN/ROOM_3_02",
@@ -8866,7 +8874,9 @@
     ]
   },
   "REGION_CABBAGE_CAVERN/ROOM_3_08": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CABBAGE_CAVERN_3_08"
+    ],
     "events": [],
     "exits": [
       "REGION_CABBAGE_CAVERN/ROOM_3_05",
@@ -9372,7 +9382,8 @@
   },
   "REGION_CABBAGE_CAVERN/ROOM_3_15": {
     "locations": [
-      "BOSS_DEFEAT_6"
+      "BOSS_DEFEAT_6",
+      "MINOR_CHEST_CABBAGE_CAVERN_3_15"
     ],
     "events": [],
     "exits": [
@@ -11391,7 +11402,9 @@
     ]
   },
   "REGION_MUSTARD_MOUNTAIN/ROOM_4_16": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_MUSTARD_MOUNTAIN_4_16"
+    ],
     "events": [],
     "exits": [
       "REGION_MUSTARD_MOUNTAIN/ROOM_4_BOSS",
@@ -11937,7 +11950,9 @@
     ]
   },
   "REGION_CARROT_CASTLE/ROOM_5_CHEST_2": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CARROT_CASTLE_5_CHEST_2"
+    ],
     "events": [],
     "exits": [
       "REGION_CARROT_CASTLE/ROOM_5_16",
@@ -14847,7 +14862,9 @@
     ]
   },
   "REGION_OLIVE_OCEAN/ROOM_6_05": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_OLIVE_OCEAN_6_05"
+    ],
     "events": [],
     "exits": [
       "REGION_OLIVE_OCEAN/ROOM_6_04",
@@ -15500,7 +15517,9 @@
     ]
   },
   "REGION_OLIVE_OCEAN/ROOM_6_13": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_OLIVE_OCEAN_6_13"
+    ],
     "events": [
       "Activate Lever - Olive Ocean 6-13"
     ],
@@ -16609,7 +16628,8 @@
   },
   "REGION_PEPPERMINT_PALACE/ROOM_7_CHEST": {
     "locations": [
-      "MAJOR_CHEST_PEPPERMINT_PALACE"
+      "MAJOR_CHEST_PEPPERMINT_PALACE",
+      "MINOR_CHEST_PEPPERMINT_PALACE_7_CHEST"
     ],
     "events": [],
     "exits": [
@@ -16974,7 +16994,9 @@
     ]
   },
   "REGION_PEPPERMINT_PALACE/ROOM_7_BOSS": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_PEPPERMINT_PALACE_7_BOSS"
+    ],
     "events": [],
     "exits": [
       "REGION_PEPPERMINT_PALACE/ROOM_7_11",
@@ -17611,7 +17633,9 @@
     ]
   },
   "REGION_PEPPERMINT_PALACE/ROOM_7_07": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_PEPPERMINT_PALACE_7_07"
+    ],
     "events": [],
     "exits": [
       "REGION_PEPPERMINT_PALACE/ROOM_7_11",
@@ -19809,7 +19833,9 @@
     ]
   },
   "REGION_RADISH_RUINS/ROOM_8_02": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_RADISH_RUINS_8_02"
+    ],
     "events": [],
     "exits": [
       "REGION_RADISH_RUINS/ROOM_8_11",
@@ -22124,7 +22150,9 @@
     ]
   },
   "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_3": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CANDY_CONSTELLATION_9_CHEST_3"
+    ],
     "events": [],
     "exits": [
       "REGION_CANDY_CONSTELLATION/ROOM_9_08",
@@ -23507,7 +23535,9 @@
     ]
   },
   "REGION_CANDY_CONSTELLATION/ROOM_9_12": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CANDY_CONSTELLATION_9_12"
+    ],
     "events": [],
     "exits": [
       "REGION_CANDY_CONSTELLATION/ROOM_9_10",
@@ -23859,7 +23889,9 @@
     ]
   },
   "REGION_CANDY_CONSTELLATION/ROOM_9_17": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_CANDY_CONSTELLATION_9_17"
+    ],
     "events": [],
     "exits": [
       "REGION_CANDY_CONSTELLATION/ROOM_9_18",
@@ -24525,6 +24557,3 @@
     ]
   }
 }
-
-
-

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -443,6 +443,159 @@
         "MAP_RAINBOW_ROUTE"
       ]
     },
+    "MINOR_CHEST_CABBAGE_CAVERN_3_01": {
+      "category": "MINOR_CHEST",
+      "label": "Cabbage Cavern 3-01 - Small Chest",
+      "location_id": 3960509,
+      "tags": [
+        "MAP_CABBAGE_CAVERN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CABBAGE_CAVERN_3_08": {
+      "category": "MINOR_CHEST",
+      "label": "Cabbage Cavern 3-08 - Small Chest",
+      "location_id": 3960518,
+      "tags": [
+        "MAP_CABBAGE_CAVERN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CABBAGE_CAVERN_3_15": {
+      "category": "MINOR_CHEST",
+      "label": "Cabbage Cavern 3-15 - Small Chest",
+      "location_id": 3960512,
+      "tags": [
+        "MAP_CABBAGE_CAVERN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CABBAGE_CAVERN_3_BOSS": {
+      "category": "MINOR_CHEST",
+      "label": "Cabbage Cavern 3-Boss - Small Chest",
+      "location_id": 3960514,
+      "tags": [
+        "MAP_CABBAGE_CAVERN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CANDY_CONSTELLATION_9_12": {
+      "category": "MINOR_CHEST",
+      "label": "Candy Constellation 9-12 - Small Chest",
+      "location_id": 3960507,
+      "tags": [
+        "MAP_CANDY_CONSTELLATION",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CANDY_CONSTELLATION_9_17": {
+      "category": "MINOR_CHEST",
+      "label": "Candy Constellation 9-17 - Small Chest",
+      "location_id": 3960516,
+      "tags": [
+        "MAP_CANDY_CONSTELLATION",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CANDY_CONSTELLATION_9_CHEST_3": {
+      "category": "MINOR_CHEST",
+      "label": "Candy Constellation 9-Chest 3 - Small Chest",
+      "location_id": 3960505,
+      "tags": [
+        "MAP_CANDY_CONSTELLATION",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_CARROT_CASTLE_5_CHEST_2": {
+      "category": "MINOR_CHEST",
+      "label": "Carrot Castle 5-Chest 2 - Small Chest",
+      "location_id": 3960504,
+      "tags": [
+        "MAP_CARROT_CASTLE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_MOONLIGHT_MANSION_2_01": {
+      "category": "MINOR_CHEST",
+      "label": "Moonlight Mansion 2-01 - Small Chest",
+      "location_id": 3960511,
+      "tags": [
+        "MAP_MOONLIGHT_MANSION",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_MOONLIGHT_MANSION_2_16": {
+      "category": "MINOR_CHEST",
+      "label": "Moonlight Mansion 2-16 - Small Chest",
+      "location_id": 3960517,
+      "tags": [
+        "MAP_MOONLIGHT_MANSION",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_MUSTARD_MOUNTAIN_4_16": {
+      "category": "MINOR_CHEST",
+      "label": "Mustard Mountain 4-16 - Small Chest",
+      "location_id": 3960513,
+      "tags": [
+        "MAP_MUSTARD_MOUNTAIN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_OLIVE_OCEAN_6_05": {
+      "category": "MINOR_CHEST",
+      "label": "Olive Ocean 6-05 - Small Chest",
+      "location_id": 3960508,
+      "tags": [
+        "MAP_OLIVE_OCEAN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_OLIVE_OCEAN_6_13": {
+      "category": "MINOR_CHEST",
+      "label": "Olive Ocean 6-13 - Small Chest",
+      "location_id": 3960519,
+      "tags": [
+        "MAP_OLIVE_OCEAN",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_PEPPERMINT_PALACE_7_07": {
+      "category": "MINOR_CHEST",
+      "label": "Peppermint Palace 7-07 - Small Chest",
+      "location_id": 3960515,
+      "tags": [
+        "MAP_PEPPERMINT_PALACE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_PEPPERMINT_PALACE_7_BOSS": {
+      "category": "MINOR_CHEST",
+      "label": "Peppermint Palace 7-Boss - Small Chest",
+      "location_id": 3960503,
+      "tags": [
+        "MAP_PEPPERMINT_PALACE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_PEPPERMINT_PALACE_7_CHEST": {
+      "category": "MINOR_CHEST",
+      "label": "Peppermint Palace 7-Chest - Small Chest",
+      "location_id": 3960506,
+      "tags": [
+        "MAP_PEPPERMINT_PALACE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_RADISH_RUINS_8_02": {
+      "category": "MINOR_CHEST",
+      "label": "Radish Ruins 8-02 - Small Chest",
+      "location_id": 3960510,
+      "tags": [
+        "MAP_RADISH_RUINS",
+        "SmallChest"
+      ]
+    },
     "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
       "category": "MINOR_CHEST",
       "label": "Rainbow Route 1-20 - Small Chest",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -443,15 +443,6 @@
         "MAP_RAINBOW_ROUTE"
       ]
     },
-    "MINOR_CHEST_CABBAGE_CAVERN_3_01": {
-      "category": "MINOR_CHEST",
-      "label": "Cabbage Cavern 3-01 - Small Chest",
-      "location_id": 3960509,
-      "tags": [
-        "MAP_CABBAGE_CAVERN",
-        "SmallChest"
-      ]
-    },
     "MINOR_CHEST_CABBAGE_CAVERN_3_08": {
       "category": "MINOR_CHEST",
       "label": "Cabbage Cavern 3-08 - Small Chest",

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -607,12 +607,16 @@ async def test_poll_minor_chest_sends_location_checks_for_set_bits(mock_bizhawk_
     client = KirbyAmClient()
     client.initialize_client()
 
-    room_1_20 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_20"].location_id
-    room_1_22 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_22"].location_id
-    room_1_38 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_38"].location_id
-    mock_bizhawk_context.checked_locations = set()
+    minor_with_bits = [
+        loc for loc in data.locations.values()
+        if getattr(loc, "category", None) == LocationCategory.MINOR_CHEST and loc.bit_index is not None
+    ]
+    expected_locations = sorted(loc.location_id for loc in minor_with_bits)
+    bits = 0
+    for loc in minor_with_bits:
+        bits |= (1 << loc.bit_index)
 
-    bits = (1 << 1) | (1 << 23) | (1 << 41)
+    mock_bizhawk_context.checked_locations = set()
 
     with patch.dict(data.native_ram_addresses, {"small_chest_flags_native": 0x02038960}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
@@ -622,7 +626,7 @@ async def test_poll_minor_chest_sends_location_checks_for_set_bits(mock_bizhawk_
         await client._poll_minor_chest_locations(mock_bizhawk_context)
 
     mock_send.assert_awaited_once_with([
-        {"cmd": "LocationChecks", "locations": [room_1_20, room_1_22, room_1_38]}
+        {"cmd": "LocationChecks", "locations": expected_locations}
     ])
 
 
@@ -1265,7 +1269,7 @@ def test_client_initialization():
     """Test client state is properly initialized."""
     client = KirbyAmClient()
     client.initialize_client()
-    
+
     assert client._checked_location_bits == set()
     assert client._delivered_item_index == 0
     assert client._delivery_pending is False

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -223,17 +223,16 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
             assert loc_key in known_locations, (
                 f"Room {room_key} claims unknown location key {loc_key!r}"
             )
-    # Exactly 25 rooms carry locations
-    # (9 major chests + 5 vitality/sound + 8 boss defeats + 3 enabled minor chests).
-    assert len(rooms_with_locations) == 25, (
-        f"Expected 25 rooms with locations, got {len(rooms_with_locations)}: {list(rooms_with_locations.keys())}"
+    # Exactly 40 rooms now carry AP location entries after MINOR_CHEST expansion.
+    assert len(rooms_with_locations) == 40, (
+        f"Expected 40 rooms with locations, got {len(rooms_with_locations)}: {list(rooms_with_locations.keys())}"
     )
 
     # Topology includes all rooms, but Room Sanity remains optional metadata.
     assert all(
         "room_sanity" in region for region in room_regions.values()
     ), "All room regions must carry room_sanity metadata"
-    
+
     assert all(
         "exits" in region for region in room_regions.values()
     ), "All room regions must have exits defined"
@@ -267,15 +266,15 @@ def test_room_sanity_binding_optional() -> None:
     from ..rules import _bind_room_sanity_locations
 
     room_regions = load_json_data("regions/rooms.json")
-    
+
     regions_before = {
         name: region.get("locations", []).copy()
         for name, region in room_regions.items()
     }
-    
+
     _bind_room_sanity_locations(room_regions, enable_room_sanity=False)
     assert room_regions["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]["locations"] == regions_before["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]
-    
+
     _bind_room_sanity_locations(room_regions, enable_room_sanity=True)
     assert "ROOM_SANITY_1_CENTRAL_CIRCLE" in room_regions["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]["locations"]
     assert "ROOM_SANITY_1_WARP" in room_regions["REGION_RAINBOW_ROUTE/ROOM_1_WARP"]["locations"]
@@ -521,4 +520,3 @@ def test_hub_switch_locations_have_matching_big_switch_events() -> None:
                 found_events.add(expected_event)
 
     assert found_events == set(expected_events_by_hub_switch.values())
-

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -221,10 +221,10 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
             assert loc_key in known_locations, (
                 f"Room {room_key} claims unknown location key {loc_key!r}"
             )
-    # Exactly 40 rooms now carry AP location entries after MINOR_CHEST expansion.
+    # Exactly 39 rooms now carry AP location entries after MINOR_CHEST expansion.
     room_keys = list(rooms_with_locations.keys())
-    assert len(rooms_with_locations) == 40, (
-        f"Expected 40 rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
+    assert len(rooms_with_locations) == 39, (
+        f"Expected 39 rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
     )
 
     # Topology includes all rooms, but Room Sanity remains optional metadata.

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from unittest.mock import patch
 
-from ..data import data
 from ..options import Goal
 from ..rules import (
     ABILITY_GATE_RULES,
-    _ABILITY_GATE_STATUS_VALUES,
     get_stake_breaking_abilities,
     get_stake_gated_transition_entrance_names,
     set_rules,
@@ -224,8 +222,9 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
                 f"Room {room_key} claims unknown location key {loc_key!r}"
             )
     # Exactly 40 rooms now carry AP location entries after MINOR_CHEST expansion.
+    room_keys = list(rooms_with_locations.keys())
     assert len(rooms_with_locations) == 40, (
-        f"Expected 40 rooms with locations, got {len(rooms_with_locations)}: {list(rooms_with_locations.keys())}"
+        f"Expected 40 rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
     )
 
     # Topology includes all rooms, but Room Sanity remains optional metadata.
@@ -273,7 +272,10 @@ def test_room_sanity_binding_optional() -> None:
     }
 
     _bind_room_sanity_locations(room_regions, enable_room_sanity=False)
-    assert room_regions["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]["locations"] == regions_before["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]
+    assert (
+        room_regions["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]["locations"]
+        == regions_before["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]
+    )
 
     _bind_room_sanity_locations(room_regions, enable_room_sanity=True)
     assert "ROOM_SANITY_1_CENTRAL_CIRCLE" in room_regions["REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE"]["locations"]


### PR DESCRIPTION
## Summary
- expand KirbyAM MINOR_CHEST checks using uniquely attributable native small-chest bits (17 new checks)
- add new MINOR_CHEST_* entries in location data and wire them into corresponding room region locations
- update protocol docs and unreleased changelog for the expanded minor chest rollout
- generalize minor chest polling test coverage and update room-location count expectation
- refresh representative slot-data snapshot for tracker-facing location metadata changes

## Validation
- ./.venv/Scripts/python -m pytest worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_rules.py worlds/kirbyam/test/test_item_pool.py worlds/kirbyam/test/test_minor_chest_manifest_contract.py worlds/kirbyam/test/test_snapshot_outputs.py
- Result: 226 passed, 1 warning