### PR TITLE
Fix Rainbow Route 1-02 exact chest checks

### DIFF
--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -243,6 +243,10 @@ def _normalize_gba_rom_address(value: int) -> int:
     return value
 
 
+def _is_exact_minor_chest_location(loc) -> bool:
+    return "ReportLocation" in loc.tags or "ExactEventLocation" in loc.tags
+
+
 class KirbyAmClient(BizHawkClient):
     game = "Kirby & The Amazing Mirror"
     system = "GBA"
@@ -312,20 +316,20 @@ class KirbyAmClient(BizHawkClient):
         for loc in data.locations.values():
             if loc.bit_index is None or loc.category != LocationCategory.MINOR_CHEST:
                 continue
-            if "ReportLocation" in loc.tags:
+            if _is_exact_minor_chest_location(loc):
                 continue
             self._minor_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
         self._report_only_minor_chest_location_ids: set[int] = {
             loc.location_id
             for loc in data.locations.values()
-            if loc.category == LocationCategory.MINOR_CHEST and "ReportLocation" in loc.tags
+            if loc.category == LocationCategory.MINOR_CHEST and _is_exact_minor_chest_location(loc)
         }
         self._minor_chest_report_manifest_source_ptrs: set[int] = set()
         self._minor_chest_location_id_by_source_ptr = self._build_minor_chest_source_ptr_map()
         report_only_minor_count = sum(
             1
             for loc in data.locations.values()
-            if loc.category == LocationCategory.MINOR_CHEST and "ReportLocation" in loc.tags
+            if loc.category == LocationCategory.MINOR_CHEST and _is_exact_minor_chest_location(loc)
         )
         if report_only_minor_count:
             self._log_verbose(
@@ -687,9 +691,10 @@ class KirbyAmClient(BizHawkClient):
         report_location_ids = [
             loc.location_id
             for loc in sorted(data.locations.values(), key=lambda loc: loc.location_id)
-            if loc.category == LocationCategory.MINOR_CHEST and "ReportLocation" in loc.tags
+            if loc.category == LocationCategory.MINOR_CHEST and _is_exact_minor_chest_location(loc)
         ]
         report_index = 0
+        assigned_report_location_ids: set[int] = set()
         source_ptr_to_location_id: dict[int, int] = {}
         report_manifest_source_ptrs: set[int] = set()
         skipped_unassigned_entries = 0
@@ -710,7 +715,7 @@ class KirbyAmClient(BizHawkClient):
 
             matched_named_location = False
             for loc in data.locations.values():
-                if loc.category != LocationCategory.MINOR_CHEST or "ReportLocation" in loc.tags:
+                if loc.category != LocationCategory.MINOR_CHEST or _is_exact_minor_chest_location(loc):
                     continue
                 if bit_index != loc.bit_index:
                     continue
@@ -721,11 +726,33 @@ class KirbyAmClient(BizHawkClient):
             if matched_named_location:
                 continue
             report_manifest_source_ptrs.add(source_ptr)
+
+            matched_report_location_id = next(
+                (
+                    loc.location_id
+                    for loc in sorted(data.locations.values(), key=lambda loc: loc.location_id)
+                    if loc.category == LocationCategory.MINOR_CHEST
+                    and _is_exact_minor_chest_location(loc)
+                    and loc.location_id not in assigned_report_location_ids
+                    and bit_index == loc.bit_index
+                    and loc.parent_region in candidate_room_keys
+                ),
+                None,
+            )
+            if matched_report_location_id is not None:
+                source_ptr_to_location_id[source_ptr] = matched_report_location_id
+                assigned_report_location_ids.add(matched_report_location_id)
+                continue
+
+            while report_index < len(report_location_ids) and report_location_ids[report_index] in assigned_report_location_ids:
+                report_index += 1
             if report_index >= len(report_location_ids):
                 skipped_unassigned_entries += 1
                 continue
 
-            source_ptr_to_location_id[source_ptr] = report_location_ids[report_index]
+            fallback_location_id = report_location_ids[report_index]
+            source_ptr_to_location_id[source_ptr] = fallback_location_id
+            assigned_report_location_ids.add(fallback_location_id)
             report_index += 1
 
         if report_location_ids and report_index != len(report_location_ids):

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -327,16 +327,16 @@ class KirbyAmClient(BizHawkClient):
         }
         self._minor_chest_report_manifest_source_ptrs: set[int] = set()
         self._minor_chest_location_id_by_source_ptr = self._build_minor_chest_source_ptr_map()
