### PR TITLE
Release: sync KirbyAM world_version to 0.2.0-rc8

### DIFF
--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.0-rc7",
+  "world_version": "0.2.0-rc8",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
## Summary
- bump worlds/kirbyam/archipelago.json world_version from 0.2.0-rc7 to 0.2.0-rc8
- align manifest version with planned tag kirbyam-v0.2.0-rc8 for pre-tag sync flow

## Validation
- pre-commit hooks passed on commit