### PR TITLE
Core: simplify runtime mapping paths and add start-here dev docs (Issue #811)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -18,6 +18,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Trap pool filtering now removes `Life Down Trap` and `Life Wipeout Trap` when `No Extra Lives` is enabled, and removes `Health Down Trap` when one-hit mode is enabled (PR #833).
 
 ### Internal Changes
+- Simplified repeated client location-map initialization paths in `worlds/kirbyam/client.py`, added focused regression coverage for the refactor, and added concise runtime developer docs for location polling and item/native-reward interception flows (Issue #811).
 - Traps are now stored in data/items.json, instead of a separate data/traps.json (PR #833).
 - Room-owned location membership is now derived from `locations.json` parent-region metadata so `rooms.json` no longer acts as a second source of truth (Issue #840).
 - Improvements to logic mapping (PR #844).

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -7,7 +7,7 @@ import random
 import re
 import time
 from struct import unpack_from
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import Utils
 from BaseClasses import ItemClassification
@@ -297,34 +297,23 @@ class KirbyAmClient(BizHawkClient):
                     self._goal_location_ids_by_option[Goal.option_defeat_random_hidden_area_boss] = loc.location_id
             else:
                 self._non_goal_location_ids_sorted.append(loc.location_id)
-        # Boss defeat bitfield → location IDs (BOSS_DEFEAT category; polled from boss_defeat_flags)
-        self._boss_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.BOSS_DEFEAT:
-                continue
-            self._boss_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        # Boss defeat bitfield -> location IDs (BOSS_DEFEAT category; polled from boss_defeat_flags)
+        self._boss_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.BOSS_DEFEAT)
         self._boss_location_ids_all: set[int] = {
             location_id
             for location_ids in self._boss_location_ids_by_bit.values()
             for location_id in location_ids
         }
 
-        # Major chest bitfield → location IDs (MAJOR_CHEST category; polled from major_chest_flags)
+        # Major chest bitfield -> location IDs (MAJOR_CHEST category; polled from major_chest_flags)
         # Bit N corresponds to area ID N in enum AreaId (e.g. bit 3 = AREA_CABBAGE_CAVERN).
-        self._major_chest_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.MAJOR_CHEST:
-                continue
-            self._major_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        self._major_chest_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.MAJOR_CHEST)
 
-        # Minor chest native bitfield → location IDs (MINOR_CHEST category; polled from native chest flags).
-        self._minor_chest_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.MINOR_CHEST:
-                continue
-            if _is_exact_minor_chest_location(loc):
-                continue
-            self._minor_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        # Minor chest native bitfield -> location IDs (MINOR_CHEST category; polled from native chest flags).
+        self._minor_chest_location_ids_by_bit = self._build_location_ids_by_bit(
+            LocationCategory.MINOR_CHEST,
+            include_predicate=lambda loc: not _is_exact_minor_chest_location(loc),
+        )
         self._report_only_minor_chest_location_ids: set[int] = {
             loc.location_id
             for loc in data.locations.values()
@@ -350,26 +339,14 @@ class KirbyAmClient(BizHawkClient):
         self._last_minor_chest_event_counter: int | None = None
         self._logged_unknown_minor_chest_source_ptrs: set[int] = set()
 
-        # Vitality chest bitfield → location IDs (VITALITY_CHEST category; dedicated transport register)
-        self._vitality_chest_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.VITALITY_CHEST:
-                continue
-            self._vitality_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        # Vitality chest bitfield -> location IDs (VITALITY_CHEST category; dedicated transport register)
+        self._vitality_chest_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.VITALITY_CHEST)
 
-        # Sound Player chest bitfield → location IDs (SOUND_PLAYER_CHEST category).
-        self._sound_player_chest_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.SOUND_PLAYER_CHEST:
-                continue
-            self._sound_player_chest_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        # Sound Player chest bitfield -> location IDs (SOUND_PLAYER_CHEST category).
+        self._sound_player_chest_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.SOUND_PLAYER_CHEST)
 
-        # Hub switch bitfield → location IDs (HUB_SWITCH category).
-        self._hub_switch_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.HUB_SWITCH:
-                continue
-            self._hub_switch_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        # Hub switch bitfield -> location IDs (HUB_SWITCH category).
+        self._hub_switch_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.HUB_SWITCH)
 
         # Compatibility aliases sourced from the generated hub-switch contract.
         # This keeps fallback bits synchronized with payload/client mapping rules.
@@ -393,20 +370,12 @@ class KirbyAmClient(BizHawkClient):
             for location_id in location_ids
         }
 
