### PR TITLE
Align RC tag manifest version with tag suffix

### DIFF
--- a/.github/scripts/kirbyam_release_metadata.py
+++ b/.github/scripts/kirbyam_release_metadata.py
@@ -48,7 +48,7 @@ def build_release_metadata(github_ref: str) -> ReleaseMetadata:
     match = TAG_PATTERN.fullmatch(ref_name)
     if match:
         version = match.group("version")
-        manifest_version = version.split("-rc", 1)[0]
+        manifest_version = version
         return ReleaseMetadata(
             apworld_name="kirbyam.apworld",
             release_name=f"KirbyAM APWorld v{version}",


### PR DESCRIPTION
## Summary
- keep manifest_version equal to the full tag version for KirbyAM release tags
- stop stripping -rcN when building tagged release metadata

## Why
Pre-tag sync flow for RCs now expects world_version to remain on the exact RC version (for example 