### PR TITLE
Issue #688: implement weighted filler generation

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -12,7 +12,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### New Features
 
 - Added a new `goal` mode, `defeat_any_area_boss`, which completes the seed after the first acknowledged area-boss defeat check (`BOSS_DEFEAT_1 .. BOSS_DEFEAT_8`) while preserving goal-location acknowledgement before `CLIENT_GOAL` when the server exposes a numeric goal location (Issue #205).
-- Implemented weighted filler generation so filler items are no longer equally likely. Current whole-number weights are: Cell Phone Battery 25, Energy Drink 17, 1 Up 15, Max Tomato 15, Small Food 14, Hunk of Meat 9, Invincibility Candy 5 (Issue #688).
+- Implemented weighted filler generation so filler items are no longer equally likely. Base whole-number weights are: Cell Phone Battery 25, Energy Drink 17, 1 Up 15, Max Tomato 15, Small Food 14, Hunk of Meat 9, Invincibility Candy 5. In one-hit mode (`exclude_vitality_counters`), healing filler (`Small Food`, `Energy Drink`, `Hunk of Meat`, `Max Tomato`) is removed and the remaining weights (`Cell Phone Battery`, `1 Up`, `Invincibility Candy`) are preserved proportionally. In no-lives mode, `1 Up` is removed and remaining filler keeps configured relative weights. When both modes are enabled together, only `Cell Phone Battery` and `Invincibility Candy` remain in weighted selection (Issue #688).
 
 ### Improvements
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -12,6 +12,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### New Features
 
 - Added a new `goal` mode, `defeat_any_area_boss`, which completes the seed after the first acknowledged area-boss defeat check (`BOSS_DEFEAT_1 .. BOSS_DEFEAT_8`) while preserving goal-location acknowledgement before `CLIENT_GOAL` when the server exposes a numeric goal location (Issue #205).
+- Implemented weighted filler generation so filler items are no longer equally likely. Current whole-number weights are: Cell Phone Battery 25, Energy Drink 17, 1 Up 15, Max Tomato 15, Small Food 14, Hunk of Meat 9, Invincibility Candy 5 (Issue #688).
 
 ### Improvements
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -119,7 +119,21 @@ All item IDs use **BASE_OFFSET = 3860000** for safety (avoids collision with Arc
 
 ### Current filler effect contract
 
-Current shipped filler generation uses a uniform active filler pool:
+Current shipped filler generation uses a weighted active filler pool.
+Configured whole-number weights (sum = 100):
+
+| Item | Weight |
+|------|--------|
+| `Cell Phone Battery` | 25 |
+| `Energy Drink` | 17 |
+| `1 Up` | 15 |
+| `Max Tomato` | 15 |
+| `Small Food` | 14 |
+| `Hunk of Meat` | 9 |
+| `Invincibility Candy` | 5 |
+
+When one-hit/no-extra-lives filters remove filler labels from the active pool,
+generation preserves these relative weights across the remaining labels.
 
 | Item | Effect |
 |------|--------|

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -119,7 +119,6 @@ class KirbyAmWorld(World):
 
     # Generation stages
     # Active filler pool for random selection.
-    # Issue #295 ships the life-up plus consumable filler set as uniform choices.
     ACTIVE_FILLER_POOL: ClassVar[tuple[str, ...]] = (
         "1 Up",
         "Small Food",
@@ -129,6 +128,17 @@ class KirbyAmWorld(World):
         "Max Tomato",
         "Invincibility Candy",
     )
+    # Issue #688: weighted filler distribution tuned from native frequency research,
+    # with whole-number percentages for easier balancing.
+    ACTIVE_FILLER_WEIGHTS: ClassVar[dict[str, int]] = {
+        "1 Up": 15,
+        "Small Food": 14,
+        "Energy Drink": 17,
+        "Hunk of Meat": 9,
+        "Cell Phone Battery": 25,
+        "Max Tomato": 15,
+        "Invincibility Candy": 5,
+    }
     ACTIVE_FILLER_POOL_NO_HEALING: ClassVar[tuple[str, ...]] = tuple(
         item_name
         for item_name in ACTIVE_FILLER_POOL
@@ -171,6 +181,7 @@ class KirbyAmWorld(World):
         "Carrot Castle - Mirror Shard",
         "Radish Ruins - Mirror Shard",
     )
+
     @classmethod
     def stage_assert_generate(cls, multiworld: MultiWorld) -> None:
         # If you don't have sanity_check.py yet, comment these out for now.
@@ -238,9 +249,16 @@ class KirbyAmWorld(World):
             pool = tuple(item_name for item_name in pool if item_name != "1 Up")
         return pool
 
+    def _active_filler_weighted_pool(self) -> tuple[tuple[str, ...], tuple[int, ...]]:
+        pool = self._active_filler_pool()
+        if not pool:
+            raise ValueError("KirbyAM active filler pool resolved empty")
+        return pool, tuple(self.ACTIVE_FILLER_WEIGHTS[item_name] for item_name in pool)
+
     # Filler item name
     def get_filler_item_name(self) -> str:
-        return self.random.choice(self._active_filler_pool())
+        filler_labels, filler_weights = self._active_filler_weighted_pool()
+        return self.random.choices(filler_labels, weights=filler_weights, k=1)[0]
 
     def get_trap_item_name(self) -> str:
         if not kirby_data.available_trap_item_labels:
@@ -554,6 +572,7 @@ class KirbyAmWorld(World):
                 if self._traps_enabled() and eligible_filler_slots > 0:
                     trap_count = (eligible_filler_slots * self._trap_fill_percentage()) // 100
                 filler_needed = eligible_filler_slots - trap_count
+                active_filler_labels, active_filler_weights = self._active_filler_weighted_pool()
                 randomized_item_codes.extend(non_filler_item_codes)
                 randomized_item_codes.extend(
                     self.item_name_to_id[self.get_trap_item_name()]
@@ -617,6 +636,14 @@ class KirbyAmWorld(World):
                     eligible_filler_slots,
                     trap_count,
                     filler_needed,
+                )
+                logger.info(
+                    "[P%s] Filler weights (active pool): %s",
+                    self.player,
+                    {
+                        label: weight
+                        for label, weight in zip(active_filler_labels, active_filler_weights)
+                    },
                 )
 
                 if self._start_with_all_maps_enabled():

--- a/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
+++ b/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
@@ -64,6 +64,7 @@ Use exact item/location names from this world (or the item groups listed above) 
 
 - There is an optional setting to enable one-life mode (no_extra_lives). If you die you are instantly sent back to the Hub, and any 1Ups you receive will be immediately removed.
 - There is an optional setting to enable one-hit mode. Kirby's HP cap is clamped to 1 plus collected Vitality Counters. In `exclude_vitality_counters` mode, Vitality Counter items are removed from the item pool and health-restoring filler (Small Food, Energy Drink, Hunk of Meat, and Max Tomato) is also removed from filler selection so randomized filler cannot counteract the 1 HP challenge.
+- Filler items use weighted generation rather than equal odds. Current whole-number weights are: Cell Phone Battery 25, Energy Drink 17, 1 Up 15, Max Tomato 15, Small Food 14, Hunk of Meat 9, Invincibility Candy 5.
 - Goal modes:
   - `dark_mind`: Defeat Dark Mind to complete the seed.
   - `defeat_any_area_boss`: Defeat any one `* - Boss Defeat` location (Mustard Mountain, Moonlight Mansion, Candy Constellation, Olive Ocean, Peppermint Palace, Cabbage Cavern, Carrot Castle, or Radish Ruins). In this mode, collecting all Mirror Shards is not required by the goal mode itself.

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -238,6 +238,18 @@ def test_active_filler_pool_contents() -> None:
     )
 
 
+def test_active_filler_weights_match_whole_number_policy() -> None:
+    assert KirbyAmWorld.ACTIVE_FILLER_WEIGHTS == {
+        "1 Up": 15,
+        "Small Food": 14,
+        "Energy Drink": 17,
+        "Hunk of Meat": 9,
+        "Cell Phone Battery": 25,
+        "Max Tomato": 15,
+        "Invincibility Candy": 5,
+    }
+
+
 def test_no_extra_lives_excludes_1_up_from_active_filler_pool() -> None:
     world = KirbyAmWorld.__new__(KirbyAmWorld)
     world.options = SimpleNamespace(
@@ -253,6 +265,26 @@ def test_no_extra_lives_excludes_1_up_from_active_filler_pool() -> None:
         "Max Tomato",
         "Invincibility Candy",
     )
+
+
+def test_no_extra_lives_excludes_1_up_from_weighted_pool() -> None:
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+    world.options = SimpleNamespace(
+        no_extra_lives=SimpleNamespace(value=True),
+        one_hit_mode=SimpleNamespace(value=OneHitMode.option_off),
+    )
+
+    labels, weights = world._active_filler_weighted_pool()
+
+    assert labels == (
+        "Small Food",
+        "Energy Drink",
+        "Hunk of Meat",
+        "Cell Phone Battery",
+        "Max Tomato",
+        "Invincibility Candy",
+    )
+    assert weights == (14, 17, 9, 25, 15, 5)
 
 
 def test_no_extra_lives_filler_selection_never_picks_1_up() -> None:
@@ -294,6 +326,22 @@ def test_one_hit_mode_exclude_vitality_counters_and_no_extra_lives_stack_filler_
         "Cell Phone Battery",
         "Invincibility Candy",
     )
+
+
+def test_one_hit_and_no_extra_lives_stack_weighted_pool_exclusions() -> None:
+    world = KirbyAmWorld.__new__(KirbyAmWorld)
+    world.options = SimpleNamespace(
+        no_extra_lives=SimpleNamespace(value=True),
+        one_hit_mode=SimpleNamespace(value=OneHitMode.option_exclude_vitality_counters),
+    )
+
+    labels, weights = world._active_filler_weighted_pool()
+
+    assert labels == (
+        "Cell Phone Battery",
+        "Invincibility Candy",
+    )
+    assert weights == (25, 5)
 
 
 def test_one_hit_mode_exclude_vitality_counters_filler_selection_never_picks_healing_fillers() -> None:


### PR DESCRIPTION
## Summary
- implement weighted filler generation using whole-number policy weights
- apply active-pool filtering (one-hit/no-extra-lives) while preserving relative configured weights
- add generation logging for active filler weights at item-pool build time
- update protocol/player docs and unreleased changelog
- add tests for configured weight map and filtered weighted pools

## Weights
- Cell Phone Battery: 25
- Energy Drink: 17
- Small Food: 14
- Hunk of Meat: 9
- Invincibility Candy: 5
- 1 Up: 15
- Max Tomato: 15

## Validation
- python -m pytest worlds/kirbyam/test/test_item_pool.py worlds/kirbyam/test/test_slot_data_contract.py

Closes #688 