-        # Room-sanity bitfield index (doorsIdx) → location IDs.
-        self._room_sanity_location_ids_by_bit: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.ROOM_SANITY:
-                continue
-            self._room_sanity_location_ids_by_bit.setdefault(loc.bit_index, []).append(loc.location_id)
+        # Room-sanity bitfield index (doorsIdx) -> location IDs.
+        self._room_sanity_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.ROOM_SANITY)
         self._room_sanity_bits_sorted: list[int] = sorted(self._room_sanity_location_ids_by_bit.keys())
 
         # Area-first-visit location map keyed by area id (1..9).
-        self._area_visit_location_ids_by_area_id: dict[int, list[int]] = {}
-        for loc in data.locations.values():
-            if loc.bit_index is None or loc.category != LocationCategory.AREA_VISIT:
-                continue
-            self._area_visit_location_ids_by_area_id.setdefault(loc.bit_index, []).append(loc.location_id)
+        self._area_visit_location_ids_by_area_id = self._build_location_ids_by_bit(LocationCategory.AREA_VISIT)
         self._area_visit_area_ids_sorted: list[int] = sorted(self._area_visit_location_ids_by_area_id.keys())
 
         # One-time RAM state load
@@ -585,6 +554,21 @@ class KirbyAmClient(BizHawkClient):
         return common_logger
 
     @staticmethod
+    def _build_location_ids_by_bit(
+        category: LocationCategory,
+        include_predicate: Callable[[object], bool] | None = None,
+    ) -> dict[int, list[int]]:
+        """Build a bit-index map for locations in the requested category."""
+        result: dict[int, list[int]] = {}
+        for loc in data.locations.values():
+            if loc.bit_index is None or loc.category != category:
+                continue
+            if include_predicate is not None and not include_predicate(loc):
+                continue
+            result.setdefault(loc.bit_index, []).append(loc.location_id)
+        return result
+
+    @staticmethod
     def _build_room_metadata_maps() -> "tuple[dict[int, str], dict[int, str], dict[int, int], dict[str, list[int]]]":
         """Build all room-derived lookup maps from a single rooms.json pass."""
         rooms_json = load_json_data("regions/rooms.json")
@@ -594,6 +578,15 @@ class KirbyAmClient(BizHawkClient):
         boss_room_result: dict[str, list[int]] = {}
         if not isinstance(rooms_json, dict):
             return room_label_result, room_region_result, room_area_result, boss_room_result
+
+        for loc_meta in data.locations.values():
+            if loc_meta.category != LocationCategory.BOSS_DEFEAT:
+                continue
+            if not isinstance(loc_meta.parent_region, str) or loc_meta.parent_region not in rooms_json:
+                continue
+            boss_room_result.setdefault(loc_meta.parent_region, []).append(loc_meta.location_id)
+        for location_ids in boss_room_result.values():
+            location_ids.sort()
 
         for region_key, room in rooms_json.items():
             if not isinstance(region_key, str) or not isinstance(room, dict):
@@ -613,17 +606,6 @@ class KirbyAmClient(BizHawkClient):
                     area_id = _AREA_REGION_TOKEN_TO_AREA_ID.get(match.group(1))
                     if area_id is not None:
                         room_area_result[doors_idx] = area_id
-
-            boss_location_ids: list[int] = []
-            for loc_meta in data.locations.values():
-                if loc_meta.parent_region != region_key:
-                    continue
-                if loc_meta.category != LocationCategory.BOSS_DEFEAT:
-                    continue
-                boss_location_ids.append(loc_meta.location_id)
-
-            if boss_location_ids:
-                boss_room_result[region_key] = sorted(boss_location_ids)
 
         return room_label_result, room_region_result, room_area_result, boss_room_result
 

--- a/worlds/kirbyam/docs/dev-docs/_start-here.md
+++ b/worlds/kirbyam/docs/dev-docs/_start-here.md
@@ -1,0 +1,26 @@
+# KirbyAM Dev Docs - Start Here
+
+This folder is the entry point for KirbyAM world and client internals.
+
+## Quick map
+
+- Runtime check flow by location type: see runtime-location-checks.md
+- Runtime item injection and native reward interception: see runtime-item-delivery-and-native-intercepts.md
+- Full protocol contract (mailbox fields, ACK behavior, transport registers): see ../../PROTOCOL.md
+- Deeper architecture context and historical notes: see kirbyam-world-architecture-notes.md
+
+## Read order for new contributors
+
+1. runtime-location-checks.md
+2. runtime-item-delivery-and-native-intercepts.md
+3. ../../PROTOCOL.md
+4. kirbyam-world-architecture-notes.md (only if you need background/legacy rationale)
+
+## Scope of this mini-set
+
+The two runtime reference docs above intentionally stay short and operational:
+
+- What exact signal is read.
+- Where the signal is written (native hook or AP transport register).
+- Which client poll/delivery method consumes it.
+- What behavior is intentionally suppressed from native game rewards in AP mode.

