### PR TITLE
Release v0.2.0: promote world_version

### DIFF
--- a/worlds/kirbyam/archipelago.json
+++ b/worlds/kirbyam/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Kirby & The Amazing Mirror",
-  "world_version": "0.2.0-rc8",
+  "world_version": "0.2.0",
   "minimum_ap_version": "0.6.3",
   "authors": [
     "Harrison Sherwin"


### PR DESCRIPTION
Promotes KirbyAM world manifest version from 0.2.0-rc8 to 0.2.0 for final release tagging.