### PR TITLE
Issue #832: fix hub switch names and restore label alignment

### DIFF
--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -380,7 +380,7 @@
     "location_id": 3960304
   },
   "HUB_SWITCH_MOONLIGHT": {
-    "label": "Radish Ruins - Big Switch",
+    "label": "Moonlight Mansion - Big Switch",
     "parent_region": "REGION_MOONLIGHT_MANSION/MAIN",
     "tags": [
       "HubSwitch",
@@ -391,7 +391,7 @@
     "location_id": 3960411
   },
   "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
-    "label": "Peppermint Palace East - Big Switch",
+    "label": "Rainbow Route East - Big Switch",
     "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
     "tags": [
       "HubSwitch",
@@ -402,7 +402,7 @@
     "location_id": 3960401
   },
   "HUB_SWITCH_RAINBOW_ROUTE_SOUTH": {
-    "label": "Cabbage Cavern East - Big Switch",
+    "label": "Rainbow Route South - Big Switch",
     "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
     "tags": [
       "HubSwitch",
@@ -424,7 +424,7 @@
     "location_id": 3960403
   },
   "HUB_SWITCH_RAINBOW_ROUTE_WEST": {
-    "label": "Candy Constellation - Big Switch",
+    "label": "Rainbow Route West - Big Switch",
     "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
     "tags": [
       "HubSwitch",
@@ -479,7 +479,7 @@
     "location_id": 3960408
   },
   "HUB_SWITCH_RADISH": {
-    "label": "Rainbow Route East - Big Switch",
+    "label": "Radish Ruins - Big Switch",
     "parent_region": "REGION_RADISH_RUINS/MAIN",
     "tags": [
       "HubSwitch",
@@ -490,7 +490,7 @@
     "location_id": 3960409
   },
   "HUB_SWITCH_PEPPERMINT_EAST": {
-    "label": "Moonlight Mansion - Big Switch",
+    "label": "Peppermint Palace East - Big Switch",
     "parent_region": "REGION_PEPPERMINT_PALACE/MAIN",
     "tags": [
       "HubSwitch",
@@ -512,7 +512,7 @@
     "location_id": 3960400
   },
   "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
-    "label": "Rainbow Route South - Big Switch",
+    "label": "Cabbage Cavern East - Big Switch",
     "parent_region": "REGION_CABBAGE_CAVERN/MAIN",
     "tags": [
       "HubSwitch",
@@ -534,7 +534,7 @@
     "location_id": 3960413
   },
   "HUB_SWITCH_CANDY": {
-    "label": "Rainbow Route West - Big Switch",
+    "label": "Candy Constellation - Big Switch",
     "parent_region": "REGION_CANDY_CONSTELLATION/MAIN",
     "tags": [
       "HubSwitch",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -249,7 +249,7 @@
     },
     "HUB_SWITCH_CABBAGE_CAVERN_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route South - Big Switch",
+      "label": "Cabbage Cavern East - Big Switch",
       "location_id": 3960412,
       "tags": [
         "HubSwitch",
@@ -267,7 +267,7 @@
     },
     "HUB_SWITCH_CANDY": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route West - Big Switch",
+      "label": "Candy Constellation - Big Switch",
       "location_id": 3960414,
       "tags": [
         "HubSwitch",
@@ -285,7 +285,7 @@
     },
     "HUB_SWITCH_MOONLIGHT": {
       "category": "HUB_SWITCH",
-      "label": "Radish Ruins - Big Switch",
+      "label": "Moonlight Mansion - Big Switch",
       "location_id": 3960411,
       "tags": [
         "HubSwitch",
@@ -312,7 +312,7 @@
     },
     "HUB_SWITCH_PEPPERMINT_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Moonlight Mansion - Big Switch",
+      "label": "Peppermint Palace East - Big Switch",
       "location_id": 3960410,
       "tags": [
         "HubSwitch",
@@ -330,7 +330,7 @@
     },
     "HUB_SWITCH_RADISH": {
       "category": "HUB_SWITCH",
-      "label": "Rainbow Route East - Big Switch",
+      "label": "Radish Ruins - Big Switch",
       "location_id": 3960409,
       "tags": [
         "HubSwitch",
@@ -339,7 +339,7 @@
     },
     "HUB_SWITCH_RAINBOW_ROUTE_EAST": {
       "category": "HUB_SWITCH",
-      "label": "Peppermint Palace East - Big Switch",
+      "label": "Rainbow Route East - Big Switch",
       "location_id": 3960401,
       "tags": [
         "HubSwitch",
@@ -357,7 +357,7 @@
     },
     "HUB_SWITCH_RAINBOW_ROUTE_SOUTH": {
       "category": "HUB_SWITCH",
-      "label": "Cabbage Cavern East - Big Switch",
+      "label": "Rainbow Route South - Big Switch",
       "location_id": 3960402,
       "tags": [
         "HubSwitch",
@@ -366,7 +366,7 @@
     },
     "HUB_SWITCH_RAINBOW_ROUTE_WEST": {
       "category": "HUB_SWITCH",
-      "label": "Candy Constellation - Big Switch",
+      "label": "Rainbow Route West - Big Switch",
       "location_id": 3960404,
       "tags": [
         "HubSwitch",

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -52,14 +52,14 @@ def test_hub_switch_moonlight_and_peppermint_east_mapping() -> None:
 
 def test_hub_switch_labels_match_expected_location_ids() -> None:
     expected_labels_by_location_id = {
-        3960401: "Peppermint Palace East - Big Switch",
-        3960402: "Cabbage Cavern East - Big Switch",
-        3960404: "Candy Constellation - Big Switch",
-        3960409: "Rainbow Route East - Big Switch",
-        3960410: "Moonlight Mansion - Big Switch",
-        3960411: "Radish Ruins - Big Switch",
-        3960412: "Rainbow Route South - Big Switch",
-        3960414: "Rainbow Route West - Big Switch",
+        3960401: "Rainbow Route East - Big Switch",
+        3960402: "Rainbow Route South - Big Switch",
+        3960404: "Rainbow Route West - Big Switch",
+        3960409: "Radish Ruins - Big Switch",
+        3960410: "Peppermint Palace East - Big Switch",
+        3960411: "Moonlight Mansion - Big Switch",
+        3960412: "Cabbage Cavern East - Big Switch",
+        3960414: "Candy Constellation - Big Switch",
     }
 
     labels_by_location_id = {


### PR DESCRIPTION
## Summary
- restore hub-switch labels so each HUB_SWITCH_* key uses the correct in-game area name
- update normalization expectations that drifted with the regression in #827
- refresh representative slot_data snapshot labels to match corrected data

## Testing
- focused data integrity check: verified HUB_SWITCH_* labels in worlds/kirbyam/data/locations.json match expected in-game names
- attempted: python -m pytest worlds/kirbyam/test/test_data_normalization.py worlds/kirbyam/test/test_rules.py worlds/kirbyam/test/test_slot_data_contract.py (blocked by local environment bootstrap constraints: Python 3.14 + world import dependency issues)

Closes #832