--- a/worlds/kirbyam/docs/dev-docs/runtime-item-delivery-and-native-intercepts.md
+++ b/worlds/kirbyam/docs/dev-docs/runtime-item-delivery-and-native-intercepts.md
@@ -1,0 +1,52 @@
+# Runtime Item Delivery And Native Reward Intercepts
+
+This document defines how AP items are injected and how native reward paths are intercepted when a location becomes AP-owned.
+
+## AP item injection path
+
+1. worlds/kirbyam/client.py _deliver_items() writes mailbox fields:
+   - incoming_item_id
+   - incoming_item_player
+   - incoming_item_flag = 1
+2. kirby_ap_payload/ap_payload.c ap_poll_mailbox_c() consumes mailbox entries.
+3. ap_apply_item(ap_item_id) applies the item effect.
+4. Payload clears incoming_item_flag to ACK.
+5. Client observes ACK and advances delivered_item_index.
+
+## Item type handling in ap_apply_item()
+
+| AP item family | IDs (base offset relative) | Runtime effect |
+|---|---|---|
+| 1-UP | +1 | ap_grant_lives(1) |
+| Mirror shards | +2..+9 | Set KIRBY_SHARD_FLAGS, AP shard authority bitfield, and persist shard state to SRAM |
+| Area maps | +10..+17 and +24 | Set native big chest map bits via ap_unlock_area_map() |
+| Vitality counters | +18..+21 | Increment vitality once per item index using AP_DELIVERED_VITALITY_ITEM_BITS replay guard |
+| Sound Player | +25 | Call KIRBY_COLLECT_SOUND_PLAYER_FN(0) |
+| Consumables | +26..+31 | Grant food, battery, max tomato, invincibility candy, energy drink, hunk of meat |
+| Traps | +32..+36 | Apply health/life/bomb/battery/lives penalties |
+
+Unknown IDs are left unhandled and do not ACK-clear, by design, to avoid silent loss.
+
+## Native reward interception policy
+
+AP mode records checks and suppresses or normalizes native rewards so progression is AP-authoritative.
+
+| Native reward event | Hook | Interception behavior |
+|---|---|---|
+| Boss shard reward | ap_on_boss_defeat_collect_shard() | Record boss-defeat check transport flag. Preserve temporary native shard write for cutscene safety, then rely on AP shard ownership/scrub logic for authority. |
+| Boss already-owned reward path | ap_on_boss_defeat_already_owned_reward() | Record boss-defeat check even when native CollectShard path is skipped. |
+| Major chest map reward | ap_on_collect_big_chest() | Record AP major-chest flag; do not unlock map from this native check path. Map unlock is AP item delivery only. |
+| Vitality big chest reward | ap_on_collect_vitality_chest() | Convert room reward event to AP vitality-chest transport bit. |
+| Sound Player chest path | ap_on_collect_sound_player_chest() | Reward index 0 becomes AP Sound Player chest check; other rewards route through AP-owned minor chest collection recording. |
+| Spray paint chest reward | ap_on_collect_spray_paint_chest() | Suppress native reward grant; only record AP-owned minor chest collection transport/native persistence bits. |
+| Small chest reward | ap_on_collect_small_chest() | Record exact source pointer and native small-chest persistence so client can map to correct AP minor location. |
+| Hub unlock/world map door unlock | ap_on_world_map_unlock_call() | Record AP hub-switch flag when unlock is persisted in world props. |
+
+## Client-side reconciliation that enforces AP ownership
+
+worlds/kirbyam/client.py runs these every active gameplay tick:
+
+- _reconcile_native_shard_ownership(): keeps shard bits aligned to AP-delivered ownership.
+- _reconcile_native_map_ownership(): keeps native map bits aligned to AP-delivered maps and start_with_all_maps.
+
+These reconciliation passes are the final guardrails that interrupt native drift from save/load/cutscene edge cases.

