### PR TITLE
Fix Big Switch name regression

### DIFF
--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -361,7 +361,7 @@
     "location_id": 3960304
   },
   "HUB_SWITCH_MOONLIGHT": {
-    "label": "Moonlight Mansion - Big Switch",
+    "label": "Radish Ruins - Big Switch",
     "parent_region": "REGION_MOONLIGHT_MANSION/MAIN",
     "tags": [
       "HubSwitch",
@@ -460,7 +460,7 @@
     "location_id": 3960408
   },
   "HUB_SWITCH_RADISH": {
-    "label": "Radish Ruins - Big Switch",
+    "label": "Rainbow Route East - Big Switch",
     "parent_region": "REGION_RADISH_RUINS/MAIN",
     "tags": [
       "HubSwitch",
@@ -471,7 +471,7 @@
     "location_id": 3960409
   },
   "HUB_SWITCH_PEPPERMINT_EAST": {
-    "label": "Rainbow Route East - Big Switch",
+    "label": "Moonlight Mansion - Big Switch",
     "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
     "tags": [
       "HubSwitch",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -274,7 +274,7 @@
     },
     "HUB_SWITCH_MOONLIGHT": {
       "category": "HUB_SWITCH",
-      "label": "Moonlight Mansion - Big Switch",
+      "label": "Radish Ruins - Big Switch",
       "location_id": 3960411,
       "tags": [
         "HubSwitch",
@@ -301,7 +301,7 @@
     },
     "HUB_SWITCH_PEPPERMINT_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route East - Big Switch",
+      "label": "Moonlight Mansion - Big Switch",
       "location_id": 3960410,
       "tags": [
         "HubSwitch",
@@ -319,7 +319,7 @@
     },
     "HUB_SWITCH_RADISH": {
       "category": "HUB_SWITCH",
-      "label": "Radish Ruins - Big Switch",
+      "label": "Rainbow Route East - Big Switch",
       "location_id": 3960409,
       "tags": [
         "HubSwitch",

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -49,7 +49,9 @@ def test_hub_switch_labels_match_expected_location_ids() -> None:
         3960401: "Peppermint Palace East - Big Switch",
         3960402: "Cabbage Cavern East - Big Switch",
         3960404: "Candy Constellation - Big Switch",
-        3960410: "Rainbow Route East - Big Switch",
+        3960409: "Rainbow Route East - Big Switch",
+        3960410: "Moonlight Mansion - Big Switch",
+        3960411: "Radish Ruins - Big Switch",
         3960412: "Rainbow Route South - Big Switch",
         3960414: "Rainbow Route West - Big Switch",
     }


### PR DESCRIPTION
## Summary
- restore Hub Switch labels to match their actual switch keys/areas in KirbyAM location data
- update data normalization coverage to assert key-to-label correctness for affected Hub Switch entries
- update representative slot_data snapshot labels and add Unreleased changelog note for Issue #775

## Testing
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_data_normalization.py -q
- d:/KirbyProject/Archipelago-kirbyam/.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_snapshot_outputs.py -q

Closes #775