### PR TITLE
Fix infinite trap rewind loop after ROM counter reset

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -19,7 +19,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### Bug Fixes
 
-- None.
+- Fixed an infinite mailbox rewind loop after BizHawk disconnect/ROM reset when the last replayed item is a session-ACKed trap by replaying that trap to ROM only when the ROM counter shows the slot is still unapplied (Issue #766).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -3184,6 +3184,15 @@ class KirbyAmClient(BizHawkClient):
                         self._item_name(ctx, item_id, player_id),
                         self._player_name(ctx, player_id),
                     )
+                elif self._delivery_counter_ahead_fallback_active or rom_received_count > len(ctx.items_received):
+                    self._log_verbose(
+                        "info",
+                        "KirbyAM: replaying session-ACKed trap at item index %s (%s from %s) because ROM counter=%s is unreliable/out-of-range",
+                        self._delivered_item_index,
+                        self._item_name(ctx, item_id, player_id),
+                        self._player_name(ctx, player_id),
+                        rom_received_count,
+                    )
                 else:
                     self._log_verbose(
                         "info",

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -3153,7 +3153,12 @@ class KirbyAmClient(BizHawkClient):
             if self._is_acknowledged_trap_index(ctx, self._delivered_item_index):
                 # Safe skip only when ROM has already applied this item slot.
                 # After ROM reset/rewind, replay the slot so ROM counter can advance.
-                if rom_received_count is not None and rom_received_count >= (self._delivered_item_index + 1):
+                if (
+                    not self._delivery_counter_ahead_fallback_active
+                    and rom_received_count is not None
+                    and rom_received_count <= len(ctx.items_received)
+                    and rom_received_count >= (self._delivered_item_index + 1)
+                ):
                     self._log_verbose(
                         "info",
                         "KirbyAM: skipping already-ACKed trap replay at item index %s (%s from %s)",
@@ -3171,12 +3176,23 @@ class KirbyAmClient(BizHawkClient):
                     await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
                     continue
 
-                self._log_verbose(
-                    "info",
-                    "KirbyAM: replaying session-ACKed trap at item index %s because ROM counter=%s indicates slot is not applied",
-                    self._delivered_item_index,
-                    rom_received_count,
-                )
+                if rom_received_count is None:
+                    self._log_verbose(
+                        "info",
+                        "KirbyAM: replaying session-ACKed trap at item index %s (%s from %s) because ROM counter is unavailable",
+                        self._delivered_item_index,
+                        self._item_name(ctx, item_id, player_id),
+                        self._player_name(ctx, player_id),
+                    )
+                else:
+                    self._log_verbose(
+                        "info",
+                        "KirbyAM: replaying session-ACKed trap at item index %s (%s from %s) because ROM counter=%s indicates slot is not applied",
+                        self._delivered_item_index,
+                        self._item_name(ctx, item_id, player_id),
+                        self._player_name(ctx, player_id),
+                        rom_received_count,
+                    )
 
             if self._delivery_counter_ahead_fallback_active and not self._delivery_counter_ahead_resume_logged:
                 self._log_verbose(

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -3151,22 +3151,32 @@ class KirbyAmClient(BizHawkClient):
             item_id, player_id = item_fields
 
             if self._is_acknowledged_trap_index(ctx, self._delivered_item_index):
+                # Safe skip only when ROM has already applied this item slot.
+                # After ROM reset/rewind, replay the slot so ROM counter can advance.
+                if rom_received_count is not None and rom_received_count >= (self._delivered_item_index + 1):
+                    self._log_verbose(
+                        "info",
+                        "KirbyAM: skipping already-ACKed trap replay at item index %s (%s from %s)",
+                        self._delivered_item_index,
+                        self._item_name(ctx, item_id, player_id),
+                        self._player_name(ctx, player_id),
+                    )
+                    self._delivered_item_index += 1
+                    self._delivery_pending = False
+                    self._delivery_pending_time = None
+                    self._delivery_pending_item_index = None
+                    self._delivery_timeout_streak = 0
+                    self._delivery_retry_not_before = 0.0
+                    self._delivery_payload_stall_warned = False
+                    await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
+                    continue
+
                 self._log_verbose(
                     "info",
-                    "KirbyAM: skipping already-ACKed trap replay at item index %s (%s from %s)",
+                    "KirbyAM: replaying session-ACKed trap at item index %s because ROM counter=%s indicates slot is not applied",
                     self._delivered_item_index,
-                    self._item_name(ctx, item_id, player_id),
-                    self._player_name(ctx, player_id),
+                    rom_received_count,
                 )
-                self._delivered_item_index += 1
-                self._delivery_pending = False
-                self._delivery_pending_time = None
-                self._delivery_pending_item_index = None
-                self._delivery_timeout_streak = 0
-                self._delivery_retry_not_before = 0.0
-                self._delivery_payload_stall_warned = False
-                await self._persist_u32(ctx, "delivered_item_index", self._delivered_item_index)
-                continue
 
             if self._delivery_counter_ahead_fallback_active and not self._delivery_counter_ahead_resume_logged:
                 self._log_verbose(

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2347,19 +2347,20 @@ async def test_deliver_items_replays_already_acked_trap_when_rom_counter_not_adv
     assert client._delivered_item_index == 0
     assert client._delivery_pending is True
     mock_display.assert_not_awaited()
-    writes = mock_write.await_args_list
-    assert writes[0] == call(
-        mock_bizhawk_context.bizhawk_ctx,
-        [(data.transport_ram_addresses["delivered_item_index"], (0).to_bytes(4, 'little'), 'System Bus')],
-    )
-    assert writes[1] == call(
-        mock_bizhawk_context.bizhawk_ctx,
-        [
-            (data.transport_ram_addresses["incoming_item_id"], int(3860032).to_bytes(4, 'little'), 'System Bus'),
-            (data.transport_ram_addresses["incoming_item_player"], int(2).to_bytes(4, 'little'), 'System Bus'),
-            (data.transport_ram_addresses["incoming_item_flag"], (1).to_bytes(4, 'little'), 'System Bus'),
-        ],
-    )
+    assert mock_write.await_args_list == [
+        call(
+            mock_bizhawk_context.bizhawk_ctx,
+            [(data.transport_ram_addresses["delivered_item_index"], (0).to_bytes(4, 'little'), 'System Bus')],
+        ),
+        call(
+            mock_bizhawk_context.bizhawk_ctx,
+            [
+                (data.transport_ram_addresses["incoming_item_id"], int(3860032).to_bytes(4, 'little'), 'System Bus'),
+                (data.transport_ram_addresses["incoming_item_player"], int(2).to_bytes(4, 'little'), 'System Bus'),
+                (data.transport_ram_addresses["incoming_item_flag"], (1).to_bytes(4, 'little'), 'System Bus'),
+            ],
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2322,8 +2322,8 @@ async def test_receive_notification_reconnect_replay_dedupes_on_rewind(mock_bizh
 
 
 @pytest.mark.asyncio
-async def test_deliver_items_skips_already_acked_trap_on_counter_rewind(mock_bizhawk_context):
-    """Trap deliveries already ACKed in this session should not be replayed after a counter rewind."""
+async def test_deliver_items_replays_already_acked_trap_when_rom_counter_not_advanced(mock_bizhawk_context):
+    """If ROM rewinds and slot is unfilled, replay session-ACKed trap so ROM counter can advance."""
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -2344,14 +2344,51 @@ async def test_deliver_items_skips_already_acked_trap_on_counter_rewind(mock_biz
 
         await client._deliver_items(mock_bizhawk_context)
 
+    assert client._delivered_item_index == 0
+    assert client._delivery_pending is True
+    mock_display.assert_not_awaited()
+    writes = mock_write.await_args_list
+    assert writes[0] == call(
+        mock_bizhawk_context.bizhawk_ctx,
+        [(data.transport_ram_addresses["delivered_item_index"], (0).to_bytes(4, 'little'), 'System Bus')],
+    )
+    assert writes[1] == call(
+        mock_bizhawk_context.bizhawk_ctx,
+        [
+            (data.transport_ram_addresses["incoming_item_id"], int(3860032).to_bytes(4, 'little'), 'System Bus'),
+            (data.transport_ram_addresses["incoming_item_player"], int(2).to_bytes(4, 'little'), 'System Bus'),
+            (data.transport_ram_addresses["incoming_item_flag"], (1).to_bytes(4, 'little'), 'System Bus'),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_items_skips_already_acked_trap_when_rom_counter_already_applied(mock_bizhawk_context):
+    """Skip trap replay only when ROM counter confirms this item slot was already applied."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.items_received = [
+        Mock(item=3860032, player=2),
+    ]
+
+    client._acknowledged_trap_indices.add(0)
+    client._delivered_item_index = 0
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write, \
+         patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display:
+        mock_read.return_value = [
+            (0).to_bytes(4, 'little'),
+            (1).to_bytes(4, 'little'),
+        ]
+
+        await client._deliver_items(mock_bizhawk_context)
+
     assert client._delivered_item_index == 1
     assert client._delivery_pending is False
     mock_display.assert_not_awaited()
     assert mock_write.await_args_list == [
-        call(
-            mock_bizhawk_context.bizhawk_ctx,
-            [(data.transport_ram_addresses["delivered_item_index"], (0).to_bytes(4, 'little'), 'System Bus')],
-        ),
         call(
             mock_bizhawk_context.bizhawk_ctx,
             [(data.transport_ram_addresses["delivered_item_index"], (1).to_bytes(4, 'little'), 'System Bus')],


### PR DESCRIPTION
## Summary
- Fix mailbox trap replay handling to only skip session-ACKed trap slots when ROM counter confirms the slot is already applied
- Replay session-ACKed trap slots when ROM counter indicates the slot is still unapplied, allowing ROM counter advancement after reconnect/reset
- Add regression tests for both replay-required and safe-skip reconnect paths
- Document the fix in the KirbyAM changelog (Unreleased)

## Testing
- python -m pytest worlds/kirbyam/test/test_client.py -k "acked_trap or save_loss"

Fixes #766