-        report_only_minor_count = sum(
+        exact_event_minor_count = sum(
             1
             for loc in data.locations.values()
             if loc.category == LocationCategory.MINOR_CHEST and _is_exact_minor_chest_location(loc)
         )
-        if report_only_minor_count:
+        if exact_event_minor_count:
             self._log_verbose(
                 "info",
-                "KirbyAM: %s report-only minor chest locations are active; they are reported only from exact event-ring source-pointer matches.",
-                report_only_minor_count,
+                "KirbyAM: %s exact-event minor chest locations are active; they are reported only from exact event-ring source-pointer matches.",
+                exact_event_minor_count,
             )
         self._last_minor_chest_event_counter: int | None = None
         self._logged_unknown_minor_chest_source_ptrs: set[int] = set()
@@ -759,14 +759,14 @@ class KirbyAmClient(BizHawkClient):
         if report_location_ids and report_index != len(report_location_ids):
             self._log_verbose(
                 "warning",
-                "KirbyAM: mapped %s/%s report-only minor chest locations from manifest source pointers; unmapped report locations remain.",
+                "KirbyAM: mapped %s/%s exact-event minor chest locations from manifest source pointers; some exact-event locations remain unmapped.",
                 report_index,
                 len(report_location_ids),
             )
         if skipped_unassigned_entries:
             self._log_verbose(
                 "warning",
-                "KirbyAM: %s report-only manifest entries could not be assigned to AP report locations (ordering/coverage mismatch).",
+                "KirbyAM: %s exact-event manifest entries could not be assigned to AP locations (ordering/coverage mismatch).",
                 skipped_unassigned_entries,
             )
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -244,7 +244,8 @@ def _normalize_gba_rom_address(value: int) -> int:
 
 
 def _is_exact_minor_chest_location(loc) -> bool:
-    return "ReportLocation" in loc.tags or "ExactEventLocation" in loc.tags
+    tags = getattr(loc, "tags", ()) or ()
+    return "ReportLocation" in tags or "ExactEventLocation" in tags
 
 
 class KirbyAmClient(BizHawkClient):

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -586,6 +586,7 @@
     "default_item": "1_UP",
     "tags": [
       "SmallChest",
+      "ExactEventLocation",
       "MAP_RAINBOW_ROUTE"
     ],
     "bit_index": 0,

--- a/worlds/kirbyam/sanity_check.py
+++ b/worlds/kirbyam/sanity_check.py
@@ -12,8 +12,8 @@ def _validate_unique_bit_indices(data, error) -> None:
         if loc.bit_index is None:
             continue
         tags = getattr(loc, "tags", ()) or ()
-        if "ReportLocation" in tags:
-            # Provisional report-only locations intentionally reuse native bits.
+        if "ReportLocation" in tags or "ExactEventLocation" in tags:
+            # Event-driven minor chest locations intentionally reuse native bits.
             continue
         category_name = getattr(loc.category, "name", str(loc.category))
         category_bit_map = bit_to_loc_by_category.setdefault(category_name, {})

--- a/worlds/kirbyam/sanity_check.py
+++ b/worlds/kirbyam/sanity_check.py
@@ -3,9 +3,11 @@ Looks through data object to double-check it makes sense. Will fail for missing 
 duplicate claims and give warnings for unused and unignored locations.
 """
 import logging
+from collections.abc import Callable
+from typing import Any
 
 
-def _validate_unique_bit_indices(data, error) -> None:
+def _validate_unique_bit_indices(data: Any, error: Callable[[str], None]) -> None:
     """Validate bit-index uniqueness within each location category."""
     bit_to_loc_by_category: dict[str, dict[int, str]] = {}
     for loc_key, loc in data.locations.items():

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -603,6 +603,7 @@
       "label": "Rainbow Route 1-02 - Small Chest",
       "location_id": 3960521,
       "tags": [
+        "ExactEventLocation",
         "MAP_RAINBOW_ROUTE",
         "SmallChest"
       ]

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -14,6 +14,7 @@ from ..data import LocationCategory, data
 from ..client import (
     KirbyAmClient,
     _build_kirbyam_command_processor,
+    _is_exact_minor_chest_location,
     _MAP_ITEM_ID_TO_AREA_ID,
     _ROOM_PROPS_DOORS_IDX_OFFSET,
     _ROOM_PROPS_ROM_BASE,
@@ -677,7 +678,7 @@ async def test_poll_minor_chest_sends_location_checks_for_set_bits(mock_bizhawk_
     minor_with_bits = [
         loc for loc in data.locations.values()
         if getattr(loc, "category", None) == LocationCategory.MINOR_CHEST and loc.bit_index is not None
-        and "ReportLocation" not in getattr(loc, "tags", frozenset())
+        and not _is_exact_minor_chest_location(loc)
     ]
     expected_locations = sorted(loc.location_id for loc in minor_with_bits)
     bits = 0
@@ -770,7 +771,7 @@ async def test_poll_minor_chest_respects_active_slot_locations(mock_bizhawk_cont
 
 @pytest.mark.asyncio
 async def test_poll_minor_chest_excludes_unmapped_report_locations(mock_bizhawk_context):
-    """Native minor-chest polling should include named checks but exclude unresolved report-only siblings."""
+    """Native minor-chest polling should exclude exact-event chests that share a native bit."""
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -782,13 +783,44 @@ async def test_poll_minor_chest_excludes_unmapped_report_locations(mock_bizhawk_
     with patch.dict(data.native_ram_addresses, {"small_chest_flags_native": 0x02038960}, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
-        # Bits 0 and 1 set; keep named locations on bit 0, but exclude report-only siblings that share it.
+        # Bits 0 and 1 set; exclude the exact-event 1-02 location from the shared bit-0 poll path.
         mock_read.return_value = [((1 << 0) | (1 << 1)).to_bytes(10, 'little')]
 
         await client._poll_minor_chest_locations(mock_bizhawk_context)
 
     mock_send.assert_awaited_once_with([
-        {"cmd": "LocationChecks", "locations": [room_1_39, room_1_02_named]}
+        {"cmd": "LocationChecks", "locations": [room_1_39]}
+    ])
+    assert room_1_02_named not in mock_send.await_args.args[0][0]["locations"]
+
+
+@pytest.mark.asyncio
+async def test_poll_minor_chest_event_sends_named_exact_location(mock_bizhawk_context):
+    """Exact minor chest events should also support named locations moved off shared native bits."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    room_1_02_named = data.locations["MINOR_CHEST_RAINBOW_ROUTE_1_02"].location_id
+    source_ptr = next(
+        source
+        for source, location_id in client._minor_chest_location_id_by_source_ptr.items()
+        if location_id == room_1_02_named
+    )
+    ring = bytearray(32)
+    ring[0:4] = source_ptr.to_bytes(4, 'little')
+
+    client._last_minor_chest_event_counter = 0
+    mock_bizhawk_context.checked_locations = set()
+    mock_bizhawk_context.server_locations = {room_1_02_named}
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        mock_read.return_value = [(1).to_bytes(4, 'little'), bytes(ring)]
+
+        await client._poll_minor_chest_event_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [room_1_02_named]}
     ])
 
 
