### PR TITLE
Fix trap replay after reload rewind

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -19,7 +19,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### Bug Fixes
 
-- None.
+- Prevent trap items that were already ACKed in the current client session from being redelivered after ROM reload/reconnect rewinds the mailbox counter.
 
 ### Internal Changes
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -431,6 +431,7 @@ Behavior note:
 
 `debug_item_counter` reconciliation contract:
 - If `debug_item_counter < delivered_item_index`, rewind cursor to the ROM count.
+- If that rewind revisits trap entries already ACKed in the current client session, the client must locally consume those trap indices instead of writing them back to the mailbox again.
 - If `debug_item_counter` is ahead but still within `len(ctx.items_received)`, treat it as advisory unless a mailbox delivery is currently pending and `incoming_item_flag == 0` (same-tick ROM ACK path).
 - If `debug_item_counter > len(ctx.items_received)`, treat the counter as stale/debug-only and continue normal mailbox delivery once the mailbox is empty. This anti-starvation fallback must not permanently suppress writes.
 - Transition-based logs should make the ahead-counter fallback visible without per-tick spam.

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -371,6 +371,7 @@ class KirbyAmClient(BizHawkClient):
         self._receive_notifications_enabled: bool = True
         self._send_notifications_enabled: bool = True
         self._notified_receive_indices: set[int] = set()
+        self._acknowledged_trap_indices: set[int] = set()
         self._notified_send_keys: set[tuple[int, int, int, int]] = set()
         self._self_send_fallback_keys: set[tuple[int, int, int, int]] = set()
         self._send_notify_window_start: float = 0.0
@@ -593,6 +594,31 @@ class KirbyAmClient(BizHawkClient):
     def _is_trap_item(item_id: int) -> bool:
         """Return True if item_id is a trap item."""
         return item_id in _TRAP_ITEM_IDS
+
+    def _record_acknowledged_trap_index(self, ctx: "BizHawkClientContext", delivered_index: int) -> None:
+        if delivered_index < 0 or delivered_index >= len(ctx.items_received):
+            return
+
+        item_fields = self._extract_delivery_item_fields(ctx.items_received[delivered_index])
+        if item_fields is None:
+            return
+
+        item_id, _player_id = item_fields
+        if self._is_trap_item(item_id):
+            self._acknowledged_trap_indices.add(delivered_index)
+
+    def _is_acknowledged_trap_index(self, ctx: "BizHawkClientContext", delivered_index: int) -> bool:
+        if delivered_index not in self._acknowledged_trap_indices:
+            return False
+        if delivered_index < 0 or delivered_index >= len(ctx.items_received):
+            return False
+
+        item_fields = self._extract_delivery_item_fields(ctx.items_received[delivered_index])
+        if item_fields is None:
+            return False
+
+        item_id, _player_id = item_fields
+        return self._is_trap_item(item_id)
 
     def _start_with_all_maps_enabled(self, ctx: "BizHawkClientContext") -> bool:
         slot_data = getattr(ctx, "slot_data", None)
@@ -2083,6 +2109,9 @@ class KirbyAmClient(BizHawkClient):
             if key == "delivered_item_index":
                 self._delivered_item_index = val
                 self._max_delivered_item_index_seen = max(self._max_delivered_item_index_seen, val)
+                delivered_count = min(val, len(ctx.items_received))
+                for delivered_index in range(delivered_count):
+                    self._record_acknowledged_trap_index(ctx, delivered_index)
 
     # --------------------------
     # Location checking
