### PR TITLE
Prepare v0.2.0-rc6 release: update version and changelog

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -7,6 +7,18 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - `### Bug Fixes`
 - `### Internal Changes`
 
+## v0.2.0-rc6
+
+### Bug Fixes
+
+- Fixed ability statues not appearing in spoiler logs when ability randomization includes statue sources; spoiler output now correctly lists enabled statues alongside enemy assignments for full transparency (Issue #805).
+- Fixed big switch timing to ensure area big switches are properly recognized for zone completion checks (Issue #806).
+- Fixed Rainbow Route 1-02 exact chest checks to correctly register minor chest locations (Issue #812).
+
+### Internal Changes
+
+- Tracker support now receives room key updates through dedicated storage channels, providing trackers with more complete room-discovery state information.
+
 ## v0.2.0-rc5
 
 ### New Features

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.0",
+  "world_version": "0.2.0-rc6",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Release v0.2.0-rc6

This PR updates the version to v0.2.0-rc6 and documents the changes since rc5.

### Changes
- Updated \rchipelago.json\ world_version from 0.2.0 to 0.2.0-rc6
- Updated CHANGELOG.md with v0.2.0-rc6 section

### Included Fixes and Improvements
- Fixed ability statues not appearing in spoiler logs (#805)
- Fixed big switch timing for zone completion checks (#806)
- Fixed Rainbow Route 1-02 exact chest checks (#812)
- Enhanced tracker storage for room key updates (#803)

### Next Steps
After merge:
1. Tag the commit with \kirbyam-v0.2.0-rc6\
2. Verify the release workflow builds successfully
3. Create manual testing issue for rc6