### PR TITLE
Release v0.2.3

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -11,6 +11,24 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ### New Features
 
+- None.
+
+### Improvements
+
+- None.
+
+### Bug Fixes
+
+- None.
+
+### Internal Changes
+
+- None.
+
+## v0.2.3
+
+### New Features
+
 - Added provisional unmapped minor chest report locations (`Unmapped Minor Chest X-N (Report Location)`) for the remaining manifest entries, gated behind a new `Unmapped Minor Chest Report Locations` option so standard seeds remain unchanged by default.
 
 ### Improvements

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.2",
+  "world_version": "0.2.3",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Release v0.2.3

This release includes:

### New Features
- Added provisional unmapped minor chest report locations gated behind a new \Unmapped Minor Chest Report Locations\ option

### Bug Fixes
- Fixed infinite mailbox rewind loop after BizHawk disconnect/ROM reset when the last replayed item is a session-ACKed trap (Issue #766)
- Fixed false \Peppermint Palace West - Big Switch\ AP checks (Issue #750)
- Hardened the Issue #754 boss-departure fallback to handle edge cases in room resolution

This PR bumps the world version to 0.2.3.