@@ -2756,13 +2785,13 @@ class KirbyAmClient(BizHawkClient):
     async def _deliver_items(self, ctx: KirbyAmBizHawkClientContext, allow_new_writes: bool = True) -> None:
         """
         Deliver items via mailbox protocol.
-        
+
         Protocol:
         1. Client writes item_id + player to mailbox
         2. Client sets flag=1 to signal ROM
         3. ROM reads mailbox, applies item, clears flag=0 (ACK)
         4. Client observes flag=0, advances index
-        
+
         State machine:
         - If _delivery_pending: wait for ROM to ACK (flag -> 0)
         - If flag=0 and items available: write next item (set flag -> 1)
@@ -2881,6 +2910,7 @@ class KirbyAmClient(BizHawkClient):
                 _notify_index = _ff_pending_item_index
                 if _notify_index is None:
                     _notify_index = self._delivered_item_index - 1
+                self._record_acknowledged_trap_index(ctx, _notify_index)
                 await self._emit_receive_notification(ctx, _notify_index)
 
         # If an item is pending, wait for ROM to clear the flag (ACK)
@@ -2904,6 +2934,7 @@ class KirbyAmClient(BizHawkClient):
                     self._delivered_item_index += 1
                 self._max_delivered_item_index_seen = max(self._max_delivered_item_index_seen, self._delivered_item_index)
                 await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
+                self._record_acknowledged_trap_index(ctx, delivered_index)
                 await self._emit_receive_notification(ctx, delivered_index)
                 return
 
@@ -3008,6 +3039,24 @@ class KirbyAmClient(BizHawkClient):
                 continue
 
             item_id, player_id = item_fields
+
+            if self._is_acknowledged_trap_index(ctx, self._delivered_item_index):
+                self._log_verbose(
+                    "info",
+                    "KirbyAM: skipping already-ACKed trap replay at item index %s (%s from %s)",
+                    self._delivered_item_index,
+                    self._item_name(ctx, item_id, player_id),
+                    self._player_name(ctx, player_id),
+                )
+                self._delivered_item_index += 1
+                self._delivery_pending = False
+                self._delivery_pending_time = None
+                self._delivery_pending_item_index = None
+                self._delivery_timeout_streak = 0
+                self._delivery_retry_not_before = 0.0
+                self._delivery_payload_stall_warned = False
+                await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
+                continue
 
             if self._delivery_counter_ahead_fallback_active and not self._delivery_counter_ahead_resume_logged:
                 self._log_verbose(

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2,7 +2,7 @@
 import asyncio
 import pytest
 import logging
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import worlds._bizhawk as bizhawk
 from worlds._bizhawk.context import _game_watcher, AuthStatus, BizHawkClientCommandProcessor
@@ -2269,6 +2269,44 @@ async def test_receive_notification_reconnect_replay_dedupes_on_rewind(mock_bizh
         await client._deliver_items(mock_bizhawk_context)
 
     mock_display.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_items_skips_already_acked_trap_on_counter_rewind(mock_bizhawk_context):
+    """Trap deliveries already ACKed in this session should not be replayed after a counter rewind."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860032, player=2),
+    ]
+
+    client._acknowledged_trap_indices.add(0)
+    client._delivered_item_index = 1
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write, \
+         patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display:
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (0).to_bytes(4, 'little'),
+        ]
+
+        await client._deliver_items(mock_bizhawk_context)
+
+    assert client._delivered_item_index == 1
+    assert client._delivery_pending is False
+    mock_display.assert_not_awaited()
+    assert mock_write.await_args_list == [
+        call(
+            mock_bizhawk_context.bizhawk_ctx,
+            [(data.transport_ram_addresses["delivered_item_index"], (0).to_bytes(4, 'little'), 'System Bus')],
+        ),
+        call(
+            mock_bizhawk_context.bizhawk_ctx,
+            [(data.transport_ram_addresses["delivered_item_index"], (1).to_bytes(4, 'little'), 'System Bus')],
+        ),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- track trap deliveries that were ACKed so reload/reconnect counter rewinds do not redeliver those trap indices
- seed the trap replay guard from the persisted delivery cursor and log when a replayed trap index is skipped
- add a regression test and document the reconnect behavior in the protocol/changelog

## Testing
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_client.py -k "acked_trap_on_counter_rewind or ack_clears_pending_and_advances_cursor or reconnect_replay_dedupes_on_rewind"
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_client.py -k "deliver_items or receive_notification"