### PR TITLE
Fix boss-defeat checks when shard already delivered

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -22,6 +22,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Fixed file-only KirbyAM verbose diagnostics still appearing in the live client log panel by marking verbose messages as GUI-hidden while keeping them in the log file output (Issue #751).
 - Prevent trap items that were already ACKed in the current client session from being redelivered after ROM reload/reconnect rewinds the mailbox counter.
 - Fixed hub-switch stale-bit baseline gating so old transport bits are ignored until a real hub-switch check is acknowledged, preventing false `Peppermint Palace West - Big Switch` sends when unrelated checks are already present (Issue #750).
+- Fixed boss-defeat AP checks being missed when the corresponding shard was already AP-delivered before the fight by staging a room-scoped boss fallback on boss-room departure (Issue #754).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -339,6 +339,13 @@ class KirbyAmClient(BizHawkClient):
         self._last_boss_probe_snapshot: bytes | None = None
         self._boss_probe_stream_marker: object = None
         self._boss_probe_fallback_location_ids: set[int] = set()
+        self._boss_location_bit_index_by_location_id: dict[int, int] = {
+            loc.location_id: loc.bit_index
+            for loc in data.locations.values()
+            if loc.location_id is not None
+            and loc.bit_index is not None
+            and loc.category == LocationCategory.BOSS_DEFEAT
+        }
 
         # Runtime gameplay-state gate tracking
         self._last_runtime_gate_reason: str | None = None
@@ -2485,6 +2492,7 @@ class KirbyAmClient(BizHawkClient):
             return
 
         native_room_id = unpack_from("<H", raw)[0]
+        previous_room_region_key = self._last_room_region_key
         room_changed = native_room_id != self._last_native_room_id
         send_pending = native_room_id != self._last_sent_room_update_native_room_id
 
@@ -2514,6 +2522,9 @@ class KirbyAmClient(BizHawkClient):
         room_label = self._room_label_by_doors_idx.get(doors_idx, f"<unknown doorsIdx={doors_idx}>")
         room_region_key = self._room_region_key_by_doors_idx.get(doors_idx, "")
         self._last_room_region_key = room_region_key
+
+        if room_changed and previous_room_region_key and previous_room_region_key != room_region_key:
+            await self._stage_boss_room_departure_fallback(ctx, previous_room_region_key)
 
         if room_changed:
             self._last_native_room_id = native_room_id
@@ -2549,6 +2560,58 @@ class KirbyAmClient(BizHawkClient):
                 )
                 return
             self._last_sent_room_update_native_room_id = native_room_id
+
+    async def _stage_boss_room_departure_fallback(
+        self,
+        ctx: KirbyAmBizHawkClientContext,
+        departed_room_region_key: str,
+    ) -> None:
+        """
+        Stage boss-defeat fallback checks when leaving a known boss room.
+
+        Issue #754: when a shard was already AP-delivered before a boss defeat,
+        the native CollectShard path may be skipped, leaving no transport bit rise
+        and no native probe rising edge. On boss-room departure, use the current
+        shard bitfield as a conservative room-scoped signal to stage fallback checks.
+        """
+        boss_location_ids = self._boss_location_ids_by_room_region.get(departed_room_region_key, [])
+        if not boss_location_ids:
+            return
+
+        shard_addr = self._transport_addr("shard_bitfield")
+        if shard_addr is None:
+            return
+
+        try:
+            raw = (await bizhawk.read(ctx.bizhawk_ctx, [(shard_addr, 4, "System Bus")]))[0]
+        except (bizhawk.RequestFailedError, bizhawk.ConnectorError, bizhawk.SyncError, TypeError, AttributeError):
+            return
+        shard_bits = self._u32_le(raw)
+
+        newly_observed_locations: list[int] = []
+        for location_id in boss_location_ids:
+            bit_index = self._boss_location_bit_index_by_location_id.get(location_id)
+            if bit_index is None:
+                continue
+            if not ((shard_bits >> bit_index) & 1):
+                continue
+            if location_id in ctx.checked_locations:
+                continue
+            newly_observed_locations.append(location_id)
+
+        if not newly_observed_locations:
+            return
+
+        staged_before = set(self._boss_probe_fallback_location_ids)
+        self._boss_probe_fallback_location_ids.update(newly_observed_locations)
+        if self._boss_probe_fallback_location_ids != staged_before:
+            self._log_verbose(
+                "info",
+                "KirbyAM: staged boss fallback from boss-room departure (departed=%s, shard_bits=0x%08x, locations=%s)",
+                departed_room_region_key,
+                shard_bits,
+                sorted(newly_observed_locations),
+            )
 
     async def _poll_room_sanity_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -4150,6 +4150,46 @@ async def test_poll_boss_defeat_does_not_stage_probe_fallback_without_rising_edg
 
 
 @pytest.mark.asyncio
+async def test_room_departure_stages_boss_fallback_when_shard_already_owned(mock_bizhawk_context):
+    """Issue #754: leaving a boss room with an already-owned shard should stage fallback checks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    boss1_loc = data.locations["BOSS_DEFEAT_1"].location_id
+    assert boss1_loc is not None
+
+    # Use compact test-only room maps so we can drive deterministic room transitions.
+    client._room_region_key_by_doors_idx = {
+        10: "REGION_MUSTARD_MOUNTAIN/ROOM_4_WARP",
+        11: "REGION_MUSTARD_MOUNTAIN/ROOM_4_00",
+    }
+    client._room_label_by_doors_idx = {
+        10: "Mustard Boss Warp",
+        11: "Mustard Exit Room",
+    }
+
+    with patch.dict(
+        data.transport_ram_addresses,
+        {"shard_bitfield": 0x0203B000},
+        clear=False,
+    ), patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        # First poll: enter boss room. Second poll: leave boss room.
+        # Shard bit 0 already set (AP-owned) when departure fallback runs.
+        mock_read.side_effect = [
+            [(1).to_bytes(2, 'little')],
+            [(10).to_bytes(2, 'little')],
+            [(2).to_bytes(2, 'little')],
+            [(11).to_bytes(2, 'little')],
+            [(0x01).to_bytes(4, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert boss1_loc in client._boss_probe_fallback_location_ids
+
+
+@pytest.mark.asyncio
 async def test_poll_boss_defeat_skips_when_address_missing(mock_bizhawk_context):
     """When boss_defeat_flags address is not in addresses.json the method should no-op."""
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary
- fix Issue #754 where boss-defeat LocationChecks could be missed when the shard was already AP-delivered
- add a room-departure fallback that stages boss checks for boss rooms when the matching shard bit is already owned
- keep existing transport and native-probe fallback behavior intact

## Testing
- python -m pytest worlds/kirbyam/test/test_client.py -k "boss_defeat or room_departure_stages_boss_fallback"

## Notes
- local pre-commit flake8 hook reports existing repository-wide violations unrelated to this change
- local push required SKIP=mypy-strict because mypy is not installed in this environment

Closes #754
