### PR TITLE
Fix duplicate self-send BizHawk notifications

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -7,6 +7,12 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - `### Bug Fixes`
 - `### Internal Changes`
 
+## Unreleased
+
+### Improvements
+
+- Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
+
 ## v0.2.0
 
 ### New Features

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -9,7 +9,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 ## Unreleased
 
-### Improvements
+### Bug Fixes
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1185,8 +1185,12 @@ class KirbyAmClient(BizHawkClient):
         lookup_slot = receiver_slot if receiver_slot is not None else player_id
         item_name = self._item_name(ctx, item_id, lookup_slot)
         sender_name = self._player_name(ctx, player_id)
-        prefix = "Received trap: " if self._is_trap_item(item_id) else "Received "
-        message = f"{prefix}{item_name} from {sender_name}"
+        is_self_receive = receiver_slot is not None and player_id == receiver_slot
+        if is_self_receive:
+            message = f"You found your {item_name}."
+        else:
+            prefix = "Received trap: " if self._is_trap_item(item_id) else "Received "
+            message = f"{prefix}{item_name} from {sender_name}"
 
 
         self._log_verbose(
@@ -1223,6 +1227,14 @@ class KirbyAmClient(BizHawkClient):
         if item_id is None or sender_id is None or receiver_id is None:
             return
         if sender_id != getattr(ctx, "slot", None):
+            return
+        if sender_id == receiver_id:
+            self._log_verbose(
+                "info",
+                "KirbyAM: self-send popup suppressed (item=%s, slot=%s)",
+                item_id,
+                sender_id,
+            )
             return
 
         send_key = (item_id, sender_id, receiver_id, location_id if location_id is not None else 0xFFFFFFFF)

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1228,7 +1228,7 @@ class KirbyAmClient(BizHawkClient):
             return
         if sender_id != getattr(ctx, "slot", None):
             return
-        if sender_id == receiver_id:
+        if sender_id == receiver_id and self._receive_notifications_enabled:
             self._log_verbose(
                 "info",
                 "KirbyAM: self-send popup suppressed (item=%s, slot=%s)",

--- a/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
+++ b/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
@@ -80,6 +80,8 @@ Use exact item/location names from this world (or the item groups listed above) 
 
 When you find an item that is not your own, you will be able to see what it was and who it was sent to in both Bizhawk and the Archipelago Bizhawk client. The sprite for the item will still appear, but you will need to receive it via Archipelago before it's usable. When collecting a mirror shard check, the cutscene will still play as if you've received the mirror shard, however it will not be given until you receive it properly via Archipelago.
 
+If an item sends to your own slot, BizHawk shows one local confirmation line (`You found your <item>.`) instead of separate send and receive popups.
+
 
 
 ## When the player receives an item, what happens?

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2814,6 +2814,27 @@ async def test_receive_notification_uses_local_slot_for_item_name_lookup(mock_bi
 
 
 @pytest.mark.asyncio
+async def test_receive_notification_uses_single_line_wording_for_self_send(mock_bizhawk_context):
+    """Self-send receives should emit a single local wording line."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    mock_bizhawk_context.slot = 1
+    mock_bizhawk_context.items_received = [Mock(item=3860001, player=1)]
+    mock_bizhawk_context.player_names = {1: "LocalPlayer"}
+    mock_bizhawk_context.item_names = Mock()
+    mock_bizhawk_context.item_names.lookup_in_slot.return_value = "Mirror Shard"
+
+    with patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock) as mock_display:
+        await client._emit_receive_notification(mock_bizhawk_context, 0)
+
+    mock_display.assert_awaited_once_with(
+        mock_bizhawk_context.bizhawk_ctx,
+        "You found your Mirror Shard.",
+    )
+
+
+@pytest.mark.asyncio
 async def test_receive_notification_queue_log_emitted_file_only(mock_bizhawk_context):
     client = KirbyAmClient()
     client.initialize_client()

--- a/worlds/kirbyam/test/test_notifications.py
+++ b/worlds/kirbyam/test/test_notifications.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 """Tests for item notification formatting and location name resolution."""
 from unittest.mock import Mock, patch
 

--- a/worlds/kirbyam/test/test_notifications.py
+++ b/worlds/kirbyam/test/test_notifications.py
@@ -209,6 +209,29 @@ def test_send_notification_only_emits_own_items():
         assert mock_display.call_count == 0, "Should not emit notifications for other players' items"
 
 
+def test_send_notification_suppresses_self_send_popups():
+    """_maybe_emit_send_notification should suppress popups for self-send ItemSend events."""
+    client = KirbyAmClient()
+    client.initialize_client()
+    ctx = Mock()
+    ctx.slot = 1
+    ctx.bizhawk_ctx = Mock()
+    ctx.item_names = None
+    ctx.player_names = {1: "LocalPlayer"}
+
+    args = {
+        "type": "ItemSend",
+        "item": Mock(item=12345, player=1, location=67890),
+        "receiving": 1,
+    }
+
+    with patch('worlds.kirbyam.client.bizhawk.display_message') as mock_display:
+        with patch('worlds.kirbyam.client.Utils.async_start', side_effect=_close_async_start_coro):
+            client._maybe_emit_send_notification(ctx, args)
+
+        assert mock_display.call_count == 0, "Self-send should not emit a send popup"
+
+
 def test_send_notification_ignores_non_itemsend_events():
     """_maybe_emit_send_notification should ignore non-ItemSend event types."""
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary
- suppress `You sent ...` BizHawk popup for self-send ItemSend events
- keep one self-send confirmation line via receive notification: `You found your <item>.`
- add regression tests for self-send popup suppression and self-send receive wording
- document behavior in the world docs and changelog

## Testing
- `python -m pytest worlds/kirbyam/test/test_notifications.py worlds/kirbyam/test/test_client.py`
- `python -m pytest worlds/kirbyam/test/test_notifications.py worlds/kirbyam/test/test_client.py -k "self_send or receive_notification_uses_single_line_wording_for_self_send or send_notification_suppresses_self_send_popups"`

Closes #848