--- a/worlds/kirbyam/docs/dev-docs/runtime-location-checks.md
+++ b/worlds/kirbyam/docs/dev-docs/runtime-location-checks.md
@@ -1,0 +1,45 @@
+# Runtime Location Checks
+
+This document defines how each KirbyAM location type is read at runtime.
+
+## Polling loop entry point
+
+All location polling runs in worlds/kirbyam/client.py from KirbyAmClient.game_watcher(), in this order:
+
+1. Boss defeat
+2. Major chest
+3. Minor chest
+4. Vitality chest
+5. Sound Player chest
+6. Hub switch
+7. Area visit
+8. Room sanity
+
+Each poll computes mapped AP location IDs and sends LocationChecks for IDs not yet acknowledged by the server.
+
+## Location type matrix
+
+| Location type | Runtime signal source | Writer side | Client reader |
+|---|---|---|---|
+| BOSS_DEFEAT | AP_BOSS_DEFEAT_FLAGS transport bitfield | payload hook ap_on_boss_defeat_collect_shard() and ap_on_boss_defeat_already_owned_reward() in kirby_ap_payload/ap_payload.c | _poll_boss_defeat_locations() |
+| MAJOR_CHEST | AP_MAJOR_CHEST_FLAGS transport bitfield | payload hook ap_on_collect_big_chest() | _poll_major_chest_locations() |
+| MINOR_CHEST | Native small chest flags + exact source-pointer ring for ambiguous chests | payload hooks ap_on_collect_small_chest(), ap_on_collect_spray_paint_chest(), ap_on_collect_sound_player_chest() write ring and native flags | _poll_minor_chest_locations() + _poll_exact_minor_chest_events() |
+| VITALITY_CHEST | AP_VITALITY_CHEST_FLAGS transport bitfield | payload hook ap_on_collect_vitality_chest() | _poll_vitality_chest_locations() |
+| SOUND_PLAYER_CHEST | AP_SOUND_PLAYER_CHEST_FLAGS transport bitfield | payload hook ap_on_collect_sound_player_chest() | _poll_sound_player_chest_locations() |
+| HUB_SWITCH | AP_HUB_SWITCH_FLAGS transport bitfield | payload hook ap_on_world_map_unlock_call() and world-props sync helpers | _poll_hub_switch_locations() |
+| AREA_VISIT | Native gVisitedDoors bit-15 interpreted via doorsIdx -> area mapping | native game room-visit state | _poll_area_visit_locations() |
+| ROOM_SANITY | Native gVisitedDoors bit-15 interpreted directly by doorsIdx | native game room-visit state | _poll_room_sanity_locations() |
+| GOAL | Native AI state signal + AP checked location state | native gameplay state + client-side goal option | _maybe_report_goal() |
+
+## Minor chest disambiguation details
+
+Minor chest reporting uses two paths:
+
+1. Standard mapped-by-bit checks from native small chest flags.
+2. Exact event ring source pointers for locations tagged as report-only/exact-event.
+
+The exact-event path exists because multiple physical chest events can share native bitfields. Source-pointer tracking keeps AP location mapping deterministic.
+
+## Active-location filtering
+
+When slot_data includes a reduced location set, the client filters mapped checks to active IDs via _active_location_id_set(). This prevents reporting checks that are not part of the current generated slot.

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -185,6 +185,32 @@ def test_locations_command_supports_name_lookup_dict_style_access(mock_bizhawk_c
     assert active_location.label in outputs
 
 
+def test_build_location_ids_by_bit_filters_exact_minor_chest_locations():
+    filtered_map = KirbyAmClient._build_location_ids_by_bit(
+        LocationCategory.MINOR_CHEST,
+        include_predicate=lambda loc: not _is_exact_minor_chest_location(loc),
+    )
+
+    filtered_ids = {location_id for location_ids in filtered_map.values() for location_id in location_ids}
+    report_only_ids = {
+        loc.location_id
+        for loc in data.locations.values()
+        if loc.category == LocationCategory.MINOR_CHEST and _is_exact_minor_chest_location(loc)
+    }
+
+    assert filtered_ids
+    assert report_only_ids
+    assert filtered_ids.isdisjoint(report_only_ids)
+
+
+def test_build_room_metadata_maps_returns_sorted_boss_location_lists():
+    _, _, _, boss_room_lookup = KirbyAmClient._build_room_metadata_maps()
+
+    assert boss_room_lookup
+    for location_ids in boss_room_lookup.values():
+        assert location_ids == sorted(location_ids)
+
+
 @pytest.mark.asyncio
 async def test_validate_rom_reads_auth_from_rom_domain_offset(mock_bizhawk_context):
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary
- simplify repeated location-bit map construction in KirbyAM client initialization
- simplify boss room metadata map building by removing repeated per-room full scans
- add concise runtime developer docs for location polling and item/native-reward interception
- add a new dev-docs start-here table of contents and entry guide
- add focused regression tests for helper behavior
- update unreleased changelog

Closes #811