### PR TITLE
Release v0.2.2 pre-tag sync

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -11,6 +11,24 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### New Features
 
+- None.
+
+### Improvements
+
+- None.
+
+### Bug Fixes
+
+- None.
+
+### Internal Changes
+
+- None.
+
+## v0.2.2
+
+### New Features
+
 - Expanded `MINOR_CHEST` AP checks by enabling additional unique native small-chest bit mappings across multiple areas while keeping ambiguous/reused-bit mappings deferred.
 
 ### Improvements

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.1",
+  "world_version": "0.2.2",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- cut changelog release section for v0.2.2 from Unreleased
- bump kirbyam world_version to 0.2.2

## Release Flow
This PR is the required pre-tag sync step. After merge, tag the merged main commit as kirbyam-v0.2.2.