### PR TITLE
Fix statue names in enemy copy ability spoiler output

### DIFF
--- a/worlds/kirbyam/enemy_ability_runtime_patch.py
+++ b/worlds/kirbyam/enemy_ability_runtime_patch.py
@@ -50,6 +50,12 @@ _STATUE_TABLES: tuple[tuple[int, tuple[str, ...]], ...] = (
     (0x35390C, ("Sword", "Cutter", "Cupid")),
 )
 
+_STATUE_SLOT_LABELS: dict[str, str] = {
+    f"STATUE:{base_address + index:06X}": f"{default_ability} Statue"
+    for base_address, default_abilities in _STATUE_TABLES
+    for index, default_ability in enumerate(default_abilities)
+}
+
 _MINI_ABILITY_NAME = "Mini"
 
 
@@ -172,7 +178,7 @@ def build_enemy_copy_spoiler_rows(
         for base_address, default_abilities in _STATUE_TABLES:
             for index, _ in enumerate(default_abilities):
                 slot_key = f"STATUE:{base_address + index:06X}"
-                rows.append(("statue", slot_key, statue_assignments[slot_key]))
+                rows.append(("statue", _STATUE_SLOT_LABELS.get(slot_key, slot_key), statue_assignments[slot_key]))
 
     rows.sort(key=lambda row: (row[0], row[1]))
     return rows

--- a/worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py
+++ b/worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py
@@ -450,8 +450,9 @@ def test_shuffled_spoiler_rows_include_statues_when_enabled() -> None:
     writes = build_enemy_copy_runtime_patch_writes(policy, include_statues=True)
     reverse_ability_names = {ability_id: ability_name for ability_name, ability_id in ABILITY_NAME_TO_ID.items()}
 
-    assert ("statue", "STATUE:3538FC") in row_map
-    assert row_map[("statue", "STATUE:3538FC")] == reverse_ability_names[writes[0x3538FC]]
+    assert ("statue", "Beam Statue") in row_map
+    assert row_map[("statue", "Beam Statue")] == reverse_ability_names[writes[0x3538FC]]
+    assert all(not key.startswith("STATUE:") for kind, key in row_map if kind == "statue")
     assert ("enemy", "GOLEM") in row_map
 
 


### PR DESCRIPTION
## Summary
- replace raw statue slot hex keys in spoiler rows with friendly labels (for example, `Beam Statue`)
- keep runtime patch addressing unchanged (still keyed by internal slot addresses)
- add regression coverage ensuring statue spoiler rows no longer expose `STATUE:<hex>` keys

## Testing
- `./.venv/Scripts/python -m pytest worlds/kirbyam/test/test_enemy_copy_ability_runtime_patch.py -q`

Closes #821