### PR TITLE
KirbyAM: send room key updates to tracker storage

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -35,6 +35,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Fixed delivery synchronization and logging issues that could skip items when client and game counters drifted, while ensuring debug-only delivery diagnostics still go to the log file even when hidden from the live client output (Issue #601).
 - Fixed vitality counter replays caused by transitions or resets, and prevented vitality counters from lingering in `One-Hit Mode` when that mode excludes them (Issue #571).
 - Fixed extra reconnect and resend diagnostics showing up in the live client when they should have remained file-only (Issue #582).
+- Fixed tracker room storage updates for PopTracker map switching by publishing the current native room id under a team/slot-scoped KirbyAM data-storage key when room changes are detected (Issue #801).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -35,7 +35,6 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Fixed delivery synchronization and logging issues that could skip items when client and game counters drifted, while ensuring debug-only delivery diagnostics still go to the log file even when hidden from the live client output (Issue #601).
 - Fixed vitality counter replays caused by transitions or resets, and prevented vitality counters from lingering in `One-Hit Mode` when that mode excludes them (Issue #571).
 - Fixed extra reconnect and resend diagnostics showing up in the live client when they should have remained file-only (Issue #582).
-- Fixed tracker room storage updates for PopTracker map switching by publishing the current native room id under a team/slot-scoped KirbyAM data-storage key when room changes are detected (Issue #801).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -84,6 +84,7 @@ _OPTIONAL_UNSAFE_DELIVERY_COUNTERS = (
 )
 _SEND_NOTIFY_WINDOW_SECONDS = 2.0
 _SEND_NOTIFY_MAX_PER_WINDOW = 5
+_TRACKER_ROOM_KEY_PREFIX = "KirbyAM"
 _LOCATION_ID_TO_LABEL: dict[int, str] = {
     loc.location_id: loc.label
     for loc in data.locations.values()
@@ -421,6 +422,7 @@ class KirbyAmClient(BizHawkClient):
         # Room entry logging (always file-only via NoStream=True).
         self._last_native_room_id: int | None = None
         self._last_sent_room_update_native_room_id: int | None = None
+        self._current_room_key: str = ""
         self._last_room_region_key: str = ""
         room_label_lookup, room_region_key_lookup, room_area_lookup, boss_room_lookup = self._build_room_metadata_maps()
         self._room_label_by_doors_idx: dict[int, str] = room_label_lookup
@@ -614,6 +616,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_runtime_gate_reason = None
         self._last_native_room_id = None
         self._last_sent_room_update_native_room_id = None
+        self._current_room_key = ""
         self._last_minor_chest_event_counter = None
         self._logged_unknown_minor_chest_source_ptrs.clear()
         self._last_shard_poll_log = None
@@ -2886,10 +2889,12 @@ class KirbyAmClient(BizHawkClient):
             return
 
         native_room_id = unpack_from("<H", raw)[0]
+        room_key = self._get_current_room_key(ctx)
+        tracker_room_pending = self._is_tracker_room_update_pending(ctx, room_key, native_room_id)
         room_changed = native_room_id != self._last_native_room_id
         send_pending = native_room_id != self._last_sent_room_update_native_room_id
 
-        if not room_changed and not send_pending:
+        if not room_changed and not send_pending and not tracker_room_pending:
             return
 
         if room_changed:
@@ -2950,6 +2955,54 @@ class KirbyAmClient(BizHawkClient):
                 )
                 return
             self._last_sent_room_update_native_room_id = native_room_id
+
+        if tracker_room_pending and room_key:
+            try:
+                await ctx.send_msgs([{
+                    "cmd": "Set",
+                    "key": room_key,
+                    "default": "0_S",
+                    "want_reply": False,
+                    "operations": [
+                        {"operation": "replace", "value": native_room_id},
+                    ],
+                }])
+            except Exception as exc:
+                # Tracker room storage updates are best-effort and must not break watcher progression.
+                self._log_verbose(
+                    "warning",
+                    "KirbyAM: failed to send tracker room storage update (key=%s, native=0x%04x): %s",
+                    room_key,
+                    native_room_id,
+                    exc,
+                )
+
+    def _get_current_room_key(self, ctx: KirbyAmBizHawkClientContext) -> str:
+        team = getattr(ctx, "team", None)
+        slot = getattr(ctx, "slot", None)
+        if team is None or slot is None:
+            return ""
+
+        room_key = f"{_TRACKER_ROOM_KEY_PREFIX}{team}_{slot}"
+        if room_key != self._current_room_key:
+            self._current_room_key = room_key
+            set_notify = getattr(ctx, "set_notify", None)
+            if callable(set_notify):
+                set_notify(room_key)
+        return room_key
+
+    @staticmethod
+    def _is_tracker_room_update_pending(
+        ctx: KirbyAmBizHawkClientContext,
+        room_key: str,
+        native_room_id: int,
+    ) -> bool:
+        if not room_key:
+            return False
+        stored_data = getattr(ctx, "stored_data", None)
+        if not isinstance(stored_data, dict):
+            return False
+        return stored_data.get(room_key, "") != native_room_id
 
     async def _poll_room_sanity_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1428,6 +1428,78 @@ async def test_poll_room_entry_logging_is_always_file_only(mock_bizhawk_context)
     assert mock_logger.info.call_args.kwargs.get("extra", {}).get("NoStream") is True
 
 
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_sends_tracker_room_storage_update(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {14: "REGION_TRACKER_ROOM"}
+    client._room_region_key_by_doors_idx = {14: "ROOM_SANITY_6_01"}
+    mock_bizhawk_context.stored_data = {}
+    mock_bizhawk_context.set_notify = Mock()
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        mock_read.side_effect = [
+            [(0x0017).to_bytes(2, 'little')],
+            [(14).to_bytes(2, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    room_key = f"KirbyAM{mock_bizhawk_context.team}_{mock_bizhawk_context.slot}"
+    assert client._current_room_key == room_key
+    mock_bizhawk_context.set_notify.assert_called_once_with(room_key)
+    assert mock_bizhawk_context.send_msgs.await_count == 2
+
+    first_payload = mock_bizhawk_context.send_msgs.await_args_list[0].args[0][0]
+    second_payload = mock_bizhawk_context.send_msgs.await_args_list[1].args[0][0]
+    assert first_payload["cmd"] == "Bounce"
+    assert first_payload["data"]["nativeRoomId"] == 0x0017
+    assert second_payload == {
+        "cmd": "Set",
+        "key": room_key,
+        "default": "0_S",
+        "want_reply": False,
+        "operations": [{"operation": "replace", "value": 0x0017}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_poll_room_entry_logging_retries_tracker_storage_until_stored_data_matches(mock_bizhawk_context):
+    client = KirbyAmClient()
+    client.initialize_client()
+    client._room_label_by_doors_idx = {15: "REGION_TRACKER_RETRY_ROOM"}
+    client._room_region_key_by_doors_idx = {15: "ROOM_SANITY_6_02"}
+    room_key = f"KirbyAM{mock_bizhawk_context.team}_{mock_bizhawk_context.slot}"
+    mock_bizhawk_context.stored_data = {}
+    mock_bizhawk_context.set_notify = Mock()
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        mock_read.side_effect = [
+            [(0x0018).to_bytes(2, 'little')],
+            [(15).to_bytes(2, 'little')],
+            [(0x0018).to_bytes(2, 'little')],
+            [(15).to_bytes(2, 'little')],
+            [(0x0018).to_bytes(2, 'little')],
+            [(15).to_bytes(2, 'little')],
+        ]
+
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+        mock_bizhawk_context.stored_data[room_key] = 0x0018
+        await client._poll_room_entry_logging(mock_bizhawk_context)
+
+    assert mock_bizhawk_context.send_msgs.await_count == 3
+    first_payload = mock_bizhawk_context.send_msgs.await_args_list[0].args[0][0]
+    second_payload = mock_bizhawk_context.send_msgs.await_args_list[1].args[0][0]
+    third_payload = mock_bizhawk_context.send_msgs.await_args_list[2].args[0][0]
+
+    assert first_payload["cmd"] == "Bounce"
+    assert second_payload["cmd"] == "Set"
+    assert second_payload["key"] == room_key
+    assert third_payload["cmd"] == "Set"
+    assert third_payload["key"] == room_key
+
+
 def test_major_chest_data_sanity():
     """Major-chest entries should have explicit unique IDs and unique mapped bits."""
     major_chests = [

--- a/worlds/kirbyam/test/test_rom_tokens.py
+++ b/worlds/kirbyam/test/test_rom_tokens.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 import worlds.kirbyam.rom as rom_module
@@ -45,7 +46,7 @@ def test_write_tokens_rejects_missing_policy_for_non_vanilla_mode() -> None:
     patch = _DummyPatch()
 
     with pytest.raises(ValueError, match="enemy_copy_ability_policy must be initialized"):
-        write_tokens(world, patch)
+        write_tokens(cast(Any, world), cast(Any, patch))
 
 
 def test_write_tokens_emits_runtime_enemy_writes_for_non_vanilla_mode() -> None:
@@ -58,7 +59,7 @@ def test_write_tokens_emits_runtime_enemy_writes_for_non_vanilla_mode() -> None:
     )
 
     patch = _DummyPatch()
-    write_tokens(world, patch)
+    write_tokens(cast(Any, world), cast(Any, patch))
 
     # Auth token write + many single-byte ability remap writes.
     single_byte_writes = [
@@ -69,7 +70,7 @@ def test_write_tokens_emits_runtime_enemy_writes_for_non_vanilla_mode() -> None:
     assert "token_data.bin" in patch.files
 
 
-def test_write_tokens_allows_non_vanilla_mode_with_no_runtime_writes(monkeypatch) -> None:
+def test_write_tokens_allows_non_vanilla_mode_with_no_runtime_writes(monkeypatch: pytest.MonkeyPatch) -> None:
     world = _make_world(AbilityRandomizationMode.option_shuffled)
     world._enemy_copy_ability_policy = build_enemy_copy_ability_policy(
         random.Random(20260324),
@@ -84,7 +85,7 @@ def test_write_tokens_allows_non_vanilla_mode_with_no_runtime_writes(monkeypatch
     )
 
     patch = _DummyPatch()
-    write_tokens(world, patch)
+    write_tokens(cast(Any, world), cast(Any, patch))
 
     single_byte_writes = [
         w for w in patch.token_writes

--- a/worlds/kirbyam/test/test_rom_tokens.py
+++ b/worlds/kirbyam/test/test_rom_tokens.py
@@ -34,7 +34,8 @@ def _make_world(mode: int) -> SimpleNamespace:
     return SimpleNamespace(
         auth=b"0123456789ABCDEF",
         options=SimpleNamespace(
-            ability_randomization_mode=SimpleNamespace(value=mode)
+            ability_randomization_mode=SimpleNamespace(value=mode),
+            ability_randomization_statues=SimpleNamespace(value=False),
         ),
     )
 
@@ -76,7 +77,11 @@ def test_write_tokens_allows_non_vanilla_mode_with_no_runtime_writes(monkeypatch
         include_boss_spawns=True,
         include_minibosses=True,
     )
-    monkeypatch.setattr(rom_module, "build_enemy_copy_runtime_patch_writes", lambda policy: {})
+    monkeypatch.setattr(
+        rom_module,
+        "build_enemy_copy_runtime_patch_writes",
+        lambda policy, include_statues=False: {},
+    )
 
     patch = _DummyPatch()
     write_tokens(world, patch)


### PR DESCRIPTION
## Summary
- add tracker room key storage updates in KirbyAM room-entry polling
- publish native room id to AP data storage using team/slot-scoped key for PopTracker map switching
- add tests for storage update send and resend behavior
- document fix in `v0.2.0-rc5` changelog bug-fix section

## Testing
- `python -m pytest worlds/kirbyam/test/test_client.py -k "poll_room_entry_logging" -q`
- `python -m pytest worlds/kirbyam/test/test_release_metadata.py -q`

## Notes
- `test/general/test_world_manifest.py` currently fails locally due unrelated pre-existing local edits in `worlds/kirbyam/archipelago.json` (container `version` fields), not from this change.

Closes #801