@@ -837,7 +869,7 @@ def test_minor_chest_source_ptr_map_targets_report_only_minor_chests():
     for location_id in client._minor_chest_location_id_by_source_ptr.values():
         loc = id_to_location[location_id]
         assert loc.category == LocationCategory.MINOR_CHEST
-        assert "ReportLocation" in loc.tags
+        assert _is_exact_minor_chest_location(loc)
 
 
 @pytest.mark.asyncio
@@ -5044,7 +5076,7 @@ def test_minor_chest_locations_have_unique_bit_indices_when_present():
         loc for loc in data.locations.values()
         if getattr(loc, "category", None) == LocationCategory.MINOR_CHEST
         and getattr(loc, "bit_index", None) is not None
-        and "ReportLocation" not in getattr(loc, "tags", frozenset())
+        and not _is_exact_minor_chest_location(loc)
     ]
     if not minor_chest_with_bits:
         return

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -770,7 +770,7 @@ async def test_poll_minor_chest_respects_active_slot_locations(mock_bizhawk_cont
 
 
 @pytest.mark.asyncio
-async def test_poll_minor_chest_excludes_unmapped_report_locations(mock_bizhawk_context):
+async def test_poll_minor_chest_excludes_exact_event_locations_from_bit_poll(mock_bizhawk_context):
     """Native minor-chest polling should exclude exact-event chests that share a native bit."""
     client = KirbyAmClient()
     client.initialize_client()
@@ -859,7 +859,7 @@ async def test_poll_minor_chest_event_sends_exact_report_location(mock_bizhawk_c
         assert sibling_location not in mock_send.await_args.args[0][0]["locations"]
 
 
-def test_minor_chest_source_ptr_map_targets_report_only_minor_chests():
+def test_minor_chest_source_ptr_map_targets_exact_event_minor_chests():
     client = KirbyAmClient()
     client.initialize_client()
 


### PR DESCRIPTION
## Summary
- move Rainbow Route 1-02 off the shared native small-chest bit resend path and treat it as an exact event-driven chest
- keep optional unmapped report chests gated behind their option while allowing named exact-event chests in normal seeds
- add regression coverage for the false positive bit poll, exact event mapping, and updated slot-data snapshot

## Testing
- python -m pytest worlds/kirbyam/test/test_client.py -k "minor_chest"
- python -m pytest worlds/kirbyam/test/test_data_normalization.py worlds/kirbyam/test/test_snapshot_outputs.py -k "slot_data or normalization or snapshot"

Closes #807
