### PR TITLE
Fix Big Switch label swaps (issue #752)

### DIFF
--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -372,7 +372,7 @@
     "location_id": 3960411
   },
   "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
-    "label": "Rainbow Route East - Big Switch",
+    "label": "Peppermint Palace East - Big Switch",
     "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
     "tags": [
       "HubSwitch",
@@ -383,7 +383,7 @@
     "location_id": 3960401
   },
   "HUB_SWITCH_RAINBOW_ROUTE_SOUTH": {
-    "label": "Rainbow Route South - Big Switch",
+    "label": "Cabbage Cavern East - Big Switch",
     "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
     "tags": [
       "HubSwitch",
@@ -405,7 +405,7 @@
     "location_id": 3960403
   },
   "HUB_SWITCH_RAINBOW_ROUTE_WEST": {
-    "label": "Rainbow Route West - Big Switch",
+    "label": "Candy Constellation - Big Switch",
     "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
     "tags": [
       "HubSwitch",
@@ -471,7 +471,7 @@
     "location_id": 3960409
   },
   "HUB_SWITCH_PEPPERMINT_EAST": {
-    "label": "Peppermint Palace East - Big Switch",
+    "label": "Rainbow Route East - Big Switch",
     "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
     "tags": [
       "HubSwitch",
@@ -493,7 +493,7 @@
     "location_id": 3960400
   },
   "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
-    "label": "Cabbage Cavern East - Big Switch",
+    "label": "Rainbow Route South - Big Switch",
     "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
     "tags": [
       "HubSwitch",
@@ -515,7 +515,7 @@
     "location_id": 3960413
   },
   "HUB_SWITCH_CANDY": {
-    "label": "Candy Constellation - Big Switch",
+    "label": "Rainbow Route West - Big Switch",
     "parent_region": "REGION_CANDY_CONSTELLATION/MAIN",
     "tags": [
       "HubSwitch",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -238,7 +238,7 @@
     },
     "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Cabbage Cavern East - Big Switch",
+      "label": "Rainbow Route South - Big Switch",
       "location_id": 3960412,
       "tags": [
         "HubSwitch",
@@ -256,7 +256,7 @@
     },
     "HUB_SWITCH_CANDY": {
       "category": "HUB_SWITCH",
-      "label": "Candy Constellation - Big Switch",
+      "label": "Rainbow Route West - Big Switch",
       "location_id": 3960414,
       "tags": [
         "HubSwitch",
@@ -301,7 +301,7 @@
     },
     "HUB_SWITCH_PEPPERMINT_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Peppermint Palace East - Big Switch",
+      "label": "Rainbow Route East - Big Switch",
       "location_id": 3960410,
       "tags": [
         "HubSwitch",
@@ -328,7 +328,7 @@
     },
     "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route East - Big Switch",
+      "label": "Peppermint Palace East - Big Switch",
       "location_id": 3960401,
       "tags": [
         "HubSwitch",
@@ -346,7 +346,7 @@
     },
     "HUB_SWITCH_RAINBOW_ROUTE_SOUTH": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route South - Big Switch",
+      "label": "Cabbage Cavern East - Big Switch",
       "location_id": 3960402,
       "tags": [
         "HubSwitch",
@@ -355,7 +355,7 @@
     },
     "HUB_SWITCH_RAINBOW_ROUTE_WEST": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route West - Big Switch",
+      "label": "Candy Constellation - Big Switch",
       "location_id": 3960404,
       "tags": [
         "HubSwitch",

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -61,3 +61,35 @@ def test_hub_switch_labels_match_expected_location_ids() -> None:
     }
 
     assert labels_by_location_id == expected_labels_by_location_id
+
+
+def test_all_hub_switches_have_expected_unique_transport_mapping() -> None:
+    expected_hub_switch_keys = {
+        "HUB_SWITCH_MOONLIGHT",
+        "HUB_SWITCH_RAINBOW_ROUTE_EAST",
+        "HUB_SWITCH_RAINBOW_ROUTE_SOUTH",
+        "HUB_SWITCH_CABBAGE_CAVERN_CENTER",
+        "HUB_SWITCH_RAINBOW_ROUTE_WEST",
+        "HUB_SWITCH_CARROT",
+        "HUB_SWITCH_RAINBOW_ROUTE_NORTH",
+        "HUB_SWITCH_MUSTARD",
+        "HUB_SWITCH_CABBAGE_CAVERN_WEST",
+        "HUB_SWITCH_RADISH",
+        "HUB_SWITCH_PEPPERMINT_EAST",
+        "HUB_SWITCH_PEPPERMINT_WEST",
+        "HUB_SWITCH_CABBAGE_CAVERN_EAST",
+        "HUB_SWITCH_OLIVE",
+        "HUB_SWITCH_CANDY",
+    }
+
+    hub_switches = {
+        key: location
+        for key, location in kirby_data.locations.items()
+        if key.startswith("HUB_SWITCH_")
+    }
+
+    assert set(hub_switches) == expected_hub_switch_keys
+    assert len({location.location_id for location in hub_switches.values()}) == len(hub_switches)
+    assert len({location.bit_index for location in hub_switches.values()}) == len(hub_switches)
+    assert {location.location_id for location in hub_switches.values()} == set(range(3960400, 3960415))
+    assert {location.bit_index for location in hub_switches.values()} == set(range(15))

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -12,11 +12,11 @@ from ..data import _normalize_gba_rom_address, data as kirby_data, format_room_r
         (0x0AF00000, 0x00F00000),
     ],
 )
-def test_normalize_gba_rom_address_mapped_ranges(raw_addr, expected_offset):
+def test_normalize_gba_rom_address_mapped_ranges(raw_addr: int, expected_offset: int) -> None:
     assert _normalize_gba_rom_address(raw_addr) == expected_offset
 
 
-def test_normalize_gba_rom_address_passthrough_for_non_mapped_values():
+def test_normalize_gba_rom_address_passthrough_for_non_mapped_values() -> None:
     assert _normalize_gba_rom_address(0x00F00000) == 0x00F00000
 
 

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -42,3 +42,22 @@ def test_hub_switch_moonlight_and_peppermint_east_mapping() -> None:
     assert moonlight.location_id == 3960411
     assert peppermint_east.bit_index == 10
     assert peppermint_east.location_id == 3960410
+
+
+def test_hub_switch_labels_match_expected_location_ids() -> None:
+    expected_labels_by_location_id = {
+        3960401: "Peppermint Palace East - Big Switch",
+        3960402: "Cabbage Cavern East - Big Switch",
+        3960404: "Candy Constellation - Big Switch",
+        3960410: "Rainbow Route East - Big Switch",
+        3960412: "Rainbow Route South - Big Switch",
+        3960414: "Rainbow Route West - Big Switch",
+    }
+
+    labels_by_location_id = {
+        location.location_id: location.label
+        for location in kirby_data.locations.values()
+        if location.location_id in expected_labels_by_location_id
+    }
+
+    assert labels_by_location_id == expected_labels_by_location_id

--- a/worlds/kirbyam/test/test_reset_safe_shards.py
+++ b/worlds/kirbyam/test/test_reset_safe_shards.py
@@ -3,7 +3,6 @@
 import re
 import sys
 import os
-import importlib.util
 
 # Prevent stdlib types module shadowing
 _SCRIPT_DIR = os.path.realpath(os.path.dirname(__file__))
@@ -13,7 +12,7 @@ for path_entry in list(sys.path):
     if resolved == _WORLD_DIR:
         sys.path.remove(path_entry)
 
-import pytest
+import pytest  # noqa: E402
 
 
 def test_shard_persistence_addresses_defined():
@@ -22,15 +21,15 @@ def test_shard_persistence_addresses_defined():
     # - SRAM_BASE (0x0E000000)
     # - SRAM_SHARD_FIELD_OFFSET (0x12)
     # - SRAM_CHECKSUM_1/2/3 offsets (0x18, 0x1A, 0x1C)
-    
+
     # This is verified at compile time in ap_payload.c, so this test
     # confirms the implementation exists and is documented.
     payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")
     assert os.path.exists(payload_path), "ap_payload.c should exist"
-    
+
     with open(payload_path, 'r') as f:
         content = f.read()
-    
+
     # Verify SRAM definitions are present
     assert "SRAM_BASE" in content, "SRAM_BASE should be defined"
     assert "SRAM_SHARD_FIELD_OFFSET" in content, "SRAM_SHARD_FIELD_OFFSET should be defined"
@@ -41,10 +40,10 @@ def test_shard_persistence_addresses_defined():
 def test_shard_persistence_function_exists():
     """Verify persist_shard_to_sram function is called when granting shards."""
     payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")
-    
+
     with open(payload_path, 'r') as f:
         content = f.read()
-    
+
     # Verify the function is defined
     assert "persist_shard_to_sram(new_shard_flags)" in content, \
         "persist_shard_to_sram should be called when granting shards"
@@ -120,7 +119,12 @@ def test_payload_tracks_sound_player_chest_checks_and_ap_unlock_apply():
 
 
 def test_payload_tracks_hub_switch_checks_from_world_map_unlocks() -> None:
-    """Verify world-map big-switch unlock callbacks set dedicated AP hub-switch check flags."""
+    """Verify world-map unlock hook records AP hub-switch checks using the task +0x08 index.
+
+    Decomp reference (katam): `sub_08039ED4` dispatches unlock callbacks from
+    `gUnk_0834BD94` using `ldrh [task, #8]`. The AP hook must read the same
+    halfword and set `AP_HUB_SWITCH_FLAGS` based on that runtime index.
+    """
     payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")
 
     with open(payload_path, 'r') as f:
@@ -129,21 +133,37 @@ def test_payload_tracks_hub_switch_checks_from_world_map_unlocks() -> None:
     assert "AP_HUB_SWITCH_FLAGS" in content, "Hub switch transport register should be defined"
     assert "ap_set_hub_switch_flag" in content, "Hub switch flag helper should exist"
     assert "ap_on_world_map_unlock_call" in content, "World-map unlock hook target should exist"
-    assert "door_index" in content, "World-map unlock hook should read the unlock door index"
+    assert "task_ptr + 0x08u" in content, "Hook should read the world-map unlock task index at +0x08"
+    assert "unlock_fn();" in content, "Hook should preserve native unlock callback behavior"
+
+    hook_match = re.search(
+        r"void\s+ap_on_world_map_unlock_call[^{]*\{(?P<body>.*?)^}",
+        content,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert hook_match is not None, "ap_on_world_map_unlock_call definition must exist"
+    hook_body = hook_match.group("body")
+
+    assert "door_index = *(volatile uint16_t*)(task_ptr + 0x08u);" in hook_body, (
+        "Hook should read world-map unlock index from task +0x08"
+    )
+    assert "ap_set_hub_switch_flag((uint32_t)door_index);" in hook_body, (
+        "Hook should map task index directly into AP_HUB_SWITCH_FLAGS"
+    )
 
 
 def test_sram_checksum_fields_updated():
     """Verify that checksum fields are updated alongside shard persistence."""
     payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")
-    
+
     with open(payload_path, 'r') as f:
         content = f.read()
-    
+
     # Verify checksum update logic exists
     assert "SRAM_CHECKSUM_1 = " in content, "Checksum 1 should be updated"
     assert "SRAM_CHECKSUM_2 = " in content, "Checksum 2 should be updated"
     assert "SRAM_CHECKSUM_3 = " in content, "Checksum 3 should be updated"
-    
+
     # Verify they use the shard bitfield value
     assert "new_shard_bitfield" in content, "Checksums should be derived from shard bitfield"
 
@@ -151,14 +171,14 @@ def test_sram_checksum_fields_updated():
 def test_issue_109_addresses_documented():
     """Verify Issue #109 addresses are documented in the payload."""
     payload_path = os.path.join(_WORLD_DIR, "kirby_ap_payload", "ap_payload.c")
-    
+
     with open(payload_path, 'r') as f:
         content = f.read()
-    
+
     # Verify the specific candidate SRAM addresses are in some form
     # Issue #109 mentions: 000018, 00001A, 00001C, 00032C, 00032E, 000330
     # Our implementation uses: 0x12 (18), 0x18 (24), 0x1A (26), 0x1C (28)
-    
+
     # These are in the ranges mentioned in Issue #109
     assert "0x12" in content or "18" in content, "SRAM offset 0x12 should be defined"
     assert "0x18" in content or "24" in content, "SRAM offset 0x18 should be defined"


### PR DESCRIPTION
## Summary
- swap the six mislabeled Big Switch display labels without changing any switch addresses/IDs
- update representative slot_data snapshot labels to match corrected data
- add a regression test that asserts expected label mapping by location_id for the affected switches

## Testing
- python -m pytest worlds/kirbyam/test/test_data_normalization.py worlds/kirbyam/test/test_rules.py

Fixes #752