### PR TITLE
Prepare KirbyAM v0.2.0-rc7 pre-tag sync

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -7,6 +7,22 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - `### Bug Fixes`
 - `### Internal Changes`
 
+## v0.2.0-rc7
+
+### New Features
+
+- None.
+
+### Bug Fixes
+
+- Fix missing AP checks for spray-paint and music small chests so these checks now send reliably (Issue #807).
+- Fix hub-switch check handling by moving to a single-source mapping pipeline so check labels and sent checks stay aligned (Issue #806).
+- Fix statue naming in enemy-ability spoiler output so statue entries use the expected display names (Issue #821).
+
+### Internal Changes
+
+- Refine the `v0.2.0` changelog section wording to match shipped behavior and issue scope without changing runtime game behavior (Issue #817, Issue #818).
+
 ## v0.2.0
 
 ### New Features

--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.0",
+  "world_version": "0.2.0-rc7",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- add a dedicated 0.2.0-rc7 changelog section for the RC delta
- bump worlds/kirbyam/archipelago.json world_version to 