### PR TITLE
Add disconnected subroom logic.

### DIFF
--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -158,6 +158,10 @@ def _parse_int(value: Any) -> int:
     raise TypeError(f"Expected int/str for integer field, got {type(value)}")
 
 
+def _logical_subregion_region_name(parent_room_region: str, logical_key: str) -> str:
+    return f"{parent_room_region}__LOGIC__{logical_key}"
+
+
 def _normalize_gba_rom_address(value: int) -> int:
     """
     Convert a GBA cartridge bus address to a ROM file/domain offset.
@@ -544,6 +548,38 @@ def _init() -> None:
                 raise ValueError(f"Region [{region_name}] was defined multiple times")
             merged_regions[region_name] = region_def
 
+    # Build reusable logical room-subregion metadata so room-sanity can stay bound
+    # to the canonical room while transition logic can target split sections.
+    logical_subregions_by_parent: dict[str, dict[str, dict[str, Any]]] = {}
+    logical_region_names: dict[tuple[str, str], str] = {}
+
+    for region_name, region_def in merged_regions.items():
+        if not isinstance(region_name, str) or not isinstance(region_def, dict):
+            continue
+        logical_subregions_raw = region_def.get("logical_subregions")
+        if logical_subregions_raw is None:
+            continue
+        if not isinstance(logical_subregions_raw, dict):
+            raise TypeError(
+                f"Region [{region_name}] logical_subregions must be an object mapping keys to definitions"
+            )
+
+        parent_subregions: dict[str, dict[str, Any]] = {}
+        for logical_key, logical_def in logical_subregions_raw.items():
+            if not isinstance(logical_key, str) or not logical_key:
+                raise TypeError(
+                    f"Region [{region_name}] logical_subregions keys must be non-empty strings"
+                )
+            if not isinstance(logical_def, dict):
+                raise TypeError(
+                    f"Region [{region_name}] logical_subregion [{logical_key}] must be an object"
+                )
+
+            parent_subregions[logical_key] = logical_def
+            logical_region_names[(region_name, logical_key)] = _logical_subregion_region_name(region_name, logical_key)
+
+        logical_subregions_by_parent[region_name] = parent_subregions
+
     # Create region objects, and claim locations
     claimed_locations: set[str] = set()
 
@@ -554,9 +590,33 @@ def _init() -> None:
         region = RegionData(region_name)
 
         # Exits
+        logical_exit_overrides = region_def.get("logical_exit_overrides", {})
+        if not isinstance(logical_exit_overrides, dict):
+            raise TypeError(
+                f"Region [{region_name}] logical_exit_overrides must be an object mapping destination rooms to logical subregion keys"
+            )
+
         for exit_name in region_def.get("exits", []):
-            if isinstance(exit_name, str):
-                region.exits.append(exit_name)
+            if not isinstance(exit_name, str):
+                continue
+
+            overridden_exit = exit_name
+            override_target = logical_exit_overrides.get(exit_name)
+            if override_target is not None:
+                if not isinstance(override_target, str) or not override_target:
+                    raise TypeError(
+                        "logical_exit_overrides values must be non-empty strings "
+                        f"(region={region_name}, destination={exit_name})"
+                    )
+                logical_region_name = logical_region_names.get((exit_name, override_target))
+                if logical_region_name is None:
+                    raise ValueError(
+                        "logical_exit_overrides references undefined logical subregion "
+                        f"[{override_target}] on destination room [{exit_name}]"
+                    )
+                overridden_exit = logical_region_name
+
+            region.exits.append(overridden_exit)
 
         # Locations
         for loc_key in region_def.get("locations", []):
@@ -577,6 +637,54 @@ def _init() -> None:
                 region.events.append(EventData(ev, region_name))
 
         data.regions[region_name] = region
+
+    # Create synthetic logical room-subregions referenced by logical_exit_overrides.
+    for parent_region_name, logical_subregions in logical_subregions_by_parent.items():
+        for logical_key, logical_def in logical_subregions.items():
+            logical_region_name = logical_region_names[(parent_region_name, logical_key)]
+            logical_region = RegionData(logical_region_name)
+
+            exits_raw = logical_def.get("exits", [])
+            if not isinstance(exits_raw, list):
+                raise TypeError(
+                    f"Logical subregion [{logical_key}] on [{parent_region_name}] exits must be a list"
+                )
+
+            for exit_name in exits_raw:
+                if isinstance(exit_name, str):
+                    logical_region.exits.append(exit_name)
+
+            locations_raw = logical_def.get("locations", [])
+            if not isinstance(locations_raw, list):
+                raise TypeError(
+                    f"Logical subregion [{logical_key}] on [{parent_region_name}] locations must be a list"
+                )
+
+            for loc_key in locations_raw:
+                if not isinstance(loc_key, str):
+                    continue
+                if loc_key in claimed_locations:
+                    raise ValueError(f"Location [{loc_key}] was claimed by multiple regions")
+                if loc_key not in data.locations:
+                    raise ValueError(
+                        f"Logical subregion [{logical_region_name}] references unknown location key [{loc_key}]"
+                    )
+                logical_region.locations.append(loc_key)
+                claimed_locations.add(loc_key)
+
+            logical_region.locations.sort()
+
+            events_raw = logical_def.get("events", [])
+            if not isinstance(events_raw, list):
+                raise TypeError(
+                    f"Logical subregion [{logical_key}] on [{parent_region_name}] events must be a list"
+                )
+
+            for ev in events_raw:
+                if isinstance(ev, str):
+                    logical_region.events.append(EventData(ev, logical_region_name))
+
+            data.regions[logical_region_name] = logical_region
 
     # Auto-claim generated room-sanity locations by their parent region.
     # This keeps data integrity checks complete while runtime region creation can

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -596,9 +596,15 @@ def _init() -> None:
                 f"Region [{region_name}] logical_exit_overrides must be an object mapping destination rooms to logical subregion keys"
             )
 
-        for exit_name in region_def.get("exits", []):
+        exits_raw = region_def.get("exits", [])
+        if not isinstance(exits_raw, list):
+            raise TypeError(f"Region [{region_name}] exits must be a list")
+
+        exit_destinations: set[str] = set()
+        for exit_name in exits_raw:
             if not isinstance(exit_name, str):
                 continue
+            exit_destinations.add(exit_name)
 
             overridden_exit = exit_name
             override_target = logical_exit_overrides.get(exit_name)
@@ -617,6 +623,17 @@ def _init() -> None:
                 overridden_exit = logical_region_name
 
             region.exits.append(overridden_exit)
+
+        for override_destination in logical_exit_overrides:
+            if not isinstance(override_destination, str) or not override_destination:
+                raise TypeError(
+                    f"Region [{region_name}] logical_exit_overrides keys must be non-empty strings"
+                )
+            if override_destination not in exit_destinations:
+                raise ValueError(
+                    "logical_exit_overrides references destination not present in exits "
+                    f"(region={region_name}, destination={override_destination})"
+                )
 
         # Locations
         for loc_key in region_def.get("locations", []):

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -12075,6 +12075,9 @@
     "exits": [
       "REGION_CARROT_CASTLE/ROOM_5_13"
     ],
+    "logical_exit_overrides": {
+      "REGION_CARROT_CASTLE/ROOM_5_13": "ENTRY_FROM_5_18_OR_5_WARP"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961260,
@@ -13394,6 +13397,9 @@
       "REGION_CARROT_CASTLE/ROOM_5_CHEST_1",
       "REGION_CARROT_CASTLE/ROOM_5_14"
     ],
+    "logical_exit_overrides": {
+      "REGION_CARROT_CASTLE/ROOM_5_13": "ENTRY_FROM_5_12"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961127,
@@ -13485,6 +13491,23 @@
       "REGION_CARROT_CASTLE/ROOM_5_18",
       "REGION_CARROT_CASTLE/ROOM_5_WARP"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_5_12": {
+        "exits": [
+          "REGION_CARROT_CASTLE/ROOM_5_12"
+        ],
+        "locations": [],
+        "events": []
+      },
+      "ENTRY_FROM_5_18_OR_5_WARP": {
+        "exits": [
+          "REGION_CARROT_CASTLE/ROOM_5_18",
+          "REGION_CARROT_CASTLE/ROOM_5_WARP"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961134,
@@ -13917,6 +13940,9 @@
       "REGION_CARROT_CASTLE/ROOM_5_CHEST_1",
       "REGION_CARROT_CASTLE/ROOM_5_WARP"
     ],
+    "logical_exit_overrides": {
+      "REGION_CARROT_CASTLE/ROOM_5_13": "ENTRY_FROM_5_18_OR_5_WARP"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961129,
@@ -14829,6 +14855,9 @@
       "REGION_OLIVE_OCEAN/ROOM_6_04",
       "REGION_OLIVE_OCEAN/ROOM_6_05"
     ],
+    "logical_exit_overrides": {
+      "REGION_OLIVE_OCEAN/ROOM_6_05": "ENTRY_FROM_6_04_OR_6_06"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961144,
@@ -14922,6 +14951,23 @@
       "REGION_OLIVE_OCEAN/ROOM_6_06",
       "REGION_OLIVE_OCEAN/ROOM_6_23"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_6_04_OR_6_06": {
+        "exits": [
+          "REGION_OLIVE_OCEAN/ROOM_6_04",
+          "REGION_OLIVE_OCEAN/ROOM_6_06"
+        ],
+        "locations": [],
+        "events": []
+      },
+      "ENTRY_FROM_6_23": {
+        "exits": [
+          "REGION_OLIVE_OCEAN/ROOM_6_23"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961145,
@@ -15013,6 +15059,9 @@
       "REGION_OLIVE_OCEAN/ROOM_6_GOAL_1",
       "REGION_OLIVE_OCEAN/ROOM_6_20"
     ],
+    "logical_exit_overrides": {
+      "REGION_OLIVE_OCEAN/ROOM_6_05": "ENTRY_FROM_6_04_OR_6_06"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961146,
@@ -16438,6 +16487,9 @@
       "REGION_OLIVE_OCEAN/ROOM_6_HUB",
       "REGION_OLIVE_OCEAN/ROOM_6_20"
     ],
+    "logical_exit_overrides": {
+      "REGION_OLIVE_OCEAN/ROOM_6_05": "ENTRY_FROM_6_23"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961164,
@@ -19529,6 +19581,9 @@
       "REGION_RADISH_RUINS/ROOM_8_17",
       "REGION_RADISH_RUINS/ROOM_8_23"
     ],
+    "logical_exit_overrides": {
+      "REGION_RADISH_RUINS/ROOM_8_07": "ENTRY_FROM_8_GOAL_1"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961210,
@@ -20010,6 +20065,9 @@
     "exits": [
       "REGION_RADISH_RUINS/ROOM_8_09"
     ],
+    "logical_exit_overrides": {
+      "REGION_RADISH_RUINS/ROOM_8_09": "ENTRY_FROM_8_03"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961204,
@@ -20050,6 +20108,9 @@
       "REGION_RADISH_RUINS/ROOM_8_06",
       "REGION_RADISH_RUINS/ROOM_8_09"
     ],
+    "logical_exit_overrides": {
+      "REGION_RADISH_RUINS/ROOM_8_09": "ENTRY_FROM_8_04"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961201,
@@ -20273,6 +20334,24 @@
       "REGION_RADISH_RUINS/ROOM_8_21",
       "REGION_RADISH_RUINS/ROOM_8_23"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_8_GOAL_1": {
+        "exits": [
+          "REGION_RADISH_RUINS/ROOM_8_GOAL_1"
+        ],
+        "locations": [],
+        "events": []
+      },
+      "ENTRY_FROM_8_18_OR_8_21_OR_8_23": {
+        "exits": [
+          "REGION_RADISH_RUINS/ROOM_8_18",
+          "REGION_RADISH_RUINS/ROOM_8_21",
+          "REGION_RADISH_RUINS/ROOM_8_23"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961211,
@@ -20479,6 +20558,22 @@
       "REGION_RADISH_RUINS/ROOM_8_04",
       "REGION_RADISH_RUINS/ROOM_8_03"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_8_03": {
+        "exits": [
+          "REGION_RADISH_RUINS/ROOM_8_03"
+        ],
+        "locations": [],
+        "events": []
+      },
+      "ENTRY_FROM_8_04": {
+        "exits": [
+          "REGION_RADISH_RUINS/ROOM_8_04"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961203,
@@ -21332,6 +21427,9 @@
       "REGION_RADISH_RUINS/ROOM_8_21",
       "REGION_RADISH_RUINS/ROOM_8_23"
     ],
+    "logical_exit_overrides": {
+      "REGION_RADISH_RUINS/ROOM_8_07": "ENTRY_FROM_8_18_OR_8_21_OR_8_23"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961213,
@@ -21630,6 +21728,9 @@
       "REGION_RADISH_RUINS/ROOM_8_07",
       "REGION_RADISH_RUINS/ROOM_8_18"
     ],
+    "logical_exit_overrides": {
+      "REGION_RADISH_RUINS/ROOM_8_07": "ENTRY_FROM_8_18_OR_8_21_OR_8_23"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961227,
@@ -21787,6 +21888,9 @@
       "REGION_RADISH_RUINS/ROOM_8_07",
       "REGION_RADISH_RUINS/ROOM_8_18"
     ],
+    "logical_exit_overrides": {
+      "REGION_RADISH_RUINS/ROOM_8_07": "ENTRY_FROM_8_18_OR_8_21_OR_8_23"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961228,

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -5283,6 +5283,9 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2",
       "REGION_MOONLIGHT_MANSION/ROOM_2_07"
     ],
+    "logical_exit_overrides": {
+      "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2": "ENTRY_FROM_2_ENTRY"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961057,
@@ -5530,6 +5533,15 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_19",
       "REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_2_ENTRY": {
+        "exits": [
+          "REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961055,
@@ -6028,6 +6040,9 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_07",
       "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_1"
     ],
+    "logical_exit_overrides": {
+      "REGION_MOONLIGHT_MANSION/ROOM_2_07": "ENTRY_FROM_2_04"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961061,
@@ -6354,6 +6369,15 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_14",
       "REGION_MOONLIGHT_MANSION/ROOM_2_05"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_2_04": {
+        "exits": [
+          "REGION_MOONLIGHT_MANSION/ROOM_2_04"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961063,
@@ -6837,6 +6861,9 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_18",
       "REGION_RAINBOW_ROUTE/ROOM_1_08"
     ],
+    "logical_exit_overrides": {
+      "REGION_MOONLIGHT_MANSION/ROOM_2_17": "LOWER_HALL"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961050,
@@ -7179,6 +7206,9 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_17",
       "REGION_RAINBOW_ROUTE/ROOM_1_07"
     ],
+    "logical_exit_overrides": {
+      "REGION_MOONLIGHT_MANSION/ROOM_2_17": "UPPER_HALL"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961051,
@@ -7271,6 +7301,24 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_18",
       "REGION_MOONLIGHT_MANSION/ROOM_2_19"
     ],
+    "logical_subregions": {
+      "UPPER_HALL": {
+        "exits": [
+          "REGION_MOONLIGHT_MANSION/ROOM_2_16",
+          "REGION_MOONLIGHT_MANSION/ROOM_2_18"
+        ],
+        "locations": [],
+        "events": []
+      },
+      "LOWER_HALL": {
+        "exits": [
+          "REGION_MOONLIGHT_MANSION/ROOM_2_12",
+          "REGION_MOONLIGHT_MANSION/ROOM_2_19"
+        ],
+        "locations": [],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961052,
@@ -7453,6 +7501,9 @@
       "REGION_MOONLIGHT_MANSION/ROOM_2_18",
       "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2"
     ],
+    "logical_exit_overrides": {
+      "REGION_MOONLIGHT_MANSION/ROOM_2_17": "LOWER_HALL"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961054,

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -14942,9 +14942,7 @@
     ]
   },
   "REGION_OLIVE_OCEAN/ROOM_6_05": {
-    "locations": [
-      "MINOR_CHEST_OLIVE_OCEAN_6_05"
-    ],
+    "locations": [],
     "events": [],
     "exits": [
       "REGION_OLIVE_OCEAN/ROOM_6_04",
@@ -14957,7 +14955,9 @@
           "REGION_OLIVE_OCEAN/ROOM_6_04",
           "REGION_OLIVE_OCEAN/ROOM_6_06"
         ],
-        "locations": [],
+        "locations": [
+          "MINOR_CHEST_OLIVE_OCEAN_6_05"
+        ],
         "events": []
       },
       "ENTRY_FROM_6_23": {
@@ -20561,14 +20561,14 @@
     "logical_subregions": {
       "ENTRY_FROM_8_03": {
         "exits": [
-          "REGION_RADISH_RUINS/ROOM_8_03"
+          "REGION_RADISH_RUINS/ROOM_8_04"
         ],
         "locations": [],
         "events": []
       },
       "ENTRY_FROM_8_04": {
         "exits": [
-          "REGION_RADISH_RUINS/ROOM_8_04"
+          "REGION_RADISH_RUINS/ROOM_8_03"
         ],
         "locations": [],
         "events": []

--- a/worlds/kirbyam/data/regions/rooms.json
+++ b/worlds/kirbyam/data/regions/rooms.json
@@ -22134,14 +22134,30 @@
     ]
   },
   "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2": {
-    "locations": [
-      "SOUND_PLAYER_CHEST"
-    ],
+    "locations": [],
     "events": [],
     "exits": [
       "REGION_CANDY_CONSTELLATION/ROOM_9_01",
       "REGION_CANDY_CONSTELLATION/ROOM_9_09"
     ],
+    "logical_subregions": {
+      "ENTRY_FROM_9_01": {
+        "exits": [
+          "REGION_CANDY_CONSTELLATION/ROOM_9_01"
+        ],
+        "locations": [],
+        "events": []
+      },
+      "ENTRY_FROM_9_09": {
+        "exits": [
+          "REGION_CANDY_CONSTELLATION/ROOM_9_09"
+        ],
+        "locations": [
+          "SOUND_PLAYER_CHEST"
+        ],
+        "events": []
+      }
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961233,
@@ -22614,6 +22630,9 @@
       "REGION_CANDY_CONSTELLATION/ROOM_9_07",
       "REGION_CANDY_CONSTELLATION/ROOM_9_02"
     ],
+    "logical_exit_overrides": {
+      "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2": "ENTRY_FROM_9_01"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961234,
@@ -23321,6 +23340,9 @@
       "REGION_CANDY_CONSTELLATION/ROOM_9_11",
       "REGION_CANDY_CONSTELLATION/ROOM_9_HUB"
     ],
+    "logical_exit_overrides": {
+      "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2": "ENTRY_FROM_9_09"
+    },
     "room_sanity": {
       "included": true,
       "location_id": 3961235,

--- a/worlds/kirbyam/data/regions/rooms_schema.md
+++ b/worlds/kirbyam/data/regions/rooms_schema.md
@@ -83,6 +83,33 @@ Each room object contains:
   - Meaning: directional transition details for exits from this room.
   - Rule: this contains per-path metadata such as coordinates, transport type, and optional gates.
 
+- `logical_subregions` (optional):
+  - Type: `dict[str, logical_subregion_object]`
+  - Meaning: defines synthetic logic-only sections for this room while preserving a single room-sanity location on the canonical room key.
+  - Use when one in-game room has disconnected internal segments that should not imply full traversal access.
+
+- `logical_exit_overrides` (optional):
+  - Type: `dict[str, str]`
+  - Meaning: per-exit routing override from this room to a destination room's logical subregion.
+  - Key: canonical destination room key from `exits`.
+  - Value: logical subregion key declared under the destination room's `logical_subregions`.
+
+### Logical Subregion Object Keys
+
+Each logical subregion object contains:
+
+- `exits`:
+  - Type: `list[str]`
+  - Meaning: adjacency list for the synthetic logic-only region.
+
+- `locations`:
+  - Type: `list[str]`
+  - Meaning: optional location keys claimed by this logical subregion.
+
+- `events`:
+  - Type: `list[str]`
+  - Meaning: optional event names claimed by this logical subregion.
+
 ## Transition Object Keys
 
 Each transition object contains:
@@ -137,6 +164,8 @@ Recommended invariants for data integrity:
 - No duplicate transition entries for the same source->destination pair.
 - `transitions` can be empty for rooms with no directional metadata.
 - `exits` remains the authoritative adjacency list.
+- `logical_exit_overrides` keys reference destinations already present in `exits`.
+- `logical_exit_overrides` values reference logical subregion keys defined on the destination room.
 
 ## Notes
 

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -422,6 +422,69 @@ def test_moonlight_rooms_define_logical_subregion_metadata() -> None:
         "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2": "ENTRY_FROM_9_09"
     }
 
+    room_8_07 = rooms["REGION_RADISH_RUINS/ROOM_8_07"]
+    assert room_8_07["logical_subregions"]["ENTRY_FROM_8_GOAL_1"]["exits"] == [
+        "REGION_RADISH_RUINS/ROOM_8_GOAL_1"
+    ]
+    assert set(room_8_07["logical_subregions"]["ENTRY_FROM_8_18_OR_8_21_OR_8_23"]["exits"]) == {
+        "REGION_RADISH_RUINS/ROOM_8_18",
+        "REGION_RADISH_RUINS/ROOM_8_21",
+        "REGION_RADISH_RUINS/ROOM_8_23",
+    }
+    assert rooms["REGION_RADISH_RUINS/ROOM_8_GOAL_1"]["logical_exit_overrides"] == {
+        "REGION_RADISH_RUINS/ROOM_8_07": "ENTRY_FROM_8_GOAL_1"
+    }
+
+    room_8_09 = rooms["REGION_RADISH_RUINS/ROOM_8_09"]
+    assert room_8_09["logical_subregions"]["ENTRY_FROM_8_03"]["exits"] == [
+        "REGION_RADISH_RUINS/ROOM_8_03"
+    ]
+    assert room_8_09["logical_subregions"]["ENTRY_FROM_8_04"]["exits"] == [
+        "REGION_RADISH_RUINS/ROOM_8_04"
+    ]
+    assert rooms["REGION_RADISH_RUINS/ROOM_8_03"]["logical_exit_overrides"] == {
+        "REGION_RADISH_RUINS/ROOM_8_09": "ENTRY_FROM_8_03"
+    }
+    assert rooms["REGION_RADISH_RUINS/ROOM_8_04"]["logical_exit_overrides"] == {
+        "REGION_RADISH_RUINS/ROOM_8_09": "ENTRY_FROM_8_04"
+    }
+
+    room_5_13 = rooms["REGION_CARROT_CASTLE/ROOM_5_13"]
+    assert room_5_13["logical_subregions"]["ENTRY_FROM_5_12"]["exits"] == [
+        "REGION_CARROT_CASTLE/ROOM_5_12"
+    ]
+    assert set(room_5_13["logical_subregions"]["ENTRY_FROM_5_18_OR_5_WARP"]["exits"]) == {
+        "REGION_CARROT_CASTLE/ROOM_5_18",
+        "REGION_CARROT_CASTLE/ROOM_5_WARP",
+    }
+    assert rooms["REGION_CARROT_CASTLE/ROOM_5_12"]["logical_exit_overrides"] == {
+        "REGION_CARROT_CASTLE/ROOM_5_13": "ENTRY_FROM_5_12"
+    }
+    assert rooms["REGION_CARROT_CASTLE/ROOM_5_18"]["logical_exit_overrides"] == {
+        "REGION_CARROT_CASTLE/ROOM_5_13": "ENTRY_FROM_5_18_OR_5_WARP"
+    }
+    assert rooms["REGION_CARROT_CASTLE/ROOM_5_WARP"]["logical_exit_overrides"] == {
+        "REGION_CARROT_CASTLE/ROOM_5_13": "ENTRY_FROM_5_18_OR_5_WARP"
+    }
+
+    room_6_05 = rooms["REGION_OLIVE_OCEAN/ROOM_6_05"]
+    assert set(room_6_05["logical_subregions"]["ENTRY_FROM_6_04_OR_6_06"]["exits"]) == {
+        "REGION_OLIVE_OCEAN/ROOM_6_04",
+        "REGION_OLIVE_OCEAN/ROOM_6_06",
+    }
+    assert room_6_05["logical_subregions"]["ENTRY_FROM_6_23"]["exits"] == [
+        "REGION_OLIVE_OCEAN/ROOM_6_23"
+    ]
+    assert rooms["REGION_OLIVE_OCEAN/ROOM_6_04"]["logical_exit_overrides"] == {
+        "REGION_OLIVE_OCEAN/ROOM_6_05": "ENTRY_FROM_6_04_OR_6_06"
+    }
+    assert rooms["REGION_OLIVE_OCEAN/ROOM_6_06"]["logical_exit_overrides"] == {
+        "REGION_OLIVE_OCEAN/ROOM_6_05": "ENTRY_FROM_6_04_OR_6_06"
+    }
+    assert rooms["REGION_OLIVE_OCEAN/ROOM_6_23"]["logical_exit_overrides"] == {
+        "REGION_OLIVE_OCEAN/ROOM_6_05": "ENTRY_FROM_6_23"
+    }
+
 
 def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     from ..data import data as kirby_data
@@ -432,6 +495,14 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     room_2_goal_2_from_entry = "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2__LOGIC__ENTRY_FROM_2_ENTRY"
     room_9_chest_2_from_9_01 = "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2__LOGIC__ENTRY_FROM_9_01"
     room_9_chest_2_from_9_09 = "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2__LOGIC__ENTRY_FROM_9_09"
+    room_8_07_from_goal_1 = "REGION_RADISH_RUINS/ROOM_8_07__LOGIC__ENTRY_FROM_8_GOAL_1"
+    room_8_07_from_8_18_8_21_8_23 = "REGION_RADISH_RUINS/ROOM_8_07__LOGIC__ENTRY_FROM_8_18_OR_8_21_OR_8_23"
+    room_8_09_from_8_03 = "REGION_RADISH_RUINS/ROOM_8_09__LOGIC__ENTRY_FROM_8_03"
+    room_8_09_from_8_04 = "REGION_RADISH_RUINS/ROOM_8_09__LOGIC__ENTRY_FROM_8_04"
+    room_5_13_from_5_12 = "REGION_CARROT_CASTLE/ROOM_5_13__LOGIC__ENTRY_FROM_5_12"
+    room_5_13_from_5_18_or_5_warp = "REGION_CARROT_CASTLE/ROOM_5_13__LOGIC__ENTRY_FROM_5_18_OR_5_WARP"
+    room_6_05_from_6_04_or_6_06 = "REGION_OLIVE_OCEAN/ROOM_6_05__LOGIC__ENTRY_FROM_6_04_OR_6_06"
+    room_6_05_from_6_23 = "REGION_OLIVE_OCEAN/ROOM_6_05__LOGIC__ENTRY_FROM_6_23"
 
     assert room_2_07_from_2_04 in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_04"].exits
     assert kirby_data.regions[room_2_07_from_2_04].exits == ["REGION_MOONLIGHT_MANSION/ROOM_2_04"]
@@ -442,6 +513,18 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     assert room_2_goal_2_from_entry in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"].exits
     assert room_9_chest_2_from_9_01 in kirby_data.regions["REGION_CANDY_CONSTELLATION/ROOM_9_01"].exits
     assert room_9_chest_2_from_9_09 in kirby_data.regions["REGION_CANDY_CONSTELLATION/ROOM_9_09"].exits
+    assert room_8_07_from_goal_1 in kirby_data.regions["REGION_RADISH_RUINS/ROOM_8_GOAL_1"].exits
+    assert room_8_07_from_8_18_8_21_8_23 in kirby_data.regions["REGION_RADISH_RUINS/ROOM_8_18"].exits
+    assert room_8_07_from_8_18_8_21_8_23 in kirby_data.regions["REGION_RADISH_RUINS/ROOM_8_21"].exits
+    assert room_8_07_from_8_18_8_21_8_23 in kirby_data.regions["REGION_RADISH_RUINS/ROOM_8_23"].exits
+    assert room_8_09_from_8_03 in kirby_data.regions["REGION_RADISH_RUINS/ROOM_8_03"].exits
+    assert room_8_09_from_8_04 in kirby_data.regions["REGION_RADISH_RUINS/ROOM_8_04"].exits
+    assert room_5_13_from_5_12 in kirby_data.regions["REGION_CARROT_CASTLE/ROOM_5_12"].exits
+    assert room_5_13_from_5_18_or_5_warp in kirby_data.regions["REGION_CARROT_CASTLE/ROOM_5_18"].exits
+    assert room_5_13_from_5_18_or_5_warp in kirby_data.regions["REGION_CARROT_CASTLE/ROOM_5_WARP"].exits
+    assert room_6_05_from_6_04_or_6_06 in kirby_data.regions["REGION_OLIVE_OCEAN/ROOM_6_04"].exits
+    assert room_6_05_from_6_04_or_6_06 in kirby_data.regions["REGION_OLIVE_OCEAN/ROOM_6_06"].exits
+    assert room_6_05_from_6_23 in kirby_data.regions["REGION_OLIVE_OCEAN/ROOM_6_23"].exits
 
     assert set(kirby_data.regions[room_2_17_upper].exits) == {
         "REGION_MOONLIGHT_MANSION/ROOM_2_16",
@@ -455,6 +538,24 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     assert kirby_data.regions[room_9_chest_2_from_9_01].exits == ["REGION_CANDY_CONSTELLATION/ROOM_9_01"]
     assert kirby_data.regions[room_9_chest_2_from_9_09].exits == ["REGION_CANDY_CONSTELLATION/ROOM_9_09"]
     assert kirby_data.regions[room_9_chest_2_from_9_09].locations == ["SOUND_PLAYER_CHEST"]
+    assert kirby_data.regions[room_8_07_from_goal_1].exits == ["REGION_RADISH_RUINS/ROOM_8_GOAL_1"]
+    assert set(kirby_data.regions[room_8_07_from_8_18_8_21_8_23].exits) == {
+        "REGION_RADISH_RUINS/ROOM_8_18",
+        "REGION_RADISH_RUINS/ROOM_8_21",
+        "REGION_RADISH_RUINS/ROOM_8_23",
+    }
+    assert kirby_data.regions[room_8_09_from_8_03].exits == ["REGION_RADISH_RUINS/ROOM_8_03"]
+    assert kirby_data.regions[room_8_09_from_8_04].exits == ["REGION_RADISH_RUINS/ROOM_8_04"]
+    assert kirby_data.regions[room_5_13_from_5_12].exits == ["REGION_CARROT_CASTLE/ROOM_5_12"]
+    assert set(kirby_data.regions[room_5_13_from_5_18_or_5_warp].exits) == {
+        "REGION_CARROT_CASTLE/ROOM_5_18",
+        "REGION_CARROT_CASTLE/ROOM_5_WARP",
+    }
+    assert set(kirby_data.regions[room_6_05_from_6_04_or_6_06].exits) == {
+        "REGION_OLIVE_OCEAN/ROOM_6_04",
+        "REGION_OLIVE_OCEAN/ROOM_6_06",
+    }
+    assert kirby_data.regions[room_6_05_from_6_23].exits == ["REGION_OLIVE_OCEAN/ROOM_6_23"]
 
 
 def test_stake_breaking_abilities_are_shared_and_expected() -> None:

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -373,6 +373,65 @@ def test_room_transition_overrides_are_room_local_only() -> None:
         )
 
 
+def test_moonlight_rooms_define_logical_subregion_metadata() -> None:
+    from ..data import load_json_data
+
+    rooms = load_json_data("regions/rooms.json")
+
+    room_2_07 = rooms["REGION_MOONLIGHT_MANSION/ROOM_2_07"]
+    assert room_2_07["logical_subregions"]["ENTRY_FROM_2_04"]["exits"] == [
+        "REGION_MOONLIGHT_MANSION/ROOM_2_04"
+    ]
+    assert rooms["REGION_MOONLIGHT_MANSION/ROOM_2_04"]["logical_exit_overrides"] == {
+        "REGION_MOONLIGHT_MANSION/ROOM_2_07": "ENTRY_FROM_2_04"
+    }
+
+    room_2_17 = rooms["REGION_MOONLIGHT_MANSION/ROOM_2_17"]
+    assert set(room_2_17["logical_subregions"]["UPPER_HALL"]["exits"]) == {
+        "REGION_MOONLIGHT_MANSION/ROOM_2_16",
+        "REGION_MOONLIGHT_MANSION/ROOM_2_18",
+    }
+    assert set(room_2_17["logical_subregions"]["LOWER_HALL"]["exits"]) == {
+        "REGION_MOONLIGHT_MANSION/ROOM_2_12",
+        "REGION_MOONLIGHT_MANSION/ROOM_2_19",
+    }
+
+    room_2_goal_2 = rooms["REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2"]
+    assert room_2_goal_2["logical_subregions"]["ENTRY_FROM_2_ENTRY"]["exits"] == [
+        "REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"
+    ]
+    assert rooms["REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"]["logical_exit_overrides"] == {
+        "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2": "ENTRY_FROM_2_ENTRY"
+    }
+
+
+def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
+    from ..data import data as kirby_data
+
+    room_2_07_from_2_04 = "REGION_MOONLIGHT_MANSION/ROOM_2_07__LOGIC__ENTRY_FROM_2_04"
+    room_2_17_upper = "REGION_MOONLIGHT_MANSION/ROOM_2_17__LOGIC__UPPER_HALL"
+    room_2_17_lower = "REGION_MOONLIGHT_MANSION/ROOM_2_17__LOGIC__LOWER_HALL"
+    room_2_goal_2_from_entry = "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2__LOGIC__ENTRY_FROM_2_ENTRY"
+
+    assert room_2_07_from_2_04 in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_04"].exits
+    assert kirby_data.regions[room_2_07_from_2_04].exits == ["REGION_MOONLIGHT_MANSION/ROOM_2_04"]
+
+    assert room_2_17_lower in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_12"].exits
+    assert room_2_17_upper in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_16"].exits
+    assert room_2_17_lower in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_19"].exits
+    assert room_2_goal_2_from_entry in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"].exits
+
+    assert set(kirby_data.regions[room_2_17_upper].exits) == {
+        "REGION_MOONLIGHT_MANSION/ROOM_2_16",
+        "REGION_MOONLIGHT_MANSION/ROOM_2_18",
+    }
+    assert set(kirby_data.regions[room_2_17_lower].exits) == {
+        "REGION_MOONLIGHT_MANSION/ROOM_2_12",
+        "REGION_MOONLIGHT_MANSION/ROOM_2_19",
+    }
+    assert kirby_data.regions[room_2_goal_2_from_entry].exits == ["REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"]
+
+
 def test_stake_breaking_abilities_are_shared_and_expected() -> None:
     abilities = get_stake_breaking_abilities()
 

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -374,7 +374,7 @@ def test_room_transition_overrides_are_room_local_only() -> None:
         )
 
 
-def test_moonlight_rooms_define_logical_subregion_metadata() -> None:
+def test_split_rooms_define_logical_subregion_metadata() -> None:
     from ..data import load_json_data
 
     rooms = load_json_data("regions/rooms.json")

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -221,11 +221,11 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
             assert loc_key in known_locations, (
                 f"Room {room_key} claims unknown location key {loc_key!r}"
             )
-    # Canonical room entries carry 39 AP locations; additional location ownership
+    # Canonical room entries carry 38 AP locations; additional location ownership
     # can live in logical_subregions for disconnected chamber modeling.
     room_keys = list(rooms_with_locations.keys())
-    assert len(rooms_with_locations) == 39, (
-        f"Expected 39 canonical rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
+    assert len(rooms_with_locations) == 38, (
+        f"Expected 38 canonical rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
     )
 
     # Topology includes all rooms, but Room Sanity remains optional metadata.
@@ -437,10 +437,10 @@ def test_moonlight_rooms_define_logical_subregion_metadata() -> None:
 
     room_8_09 = rooms["REGION_RADISH_RUINS/ROOM_8_09"]
     assert room_8_09["logical_subregions"]["ENTRY_FROM_8_03"]["exits"] == [
-        "REGION_RADISH_RUINS/ROOM_8_03"
+        "REGION_RADISH_RUINS/ROOM_8_04"
     ]
     assert room_8_09["logical_subregions"]["ENTRY_FROM_8_04"]["exits"] == [
-        "REGION_RADISH_RUINS/ROOM_8_04"
+        "REGION_RADISH_RUINS/ROOM_8_03"
     ]
     assert rooms["REGION_RADISH_RUINS/ROOM_8_03"]["logical_exit_overrides"] == {
         "REGION_RADISH_RUINS/ROOM_8_09": "ENTRY_FROM_8_03"
@@ -472,6 +472,9 @@ def test_moonlight_rooms_define_logical_subregion_metadata() -> None:
         "REGION_OLIVE_OCEAN/ROOM_6_04",
         "REGION_OLIVE_OCEAN/ROOM_6_06",
     }
+    assert room_6_05["logical_subregions"]["ENTRY_FROM_6_04_OR_6_06"]["locations"] == [
+        "MINOR_CHEST_OLIVE_OCEAN_6_05"
+    ]
     assert room_6_05["logical_subregions"]["ENTRY_FROM_6_23"]["exits"] == [
         "REGION_OLIVE_OCEAN/ROOM_6_23"
     ]
@@ -544,8 +547,8 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
         "REGION_RADISH_RUINS/ROOM_8_21",
         "REGION_RADISH_RUINS/ROOM_8_23",
     }
-    assert kirby_data.regions[room_8_09_from_8_03].exits == ["REGION_RADISH_RUINS/ROOM_8_03"]
-    assert kirby_data.regions[room_8_09_from_8_04].exits == ["REGION_RADISH_RUINS/ROOM_8_04"]
+    assert kirby_data.regions[room_8_09_from_8_03].exits == ["REGION_RADISH_RUINS/ROOM_8_04"]
+    assert kirby_data.regions[room_8_09_from_8_04].exits == ["REGION_RADISH_RUINS/ROOM_8_03"]
     assert kirby_data.regions[room_5_13_from_5_12].exits == ["REGION_CARROT_CASTLE/ROOM_5_12"]
     assert set(kirby_data.regions[room_5_13_from_5_18_or_5_warp].exits) == {
         "REGION_CARROT_CASTLE/ROOM_5_18",
@@ -555,6 +558,7 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
         "REGION_OLIVE_OCEAN/ROOM_6_04",
         "REGION_OLIVE_OCEAN/ROOM_6_06",
     }
+    assert kirby_data.regions[room_6_05_from_6_04_or_6_06].locations == ["MINOR_CHEST_OLIVE_OCEAN_6_05"]
     assert kirby_data.regions[room_6_05_from_6_23].exits == ["REGION_OLIVE_OCEAN/ROOM_6_23"]
 
 

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -374,6 +374,29 @@ def test_room_transition_overrides_are_room_local_only() -> None:
         )
 
 
+def test_logical_exit_overrides_reference_declared_exits() -> None:
+    from ..data import load_json_data
+
+    rooms = load_json_data("regions/rooms.json")
+
+    for room_name, room_def in rooms.items():
+        exits = room_def.get("exits", [])
+        assert isinstance(exits, list), f"Room {room_name} exits must be a list"
+        exit_set = {exit_name for exit_name in exits if isinstance(exit_name, str)}
+
+        logical_exit_overrides = room_def.get("logical_exit_overrides", {})
+        if logical_exit_overrides is None:
+            logical_exit_overrides = {}
+        assert isinstance(logical_exit_overrides, dict), (
+            f"Room {room_name} logical_exit_overrides must be a dict when present"
+        )
+
+        missing = sorted(str(destination) for destination in logical_exit_overrides if destination not in exit_set)
+        assert not missing, (
+            f"Room {room_name} logical_exit_overrides includes destinations missing from exits: {missing}"
+        )
+
+
 def test_split_rooms_define_logical_subregion_metadata() -> None:
     from ..data import load_json_data
 

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -221,10 +221,11 @@ def test_room_subareas_pure_topology_with_all_rooms() -> None:
             assert loc_key in known_locations, (
                 f"Room {room_key} claims unknown location key {loc_key!r}"
             )
-    # Exactly 40 rooms now carry AP location entries after MINOR_CHEST expansion.
+    # Canonical room entries carry 39 AP locations; additional location ownership
+    # can live in logical_subregions for disconnected chamber modeling.
     room_keys = list(rooms_with_locations.keys())
-    assert len(rooms_with_locations) == 40, (
-        f"Expected 40 rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
+    assert len(rooms_with_locations) == 39, (
+        f"Expected 39 canonical rooms with locations, got {len(rooms_with_locations)}: {room_keys}"
     )
 
     # Topology includes all rooms, but Room Sanity remains optional metadata.
@@ -404,6 +405,23 @@ def test_moonlight_rooms_define_logical_subregion_metadata() -> None:
         "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2": "ENTRY_FROM_2_ENTRY"
     }
 
+    room_9_chest_2 = rooms["REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2"]
+    assert room_9_chest_2["logical_subregions"]["ENTRY_FROM_9_01"]["exits"] == [
+        "REGION_CANDY_CONSTELLATION/ROOM_9_01"
+    ]
+    assert room_9_chest_2["logical_subregions"]["ENTRY_FROM_9_09"]["exits"] == [
+        "REGION_CANDY_CONSTELLATION/ROOM_9_09"
+    ]
+    assert room_9_chest_2["logical_subregions"]["ENTRY_FROM_9_09"]["locations"] == [
+        "SOUND_PLAYER_CHEST"
+    ]
+    assert rooms["REGION_CANDY_CONSTELLATION/ROOM_9_01"]["logical_exit_overrides"] == {
+        "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2": "ENTRY_FROM_9_01"
+    }
+    assert rooms["REGION_CANDY_CONSTELLATION/ROOM_9_09"]["logical_exit_overrides"] == {
+        "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2": "ENTRY_FROM_9_09"
+    }
+
 
 def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     from ..data import data as kirby_data
@@ -412,6 +430,8 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     room_2_17_upper = "REGION_MOONLIGHT_MANSION/ROOM_2_17__LOGIC__UPPER_HALL"
     room_2_17_lower = "REGION_MOONLIGHT_MANSION/ROOM_2_17__LOGIC__LOWER_HALL"
     room_2_goal_2_from_entry = "REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2__LOGIC__ENTRY_FROM_2_ENTRY"
+    room_9_chest_2_from_9_01 = "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2__LOGIC__ENTRY_FROM_9_01"
+    room_9_chest_2_from_9_09 = "REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2__LOGIC__ENTRY_FROM_9_09"
 
     assert room_2_07_from_2_04 in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_04"].exits
     assert kirby_data.regions[room_2_07_from_2_04].exits == ["REGION_MOONLIGHT_MANSION/ROOM_2_04"]
@@ -420,6 +440,8 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
     assert room_2_17_upper in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_16"].exits
     assert room_2_17_lower in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_19"].exits
     assert room_2_goal_2_from_entry in kirby_data.regions["REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"].exits
+    assert room_9_chest_2_from_9_01 in kirby_data.regions["REGION_CANDY_CONSTELLATION/ROOM_9_01"].exits
+    assert room_9_chest_2_from_9_09 in kirby_data.regions["REGION_CANDY_CONSTELLATION/ROOM_9_09"].exits
 
     assert set(kirby_data.regions[room_2_17_upper].exits) == {
         "REGION_MOONLIGHT_MANSION/ROOM_2_16",
@@ -430,6 +452,9 @@ def test_logical_exit_overrides_route_to_synthetic_subregions() -> None:
         "REGION_MOONLIGHT_MANSION/ROOM_2_19",
     }
     assert kirby_data.regions[room_2_goal_2_from_entry].exits == ["REGION_MOONLIGHT_MANSION/ROOM_2_ENTRY"]
+    assert kirby_data.regions[room_9_chest_2_from_9_01].exits == ["REGION_CANDY_CONSTELLATION/ROOM_9_01"]
+    assert kirby_data.regions[room_9_chest_2_from_9_09].exits == ["REGION_CANDY_CONSTELLATION/ROOM_9_09"]
+    assert kirby_data.regions[room_9_chest_2_from_9_09].locations == ["SOUND_PLAYER_CHEST"]
 
 
 def test_stake_breaking_abilities_are_shared_and_expected() -> None:


### PR DESCRIPTION
## Summary
This PR extends disconnected within-room traversal modeling by routing selected room transitions into logical subregions (synthetic regions) so pathing matches real in-game entry constraints.

Implemented coverage:
- Moonlight Mansion:
  - Room 7 (`REGION_MOONLIGHT_MANSION/ROOM_2_07`)
  - Room 3 (`REGION_MOONLIGHT_MANSION/ROOM_2_17`)
  - Goal 2 (`REGION_MOONLIGHT_MANSION/ROOM_2_GOAL_2`)
- Candy Constellation:
  - Chest 2 (`REGION_CANDY_CONSTELLATION/ROOM_9_CHEST_2`)
- Radish Ruins:
  - Room 7 (`REGION_RADISH_RUINS/ROOM_8_07`)
  - Room 9 (`REGION_RADISH_RUINS/ROOM_8_09`)
- Carrot Castle:
  - Room 13 (`REGION_CARROT_CASTLE/ROOM_5_13`)
- Olive Ocean:
  - Room 5 (`REGION_OLIVE_OCEAN/ROOM_6_05`)

Core changes:
- Adds reusable logical-subregion handling in `worlds/kirbyam/data.py`.
- Adds room metadata (`logical_subregions`, `logical_exit_overrides`) in `worlds/kirbyam/data/regions/rooms.json`.
- Documents schema additions/invariants in `worlds/kirbyam/data/regions/rooms_schema.md`.
- Extends rule tests for metadata and synthetic-region routing in `worlds/kirbyam/test/test_rules.py`.

## Testing
- `./.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_rules.py -q`
- `./.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_slot_data_contract.py -q`

Closes #736.
