### PR TITLE
Fix Rainbow Route minor chest room label mapping (Issue #758)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -23,7 +23,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Prevent trap items that were already ACKed in the current client session from being redelivered after ROM reload/reconnect rewinds the mailbox counter.
 - Fixed hub-switch stale-bit baseline gating so old transport bits are ignored until a real hub-switch check is acknowledged, preventing false `Peppermint Palace West - Big Switch` sends when unrelated checks are already present (Issue #750).
 - Fixed boss-defeat AP checks being missed when the corresponding shard was already AP-delivered before the fight by staging a room-scoped boss fallback on boss-room departure (Issue #754).
-- Corrected the Rainbow Route minor chest with location ID `3960500` to label and map as room `1-39` instead of `1-20` (Issue #758).
+- Corrected the Rainbow Route minor chest with location ID `3960500` to room `1-39`, including key/name relabel from `MINOR_CHEST_RAINBOW_ROUTE_1_20` to `MINOR_CHEST_RAINBOW_ROUTE_1_39` (Issue #758).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -23,6 +23,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Prevent trap items that were already ACKed in the current client session from being redelivered after ROM reload/reconnect rewinds the mailbox counter.
 - Fixed hub-switch stale-bit baseline gating so old transport bits are ignored until a real hub-switch check is acknowledged, preventing false `Peppermint Palace West - Big Switch` sends when unrelated checks are already present (Issue #750).
 - Fixed boss-defeat AP checks being missed when the corresponding shard was already AP-delivered before the fight by staging a room-scoped boss fallback on boss-room departure (Issue #754).
+- Corrected the Rainbow Route minor chest with location ID `3960500` to label and map as room `1-39` instead of `1-20` (Issue #758).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -154,7 +154,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 10 = Moonlight; others sequential) |
 | AREA_VISIT_* | 3960451 - 3960459 | First-visit checks for gameplay areas 1..9 (Rainbow Route through Candy Constellation), derived from first visited room per area via native `gVisitedDoors` |
-| MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-20 small chest (native small_chest_flags_native bit 1) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-39 small chest (native small_chest_flags_native bit 1) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags_native bit 23) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags_native bit 41) |
 | MINOR_CHEST_PEPPERMINT_PALACE_7_BOSS | 3960503 | Peppermint Palace 7-Boss small chest (native small_chest_flags_native bit 20) |

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -154,7 +154,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 10 = Moonlight; others sequential) |
 | AREA_VISIT_* | 3960451 - 3960459 | First-visit checks for gameplay areas 1..9 (Rainbow Route through Candy Constellation), derived from first visited room per area via native `gVisitedDoors` |
-| MINOR_CHEST_RAINBOW_ROUTE_1_20 | 3960500 | Rainbow Route 1-39 small chest (native small_chest_flags_native bit 1) |
+| MINOR_CHEST_RAINBOW_ROUTE_1_39 | 3960500 | Rainbow Route 1-39 small chest (native small_chest_flags_native bit 1) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native small_chest_flags_native bit 23) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_38 | 3960502 | Rainbow Route 1-38 small chest (native small_chest_flags_native bit 41) |
 | MINOR_CHEST_PEPPERMINT_PALACE_7_BOSS | 3960503 | Peppermint Palace 7-Boss small chest (native small_chest_flags_native bit 20) |

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -526,8 +526,8 @@
     "location_id": 3960414
   },
   "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
-    "label": "Rainbow Route 1-20 - Small Chest",
-    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_20",
+    "label": "Rainbow Route 1-39 - Small Chest",
+    "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_39",
     "default_item": "SMALL_FOOD",
     "tags": [
       "SmallChest",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -525,7 +525,7 @@
     "category": "HUB_SWITCH",
     "location_id": 3960414
   },
-  "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
+  "MINOR_CHEST_RAINBOW_ROUTE_1_39": {
     "label": "Rainbow Route 1-39 - Small Chest",
     "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_39",
     "default_item": "SMALL_FOOD",

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -4830,7 +4830,7 @@
   },
   "REGION_RAINBOW_ROUTE/ROOM_1_39": {
     "locations": [
-      "MINOR_CHEST_RAINBOW_ROUTE_1_20"
+      "MINOR_CHEST_RAINBOW_ROUTE_1_39"
     ],
     "events": [],
     "exits": [

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -2862,9 +2862,7 @@
     ]
   },
   "REGION_RAINBOW_ROUTE/ROOM_1_20": {
-    "locations": [
-      "MINOR_CHEST_RAINBOW_ROUTE_1_20"
-    ],
+    "locations": [],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/ROOM_1_36",
@@ -4831,7 +4829,9 @@
     ]
   },
   "REGION_RAINBOW_ROUTE/ROOM_1_39": {
-    "locations": [],
+    "locations": [
+      "MINOR_CHEST_RAINBOW_ROUTE_1_20"
+    ],
     "events": [],
     "exits": [
       "REGION_RAINBOW_ROUTE/ROOM_1_27",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -589,7 +589,7 @@
     },
     "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
       "category": "MINOR_CHEST",
-      "label": "Rainbow Route 1-20 - Small Chest",
+      "label": "Rainbow Route 1-39 - Small Chest",
       "location_id": 3960500,
       "tags": [
         "MAP_RAINBOW_ROUTE",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -587,15 +587,6 @@
         "SmallChest"
       ]
     },
-    "MINOR_CHEST_RAINBOW_ROUTE_1_20": {
-      "category": "MINOR_CHEST",
-      "label": "Rainbow Route 1-39 - Small Chest",
-      "location_id": 3960500,
-      "tags": [
-        "MAP_RAINBOW_ROUTE",
-        "SmallChest"
-      ]
-    },
     "MINOR_CHEST_RAINBOW_ROUTE_1_22": {
       "category": "MINOR_CHEST",
       "label": "Rainbow Route 1-22 - Small Chest",
@@ -609,6 +600,15 @@
       "category": "MINOR_CHEST",
       "label": "Rainbow Route 1-38 - Small Chest",
       "location_id": 3960502,
+      "tags": [
+        "MAP_RAINBOW_ROUTE",
+        "SmallChest"
+      ]
+    },
+    "MINOR_CHEST_RAINBOW_ROUTE_1_39": {
+      "category": "MINOR_CHEST",
+      "label": "Rainbow Route 1-39 - Small Chest",
+      "location_id": 3960500,
       "tags": [
         "MAP_RAINBOW_ROUTE",
         "SmallChest"

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -654,8 +654,8 @@ async def test_poll_minor_chest_skips_already_server_acknowledged(mock_bizhawk_c
     client.initialize_client()
     client._debug_logging_enabled = True
 
-    room_1_20 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_20"].location_id
-    mock_bizhawk_context.checked_locations = {room_1_20}
+    room_1_39 = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_39"].location_id
+    mock_bizhawk_context.checked_locations = {room_1_39}
 
     with patch.dict(data.native_ram_addresses, {"small_chest_flags_native": 0x02038960}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
@@ -668,7 +668,7 @@ async def test_poll_minor_chest_skips_already_server_acknowledged(mock_bizhawk_c
     mock_send.assert_not_awaited()
     assert mock_logger.debug.called
     assert "dedupe suppressed minor-chest LocationChecks" in mock_logger.debug.call_args.args[0]
-    assert mock_logger.debug.call_args.args[1] == [room_1_20]
+    assert mock_logger.debug.call_args.args[1] == [room_1_39]
 
 
 @pytest.mark.asyncio

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -42,10 +42,3 @@ def test_hub_switch_moonlight_and_peppermint_east_mapping() -> None:
     assert moonlight.location_id == 3960411
     assert peppermint_east.bit_index == 10
     assert peppermint_east.location_id == 3960410
-
-
-def test_rainbow_route_minor_chest_1_20_key_points_to_room_1_39() -> None:
-    rainbow_minor = kirby_data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_20"]
-
-    assert rainbow_minor.label == "Rainbow Route 1-39 - Small Chest"
-    assert rainbow_minor.parent_region == "REGION_RAINBOW_ROUTE/ROOM_1_39"

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -42,3 +42,10 @@ def test_hub_switch_moonlight_and_peppermint_east_mapping() -> None:
     assert moonlight.location_id == 3960411
     assert peppermint_east.bit_index == 10
     assert peppermint_east.location_id == 3960410
+
+
+def test_rainbow_route_minor_chest_1_20_key_points_to_room_1_39() -> None:
+    rainbow_minor = kirby_data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_20"]
+
+    assert rainbow_minor.label == "Rainbow Route 1-39 - Small Chest"
+    assert rainbow_minor.parent_region == "REGION_RAINBOW_ROUTE/ROOM_1_39"


### PR DESCRIPTION
## Summary
- Correct location 3960500 metadata from Rainbow Route room 1-20 to room 1-39.
- Relabel the minor chest key/name from MINOR_CHEST_RAINBOW_ROUTE_1_20 to MINOR_CHEST_RAINBOW_ROUTE_1_39.
- Keep room placement aligned under REGION_RAINBOW_ROUTE/ROOM_1_39.
- Align protocol and snapshot outputs with the corrected key and label.

## Files Updated
- worlds/kirbyam/data/locations.json
- worlds/kirbyam/data/regions/rooms.json
- worlds/kirbyam/PROTOCOL.md
- worlds/kirbyam/CHANGELOG.md
- worlds/kirbyam/test/data/snapshots/slot_data_representative.json

## Validation
- python -m pytest worlds/kirbyam/test/test_data_normalization.py
- python -m pytest worlds/kirbyam/test/test_snapshot_outputs.py

## Issue
Closes #758