### PR TITLE
Fix false hub-switch resend from stale baseline bits

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -21,6 +21,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 - Fixed file-only KirbyAM verbose diagnostics still appearing in the live client log panel by marking verbose messages as GUI-hidden while keeping them in the log file output (Issue #751).
 - Prevent trap items that were already ACKed in the current client session from being redelivered after ROM reload/reconnect rewinds the mailbox counter.
+- Fixed hub-switch stale-bit baseline gating so old transport bits are ignored until a real hub-switch check is acknowledged, preventing false `Peppermint Palace West - Big Switch` sends when unrelated checks are already present (Issue #750).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -385,7 +385,7 @@ Boss shard scrub timing contract (Issue #505):
 
 **Behavior notes:**
 - Detection is **level-based** (current bitfield state), not edge-based, to be reconnect-safe.
-- Hub-switch polling suppresses only pre-session baseline bits on first poll when server state is empty, preventing stale EWRAM bits from being resent as fresh checks.
+- Hub-switch polling suppresses only pre-session baseline bits on first poll when no hub-switch checks are yet acknowledged by the server, preventing stale EWRAM bits from being resent as fresh checks.
 - No checks are sent for bits already in `server_checked_locations`.
 - No checks are sent for reserved/unmapped bits even when set.
 - Boss-defeat, major-chest, vitality-chest, sound-player-chest, hub-switch, and room-sanity polling follow the same resend/dedupe diagnostic contract.

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -305,6 +305,11 @@ class KirbyAmClient(BizHawkClient):
             fallback_ids = self._hub_switch_location_ids_by_bit.setdefault(15, [])
             if rr_north.location_id not in fallback_ids:
                 fallback_ids.append(rr_north.location_id)
+        self._hub_switch_location_ids_all: set[int] = {
+            location_id
+            for location_ids in self._hub_switch_location_ids_by_bit.values()
+            for location_id in location_ids
+        }
 
         # Room-sanity bitfield index (doorsIdx) → location IDs.
         self._room_sanity_location_ids_by_bit: dict[int, list[int]] = {}
@@ -2405,15 +2410,17 @@ class KirbyAmClient(BizHawkClient):
             self._hub_switch_baseline_mask = None
 
         # Capture baseline only on first hub-switch poll of a session when the server
-        # has not yet acknowledged any locations. This suppresses pre-session stale
-        # transport bits while avoiding suppression when the session is already active.
+        # has not yet acknowledged any hub-switch locations. This suppresses
+        # pre-session stale transport bits without suppressing legitimate reconnect
+        # resends for hub-switch checks that the server already knows about.
+        has_hub_switch_acknowledgements = bool(self._hub_switch_location_ids_all & ctx.checked_locations)
         if not self._hub_switch_session_initialized:
             self._hub_switch_session_initialized = True
-            if self._hub_switch_baseline_mask is None and switch_bits != 0 and not ctx.checked_locations:
+            if self._hub_switch_baseline_mask is None and switch_bits != 0 and not has_hub_switch_acknowledgements:
                 self._hub_switch_baseline_mask = switch_bits
                 self._log_verbose(
                     "info",
-                    "KirbyAM: hub-switch baseline initialized from first-poll transport state before any server acknowledgements (baseline=0x%08X)",
+                    "KirbyAM: hub-switch baseline initialized from first-poll transport state before any hub-switch server acknowledgements (baseline=0x%08X)",
                     switch_bits,
                 )
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -857,6 +857,30 @@ async def test_poll_hub_switch_suppresses_pre_session_stale_bits(mock_bizhawk_co
 
 
 @pytest.mark.asyncio
+async def test_poll_hub_switch_suppresses_pre_session_stale_bits_with_unrelated_server_checks(mock_bizhawk_context):
+    """First-poll stale hub-switch bits should still be baselined when only non-hub checks are acknowledged."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    unrelated_location = next(
+        loc.location_id
+        for loc in data.locations.values()
+        if loc.location_id is not None and loc.category != LocationCategory.HUB_SWITCH
+    )
+    mock_bizhawk_context.checked_locations = {unrelated_location}
+
+    with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.return_value = [((1 << 0)).to_bytes(4, 'little')]
+
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+        await client._poll_hub_switch_locations(mock_bizhawk_context)
+
+    mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_poll_hub_switch_skips_already_server_acknowledged(mock_bizhawk_context):
     """No hub-switch resend when server already acknowledges all mapped transport checks."""
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary\n- fix hub-switch baseline capture to key off hub-switch acknowledgements only\n- prevent stale transport bits from being resent as fresh checks when unrelated checks already exist\n- add regression test for first-poll stale hub-switch bits with unrelated server-acknowledged checks\n- update protocol/changelog notes for hub-switch baseline behavior\n\n## Testing\n- python -m pytest worlds/kirbyam/test/test_client.py -k hub_switch\n\nCloses #750