### PR TITLE
Issue #207: configured area boss goal mode

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -15,7 +15,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Added a new goal mode: `defeat_configured_area_boss` completes the seed after a specific area-boss is defeated (Issue #207).
   - Which area boss is used is determined by the new `configured_area_boss` option. It defaults to Master Hand and Crazy Hand.
 
-### Bug Fixes
+### Improvements
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -12,6 +12,8 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### New Features
 
 - Ability gating is now available and controlled by a `Make the game harder` option and defaults to "on". A preset list of abilities is available at the beginning of the game (Beam, Burning, Mini, Stone, and Wheel). This list should be the bare minimum you need to complete the game and get all the currently supported locations. All other abilities are gated by custom AP items (for example, "Sword Ability") (Issues #855, #819).
+- Added a new goal mode: `defeat_configured_area_boss` completes the seed after a specific area-boss is defeated (Issue #207).
+  - Which area boss is used is determined by the new `configured_area_boss` option. It defaults to Master Hand and Crazy Hand.
 
 ### Bug Fixes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -15,9 +15,13 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Added a new goal mode: `defeat_configured_area_boss` completes the seed after a specific area-boss is defeated (Issue #207).
   - Which area boss is used is determined by the new `configured_area_boss` option. It defaults to Master Hand and Crazy Hand.
 
-### Improvements
+### Bug Fixes
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
+
+### Internal Changes
+
+- Updated KirbyAM goal-mode slot data, protocol documentation, client handling, and tests to support the configured area-boss goal flow (Issue #207).
 
 ## v0.2.0
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -179,6 +179,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 |---------------|----------|-------------|
 | GOAL_DARK_MIND | auto-assigned | Internal goal metadata entry for Dark Mind completion. Current shipped worlds convert goal locations to runtime events, so the client may report `CLIENT_GOAL` directly when no numeric goal location is exposed by the server. |
 | GOAL_ANY_AREA_BOSS | auto-assigned | Internal goal metadata entry for the "Defeat Any Area Boss" mode. Trigger source is acknowledged `BOSS_DEFEAT_1 .. BOSS_DEFEAT_8` checks; Candy Constellation's Master Hand + Crazy Hand pair counts as one pooled target (`BOSS_DEFEAT_3`). |
+| GOAL_CONFIGURED_AREA_BOSS | auto-assigned | Internal goal metadata entry for the "Defeat Configured Area Boss" mode. Trigger source is the configured `BOSS_DEFEAT_N` check selected via `goal_configured_area_boss_key`. |
 | BOSS_DEFEAT_1 .. BOSS_DEFEAT_8 | auto-assigned | Area boss defeat locations (8 locations) |
 | MAJOR_CHEST_CABBAGE_CAVERN | 3960200 | Cabbage Cavern big chest (bit 3, gTreasures.bigChestField) |
 | MAJOR_CHEST_OLIVE_OCEAN | 3960201 | Olive Ocean big chest (bit 6, gTreasures.bigChestField) |
@@ -236,7 +237,9 @@ Server → Client: ConnectionRefused | Connected
                  (with items_received, checked_locations, slot_data)
 
 `slot_data` currently includes:
-- `goal` (int): selected goal option (`0=Dark Mind`, `1=Defeat Any Area Boss`).
+- `goal` (int): selected goal option (`0=Dark Mind`, `1=Defeat Any Area Boss`, `2=Defeat Configured Area Boss`, `3=Defeat Random Hidden Area Boss`).
+- `configured_area_boss` (int): selected configured area-boss option (`0=King Golem`, `1=Moley`, `2=Kracko`, `3=Mega Titan`, `4=Gobbler`, `5=Wiz`, `6=Dark Meta Knight`, `7=Master Hand + Crazy Hand pair`). Only used when `goal` is `defeat_configured_area_boss`.
+- `goal_configured_area_boss_key` (str | null): internal boss-defeat key selected for `defeat_configured_area_boss` (`BOSS_DEFEAT_1 .. BOSS_DEFEAT_8`). Default target is `BOSS_DEFEAT_3` (Master Hand + Crazy Hand pair). Normal player-facing output does not reveal the boss name; spoiler output may resolve the key to the configured target.
 - `goal_hidden_area_boss_key` (str | null): internal boss-defeat key selected for `defeat_random_hidden_area_boss` (`BOSS_DEFEAT_1 .. BOSS_DEFEAT_8`). Normal player-facing output does not reveal the boss name; spoiler output may resolve the key to the hidden target.
 - `shards` (int): shard randomization mode.
 - `start_with_all_maps` (bool): when true, all map items are precollected and removed from randomized placement, and the BizHawk client reasserts all native area-map bits during gameplay reconciliation.
@@ -274,6 +277,7 @@ Compatibility note (Issue #398 option-key reorganization):
 Goal runtime behavior contract:
 - Goal mode `dark_mind` reports completion after the native Dark Mind clear signal.
 - Goal mode `defeat_any_area_boss` reports completion after the first acknowledged area-boss defeat check in `BOSS_DEFEAT_1 .. BOSS_DEFEAT_8`.
+- Goal mode `defeat_configured_area_boss` reports completion after the configured boss-defeat target is acknowledged by the server; the client resolves the target from `goal_configured_area_boss_key`.
 - Goal mode `defeat_random_hidden_area_boss` reports completion after the seed-selected hidden boss-defeat target is acknowledged by the server; the client resolves the target from `goal_hidden_area_boss_key`.
 
 DeathLink runtime behavior contract:

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -294,6 +294,11 @@ class KirbyAmWorld(World):
 
         option = getattr(getattr(self, "options", None), "configured_area_boss", None)
         value = getattr(option, "value", option)
+        if value is None:
+            raise RuntimeError(
+                "KirbyAM configured area-boss goal could not be resolved from the selected option value. "
+                "Expected one of the defined ConfiguredAreaBoss choices."
+            )
         try:
             choice_value = int(value)
         except (TypeError, ValueError):

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -1000,6 +1000,7 @@ class KirbyAmWorld(World):
         # Legacy key aliases are intentionally not emitted before first public release.
         slot_data = self.options.as_dict(
             "goal",
+            "configured_area_boss",
             "shards",
             "start_with_all_maps",
             "starting_kirby_color",

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -36,6 +36,7 @@ from .locations import KirbyAmLocation, create_location_label_to_id_map
 from .options import (
     OPTION_GROUPS,
     AbilityRandomizationMode,
+    ConfiguredAreaBoss,
     Goal,
     KirbyAmOptions,
     OneHitMode,
@@ -116,6 +117,7 @@ class KirbyAmWorld(World):
     _enemy_copy_ability_policy: dict[str, Any]
     _resolved_starting_kirby_color_id: int
     _resolved_starting_kirby_color_name: str
+    _resolved_configured_area_boss_goal_key: str | None
     _resolved_hidden_area_boss_goal_key: str | None
 
     # Generation stages
@@ -285,6 +287,41 @@ class KirbyAmWorld(World):
         self._resolved_hidden_area_boss_goal_key = rng.choice(self._BOSS_DEFEAT_KEY_ORDER)
         return self._resolved_hidden_area_boss_goal_key
 
+    def _get_resolved_configured_area_boss_goal_key(self) -> str | None:
+        resolved_key = getattr(self, "_resolved_configured_area_boss_goal_key", None)
+        if isinstance(resolved_key, str) and resolved_key:
+            return resolved_key
+
+        option = getattr(getattr(self, "options", None), "configured_area_boss", None)
+        value = getattr(option, "value", option)
+        try:
+            choice_value = int(value)
+        except (TypeError, ValueError):
+            raise RuntimeError(
+                "KirbyAM configured area-boss goal could not be resolved from the selected option value. "
+                "Expected one of the defined ConfiguredAreaBoss choices."
+            ) from None
+
+        configured_area_boss_key_by_value = {
+            ConfiguredAreaBoss.option_king_golem: "BOSS_DEFEAT_1",
+            ConfiguredAreaBoss.option_moley: "BOSS_DEFEAT_2",
+            ConfiguredAreaBoss.option_kracko: "BOSS_DEFEAT_4",
+            ConfiguredAreaBoss.option_mega_titan: "BOSS_DEFEAT_5",
+            ConfiguredAreaBoss.option_gobbler: "BOSS_DEFEAT_6",
+            ConfiguredAreaBoss.option_wiz: "BOSS_DEFEAT_8",
+            ConfiguredAreaBoss.option_dark_meta_knight: "BOSS_DEFEAT_7",
+            ConfiguredAreaBoss.option_master_hand_crazy_hand_pair: "BOSS_DEFEAT_3",
+        }
+
+        resolved = configured_area_boss_key_by_value.get(choice_value)
+        if resolved is None:
+            raise RuntimeError(
+                f"KirbyAM configured area-boss goal resolved an unsupported option value: {choice_value}"
+            )
+
+        self._resolved_configured_area_boss_goal_key = resolved
+        return resolved
+
     def _active_filler_pool(self) -> tuple[str, ...]:
         pool = self.ACTIVE_FILLER_POOL
         if self._one_hit_mode_value() == OneHitMode.option_exclude_vitality_counters:
@@ -355,7 +392,11 @@ class KirbyAmWorld(World):
     def generate_early(self) -> None:
         # Track generation start
         self._generation_start_time = time.time()
-        log_generation_start(self.player, self.player_name, self.options.as_dict("goal", "shards", "death_link"))
+        log_generation_start(
+            self.player,
+            self.player_name,
+            self.options.as_dict("goal", "configured_area_boss", "shards", "death_link"),
+        )
 
         with generation_stage("generate_early", self.player, self.player_name):
             logger.info(f"[P{self.player}] Shards mode: {self.options.shards.current_key}")
@@ -365,6 +406,7 @@ class KirbyAmWorld(World):
             resolved_color = resolve_kirby_color(int(starting_color_value), self.random)
             self._resolved_starting_kirby_color_id = resolved_color.color_id
             self._resolved_starting_kirby_color_name = resolved_color.display_name
+            configured_area_boss_key = self._get_resolved_configured_area_boss_goal_key()
             self._get_resolved_hidden_area_boss_goal_key()
             logger.info(
                 "[P%s] Starting Kirby color option: %s -> %s (%s)",
@@ -372,6 +414,12 @@ class KirbyAmWorld(World):
                 chosen_color_key,
                 resolved_color.display_name,
                 resolved_color.color_id,
+            )
+            logger.info(
+                "[P%s] Configured area boss option: %s -> %s",
+                self.player,
+                getattr(self.options.configured_area_boss, "current_key", "unknown"),
+                configured_area_boss_key,
             )
 
             mode = int(self.options.ability_randomization_mode.value)
@@ -969,6 +1017,7 @@ class KirbyAmWorld(World):
         resolved_color_id, resolved_color_name = self._get_resolved_starting_kirby_color()
         slot_data["starting_kirby_color"] = resolved_color_id
         slot_data["starting_kirby_color_name"] = resolved_color_name
+        slot_data["goal_configured_area_boss_key"] = self._get_resolved_configured_area_boss_goal_key()
         slot_data["goal_hidden_area_boss_key"] = self._get_resolved_hidden_area_boss_goal_key()
         ability_gating_enabled = self._ability_gating_enabled()
         slot_data["ability_gating"] = ability_gating_enabled

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -291,6 +291,8 @@ class KirbyAmClient(BizHawkClient):
                     self._goal_location_ids_by_option[Goal.option_dark_mind] = loc.location_id
                 elif loc.name == "GOAL_ANY_AREA_BOSS":
                     self._goal_location_ids_by_option[Goal.option_defeat_any_area_boss] = loc.location_id
+                elif loc.name == "GOAL_CONFIGURED_AREA_BOSS":
+                    self._goal_location_ids_by_option[Goal.option_defeat_configured_area_boss] = loc.location_id
                 elif loc.name == "GOAL_HIDDEN_AREA_BOSS":
                     self._goal_location_ids_by_option[Goal.option_defeat_random_hidden_area_boss] = loc.location_id
             else:
@@ -3586,6 +3588,17 @@ class KirbyAmClient(BizHawkClient):
             return False
         return hidden_goal.location_id in checked_locations
 
+    def _configured_area_boss_goal_signal_active(self, ctx: KirbyAmBizHawkClientContext, configured_goal_key: str) -> bool:
+        """Return whether the selected configured area boss has been acknowledged by the server."""
+        configured_goal = data.locations.get(configured_goal_key)
+        if configured_goal is None or configured_goal.location_id is None:
+            return False
+
+        checked_locations = getattr(ctx, "checked_locations", None)
+        if not isinstance(checked_locations, set):
+            return False
+        return configured_goal.location_id in checked_locations
+
     async def _maybe_report_goal(
         self,
         ctx: KirbyAmBizHawkClientContext,
@@ -3617,6 +3630,7 @@ class KirbyAmClient(BizHawkClient):
         if parsed_slot_goal in (
             Goal.option_dark_mind,
             Goal.option_defeat_any_area_boss,
+            Goal.option_defeat_configured_area_boss,
             Goal.option_defeat_random_hidden_area_boss,
         ):
             slot_goal = parsed_slot_goal
@@ -3633,7 +3647,20 @@ class KirbyAmClient(BizHawkClient):
             )
 
         hidden_goal_key: str | None = None
+        configured_goal_key: str | None = None
         goal_location_id = self._goal_location_ids_by_option.get(slot_goal)
+        if slot_goal == Goal.option_defeat_configured_area_boss:
+            configured_goal_key_raw = ctx.slot_data.get("goal_configured_area_boss_key")
+            if isinstance(configured_goal_key_raw, str):
+                configured_goal = data.locations.get(configured_goal_key_raw)
+                if configured_goal is not None and configured_goal.location_id is not None:
+                    configured_goal_key = configured_goal_key_raw
+            if goal_location_id is None or configured_goal_key is None:
+                self._log_client(
+                    "warning",
+                    "KirbyAM: configured area-boss target missing or invalid; goal reporting disabled.",
+                )
+                return
         if slot_goal == Goal.option_defeat_random_hidden_area_boss:
             hidden_goal_key_raw = ctx.slot_data.get("goal_hidden_area_boss_key")
             if isinstance(hidden_goal_key_raw, str):
@@ -3657,6 +3684,8 @@ class KirbyAmClient(BizHawkClient):
         if not self._native_goal_signal_seen:
             if slot_goal == Goal.option_defeat_any_area_boss:
                 self._native_goal_signal_seen = self._any_area_boss_goal_signal_active(ctx)
+            elif slot_goal == Goal.option_defeat_configured_area_boss:
+                self._native_goal_signal_seen = self._configured_area_boss_goal_signal_active(ctx, configured_goal_key)
             elif slot_goal == Goal.option_defeat_random_hidden_area_boss:
                 self._native_goal_signal_seen = self._hidden_area_boss_goal_signal_active(ctx, hidden_goal_key)
             else:

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -29,6 +29,16 @@
     "location_id": 3960010,
     "category": "GOAL"
   },
+  "GOAL_CONFIGURED_AREA_BOSS": {
+    "label": "Defeat Configured Area Boss",
+    "parent_region": "REGION_RAINBOW_ROUTE/MAIN",
+    "tags": [
+      "Goal",
+      "MAP_RAINBOW_ROUTE"
+    ],
+    "location_id": 3960011,
+    "category": "GOAL"
+  },
   "BOSS_DEFEAT_1": {
     "label": "Mustard Mountain - Boss Defeat",
     "parent_region": "REGION_MUSTARD_MOUNTAIN/ROOM_4_BOSS",

--- a/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
+++ b/worlds/kirbyam/docs/en_Kirby & The Amazing Mirror.md
@@ -71,6 +71,7 @@ Use exact item/location names from this world (or the item groups listed above) 
   - `dark_mind`: Defeat Dark Mind to complete the seed.
   - `defeat_any_area_boss`: Defeat any one `* - Boss Defeat` location (Mustard Mountain, Moonlight Mansion, Candy Constellation, Olive Ocean, Peppermint Palace, Cabbage Cavern, Carrot Castle, or Radish Ruins). In this mode, collecting all Mirror Shards is not required by the goal mode itself.
     - Candy Constellation's Master Hand + Crazy Hand fight is treated as one pooled boss target (`BOSS_DEFEAT_3`).
+  - `defeat_configured_area_boss`: Defeat a specific area boss selected by the `configured_area_boss` option. The default target is the Master Hand + Crazy Hand pair (`BOSS_DEFEAT_3`), and the selected target is only used by this goal mode.
   - `defeat_random_hidden_area_boss`: Defeat one seed-selected hidden area boss. The selected target is carried in slot data as an internal boss-defeat key; normal player-facing output does not reveal the boss name, but spoiler output may.
 
 
@@ -97,7 +98,7 @@ You will not see an indicator in the game, instead you'll see you received an it
 
 
 
-Currently a tracker is not available. Goal logic depends on the selected mode: either defeat Dark Mind, defeat any one area boss in `defeat_any_area_boss` mode, or defeat the seed-selected hidden area boss in `defeat_random_hidden_area_boss` mode.
+Currently a tracker is not available. Goal logic depends on the selected mode: either defeat Dark Mind, defeat any one area boss in `defeat_any_area_boss` mode, defeat the configured area boss in `defeat_configured_area_boss` mode, or defeat the seed-selected hidden area boss in `defeat_random_hidden_area_boss` mode.
 
 
 

--- a/worlds/kirbyam/options.py
+++ b/worlds/kirbyam/options.py
@@ -21,13 +21,34 @@ class Goal(Choice):
 
     - Dark Mind: Defeat Dark Mind and beat the game.
     - Defeat Any Area Boss: Defeat any one eligible area boss.
+    - Defeat Configured Area Boss: Defeat the selected area boss target.
     - Defeat Random Hidden Area Boss: Defeat one hidden, seed-selected area boss.
     """
     display_name = "Goal"
     default = 0
     option_dark_mind = 0
     option_defeat_any_area_boss = 1
-    option_defeat_random_hidden_area_boss = 2
+    option_defeat_configured_area_boss = 2
+    option_defeat_random_hidden_area_boss = 3
+
+
+class ConfiguredAreaBoss(Choice):
+    """
+    Selects which area boss is used when the goal is set to Defeat Configured Area Boss.
+
+    The default target is the Master Hand + Crazy Hand pair.
+    This option is ignored unless `goal` is set to `defeat_configured_area_boss`.
+    """
+    display_name = "Configured Area Boss"
+    default = 7
+    option_king_golem = 0
+    option_moley = 1
+    option_kracko = 2
+    option_mega_titan = 3
+    option_gobbler = 4
+    option_wiz = 5
+    option_dark_meta_knight = 6
+    option_master_hand_crazy_hand_pair = 7
 
 
 class RandomizeShards(Choice):
@@ -290,6 +311,8 @@ class KirbyAmDeathLink(DeathLink):
 class KirbyAmOptions(PerGameCommonOptions):
     goal: Goal
 
+    configured_area_boss: ConfiguredAreaBoss
+
     shards: RandomizeShards
 
     start_with_all_maps: StartWithAllMaps
@@ -326,6 +349,10 @@ class KirbyAmOptions(PerGameCommonOptions):
 
 
 OPTION_GROUPS = [
+    OptionGroup("Make the game shorter", [
+        Goal,
+        ConfiguredAreaBoss,
+    ]),
     OptionGroup("Make the game easier", [
         StartWithAllMaps,
     ]),

--- a/worlds/kirbyam/rules.py
+++ b/worlds/kirbyam/rules.py
@@ -56,10 +56,12 @@ _SHARD_ITEM_LABELS = [
 _GOAL_LOCATION_LABELS = {
     Goal.option_dark_mind: "Defeat Dark Mind",
     Goal.option_defeat_any_area_boss: "Defeat Any Area Boss",
+    Goal.option_defeat_configured_area_boss: "Defeat Configured Area Boss",
     Goal.option_defeat_random_hidden_area_boss: "Defeat a Hidden Area Boss",
 }
 _DARK_MIND_GOAL_LABEL = _GOAL_LOCATION_LABELS[Goal.option_dark_mind]
 _ANY_AREA_BOSS_GOAL_LABEL = _GOAL_LOCATION_LABELS[Goal.option_defeat_any_area_boss]
+_CONFIGURED_AREA_BOSS_GOAL_LABEL = _GOAL_LOCATION_LABELS[Goal.option_defeat_configured_area_boss]
 _HIDDEN_RANDOM_AREA_BOSS_GOAL_LABEL = _GOAL_LOCATION_LABELS[Goal.option_defeat_random_hidden_area_boss]
 
 _BOSS_DEFEAT_LOCATION_LABELS = [
@@ -213,7 +215,23 @@ def set_rules(world: KirbyAmWorld) -> None:  # noqa: C901
     else:
         logger.debug("[P%s] Goal mode %s: require %s", world.player, goal_value, goal_label)
 
-    if goal_value == Goal.option_defeat_random_hidden_area_boss:
+    if goal_value == Goal.option_defeat_configured_area_boss:
+        configured_goal_key = getattr(world, "_resolved_configured_area_boss_goal_key", None)
+        configured_goal = data.locations.get(configured_goal_key) if isinstance(configured_goal_key, str) else None
+        if configured_goal is None or not isinstance(configured_goal.label, str):
+            raise ValueError(
+                f"[P{world.player}] Configured area-boss goal target was not resolved for goal mode {goal_value}"
+            )
+        logger.debug(
+            "[P%s] Configured area boss goal mode requires %s (%s)",
+            world.player,
+            configured_goal.label,
+            configured_goal_key,
+        )
+        world.multiworld.completion_condition[world.player] = (
+            lambda state, required_goal=configured_goal.label: state.can_reach_location(required_goal, world.player)
+        )
+    elif goal_value == Goal.option_defeat_random_hidden_area_boss:
         hidden_goal_key = getattr(world, "_resolved_hidden_area_boss_goal_key", None)
         hidden_goal = data.locations.get(hidden_goal_key) if isinstance(hidden_goal_key, str) else None
         if hidden_goal is None or not isinstance(hidden_goal.label, str):
@@ -296,6 +314,27 @@ def set_rules(world: KirbyAmWorld) -> None:  # noqa: C901
                         for location_name in _BOSS_DEFEAT_LOCATION_LABELS
                     )
                 set_rule(goal_location, any_area_boss_rule)
+            elif goal_location_name == _CONFIGURED_AREA_BOSS_GOAL_LABEL:
+                configured_goal_key = getattr(
+                    world,
+                    "_resolved_configured_area_boss_goal_key",
+                    None,
+                )
+                configured_goal = (
+                    data.locations.get(configured_goal_key)
+                    if isinstance(configured_goal_key, str)
+                    else None
+                )
+                if configured_goal is None or not isinstance(configured_goal.label, str):
+                    raise ValueError(
+                        f"[P{world.player}] Configured area-boss goal target was not resolved "
+                        f"for goal location {goal_location_name!r}"
+                    )
+
+                def configured_area_boss_rule(state):
+                    return state.can_reach_location(configured_goal.label, world.player)
+
+                set_rule(goal_location, configured_area_boss_rule)
             elif goal_location_name == _HIDDEN_RANDOM_AREA_BOSS_GOAL_LABEL:
                 def hidden_area_boss_rule(state):
                     hidden_goal_key = getattr(world, "_resolved_hidden_area_boss_goal_key", None)

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -232,6 +232,15 @@
         "MAP_RAINBOW_ROUTE"
       ]
     },
+    "GOAL_CONFIGURED_AREA_BOSS": {
+      "category": "GOAL",
+      "label": "Defeat Configured Area Boss",
+      "location_id": 3960011,
+      "tags": [
+        "Goal",
+        "MAP_RAINBOW_ROUTE"
+      ]
+    },
     "GOAL_DARK_MIND": {
       "category": "GOAL",
       "label": "Defeat Dark Mind",

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -7,6 +7,7 @@
   "ability_randomization_no_ability_weight": 55,
   "ability_randomization_passive_enemies": false,
   "ability_randomization_statues": false,
+  "configured_area_boss": 7,
   "death_link": true,
   "enable_traps": false,
   "enemy_copy_ability_policy": {
@@ -74,6 +75,7 @@
     "Wheel"
   ],
   "goal": 0,
+  "goal_configured_area_boss_key": "BOSS_DEFEAT_3",
   "goal_hidden_area_boss_key": null,
   "locations": {
     "AREA_VISIT_1_RAINBOW_ROUTE": {

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -2470,6 +2470,66 @@ async def test_goal_any_area_boss_does_not_trigger_without_acknowledged_boss_che
 
 
 @pytest.mark.asyncio
+async def test_goal_configured_area_boss_server_exposed_goal_reports_location_then_goal_status(mock_bizhawk_context):
+    """Configured area-boss goal should wait for goal-location acknowledgement before sending CLIENT_GOAL."""
+    from NetUtils import ClientStatus
+
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    configured_goal_key = "BOSS_DEFEAT_3"
+    configured_goal_id = data.locations["GOAL_CONFIGURED_AREA_BOSS"].location_id
+
+    mock_bizhawk_context.slot_data["goal"] = 2
+    mock_bizhawk_context.slot_data["goal_configured_area_boss_key"] = configured_goal_key
+    mock_bizhawk_context.checked_locations = set()
+    mock_bizhawk_context.server_locations = {configured_goal_id}
+    mock_bizhawk_context.finished_game = False
+
+    client._native_goal_signal_seen = True
+
+    await client._maybe_report_goal(mock_bizhawk_context)
+
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [configured_goal_id]}
+    ])
+
+    mock_bizhawk_context.send_msgs.reset_mock()
+    mock_bizhawk_context.checked_locations.add(configured_goal_id)
+
+    await client._maybe_report_goal(mock_bizhawk_context)
+
+    mock_bizhawk_context.send_msgs.assert_awaited_once_with([
+        {"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}
+    ])
+    assert mock_bizhawk_context.finished_game is True
+    assert client._goal_reported is True
+
+
+@pytest.mark.asyncio
+async def test_goal_configured_area_boss_does_not_trigger_for_non_target_boss(mock_bizhawk_context):
+    """Configured area-boss goal should ignore non-target boss defeats."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    configured_goal_key = "BOSS_DEFEAT_3"
+    non_target_key = "BOSS_DEFEAT_1"
+    configured_goal_id = data.locations["GOAL_CONFIGURED_AREA_BOSS"].location_id
+
+    mock_bizhawk_context.slot_data["goal"] = 2
+    mock_bizhawk_context.slot_data["goal_configured_area_boss_key"] = configured_goal_key
+    mock_bizhawk_context.checked_locations = {data.locations[non_target_key].location_id}
+    mock_bizhawk_context.server_locations = {configured_goal_id}
+    mock_bizhawk_context.finished_game = False
+
+    await client._maybe_report_goal(mock_bizhawk_context)
+
+    mock_bizhawk_context.send_msgs.assert_not_awaited()
+    assert mock_bizhawk_context.finished_game is False
+    assert client._goal_reported is False
+
+
+@pytest.mark.asyncio
 async def test_goal_hidden_random_area_boss_server_exposed_goal_reports_location_then_goal_status(mock_bizhawk_context):
     """Hidden random boss goal should wait for goal-location acknowledgement before sending CLIENT_GOAL."""
     from NetUtils import ClientStatus
@@ -2480,7 +2540,7 @@ async def test_goal_hidden_random_area_boss_server_exposed_goal_reports_location
     hidden_goal_key = "BOSS_DEFEAT_3"
     hidden_goal_id = data.locations["GOAL_HIDDEN_AREA_BOSS"].location_id
 
-    mock_bizhawk_context.slot_data["goal"] = 2
+    mock_bizhawk_context.slot_data["goal"] = 3
     mock_bizhawk_context.slot_data["goal_hidden_area_boss_key"] = hidden_goal_key
     mock_bizhawk_context.checked_locations = set()
     mock_bizhawk_context.server_locations = {hidden_goal_id}
@@ -2516,7 +2576,7 @@ async def test_goal_hidden_random_area_boss_does_not_trigger_for_non_target_boss
     non_target_key = "BOSS_DEFEAT_1"
     hidden_goal_id = data.locations["GOAL_HIDDEN_AREA_BOSS"].location_id
 
-    mock_bizhawk_context.slot_data["goal"] = 2
+    mock_bizhawk_context.slot_data["goal"] = 3
     mock_bizhawk_context.slot_data["goal_hidden_area_boss_key"] = hidden_goal_key
     mock_bizhawk_context.checked_locations = {data.locations[non_target_key].location_id}
     mock_bizhawk_context.server_locations = {hidden_goal_id}

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -20,6 +20,7 @@ from ..rules import (
 @dataclass
 class _FakeOptions:
     goal_value: int
+    configured_area_boss_value: int = 7
 
     @property
     def goal(self):
@@ -28,6 +29,14 @@ class _FakeOptions:
                 self.value = value
 
         return _GoalValue(self.goal_value)
+
+    @property
+    def configured_area_boss(self):
+        class _ConfiguredAreaBossValue:
+            def __init__(self, value: int):
+                self.value = value
+
+        return _ConfiguredAreaBossValue(self.configured_area_boss_value)
 
 
 class _FakeEntrance:
@@ -131,6 +140,17 @@ def test_hidden_random_area_boss_goal_key_resolves_deterministically_from_seed()
 def test_hidden_random_area_boss_goal_requires_selected_location() -> None:
     world = _FakeWorld(Goal.option_defeat_random_hidden_area_boss)
     world._resolved_hidden_area_boss_goal_key = "BOSS_DEFEAT_3"
+    set_rules(world)
+
+    completion_fn = _get_completion_fn(world)
+    assert not completion_fn(_FakeState())
+    assert not completion_fn(_FakeState(reachable_locations={"Mustard Mountain - Boss Defeat"}))
+    assert completion_fn(_FakeState(reachable_locations={"Candy Constellation - Boss Defeat"}))
+
+
+def test_configured_area_boss_goal_requires_selected_location() -> None:
+    world = _FakeWorld(Goal.option_defeat_configured_area_boss)
+    world._resolved_configured_area_boss_goal_key = "BOSS_DEFEAT_3"
     set_rules(world)
 
     completion_fn = _get_completion_fn(world)

--- a/worlds/kirbyam/test/test_slot_data_contract.py
+++ b/worlds/kirbyam/test/test_slot_data_contract.py
@@ -37,6 +37,7 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
     options = Mock()
     options.as_dict.return_value = {
         "goal": 0,
+        "configured_area_boss": 7,
         "shards": 2,
         "start_with_all_maps": False,
         "starting_kirby_color": 7,
@@ -59,6 +60,7 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
     world.options = options
     world._resolved_starting_kirby_color_id = 7
     world._resolved_starting_kirby_color_name = "Sapphire"
+    world._resolved_configured_area_boss_goal_key = "BOSS_DEFEAT_3"
     world._enemy_copy_ability_policy = {
         "mode": "shuffled",
         "allowed_abilities": ["Sword", "Beam", "Burning"],
@@ -101,10 +103,19 @@ def test_starting_kirby_color_contract_fields_present_with_expected_shapes() -> 
     assert isinstance(slot_data["starting_kirby_color_name"], str)
     assert slot_data["starting_kirby_color_name"]
 
+    assert "goal_configured_area_boss_key" in slot_data
+    assert slot_data["goal_configured_area_boss_key"] is None or isinstance(
+        slot_data["goal_configured_area_boss_key"],
+        str,
+    )
+
     assert isinstance(slot_data["ability_gating"], bool)
 
     assert "goal_hidden_area_boss_key" in slot_data
-    assert slot_data["goal_hidden_area_boss_key"] is None or isinstance(slot_data["goal_hidden_area_boss_key"], str)
+    assert slot_data["goal_hidden_area_boss_key"] is None or isinstance(
+        slot_data["goal_hidden_area_boss_key"],
+        str,
+    )
 
 
 def test_tracker_surface_contract_fields_present_with_expected_shapes() -> None:

--- a/worlds/kirbyam/test/test_slot_data_contract.py
+++ b/worlds/kirbyam/test/test_slot_data_contract.py
@@ -73,7 +73,30 @@ def _emit_slot_data_for_contract_test() -> dict[str, object]:
         "ability_randomization_statues": False,
     }
 
-    return KirbyAmWorld.fill_slot_data(world)
+    slot_data = KirbyAmWorld.fill_slot_data(world)
+    options.as_dict.assert_called_once_with(
+        "goal",
+        "configured_area_boss",
+        "shards",
+        "start_with_all_maps",
+        "starting_kirby_color",
+        "no_extra_lives",
+        "ability_gating",
+        "enable_traps",
+        "trap_fill_percentage",
+        "one_hit_mode",
+        "death_link",
+        "ability_randomization_mode",
+        "ability_randomization_boss_spawns",
+        "ability_randomization_minibosses",
+        "ability_randomization_minny",
+        "ability_randomization_passive_enemies",
+        "ability_randomization_no_ability_weight",
+        "ability_randomization_statues",
+        "room_sanity",
+        toggles_as_bools=True,
+    )
+    return slot_data
 
 
 def test_protocol_slot_data_keys_match_emitted_slot_data_keys() -> None:

--- a/worlds/kirbyam/test/test_snapshot_outputs.py
+++ b/worlds/kirbyam/test/test_snapshot_outputs.py
@@ -62,8 +62,10 @@ def _build_representative_slot_data() -> dict[str, object]:
     world = KirbyAmWorld.__new__(KirbyAmWorld)
 
     options = Mock()
+    options.configured_area_boss = Mock(value=7, current_key="master_hand_crazy_hand_pair")
     options.as_dict.return_value = {
         "goal": 0,
+        "configured_area_boss": 7,
         "shards": 2,
         "no_extra_lives": False,
         "ability_gating": True,

--- a/worlds/kirbyam/test/test_template_options.py
+++ b/worlds/kirbyam/test/test_template_options.py
@@ -27,6 +27,7 @@ def test_kirbyam_template_surface_options_visibility() -> None:
             requires_game_version = data["requires"]["game"][KirbyAmWorld.game]
             game_block = data["Kirby & The Amazing Mirror"]
             goal_weights = game_block["goal"]
+            configured_boss_weights = game_block["configured_area_boss"]
             shard_weights = game_block["shards"]
             ability_weights = game_block["ability_randomization_mode"]
             assert "starting_kirby_color" in game_block, (
@@ -35,8 +36,12 @@ def test_kirbyam_template_surface_options_visibility() -> None:
             color_weights = game_block["starting_kirby_color"]
 
             assert "dark_mind" in goal_weights
+            assert "defeat_configured_area_boss" in goal_weights
             assert "100" not in goal_weights
             assert "debug" not in goal_weights
+
+            assert "master_hand_crazy_hand_pair" in configured_boss_weights
+            assert "king_golem" in configured_boss_weights
 
             assert "vanilla" in shard_weights
             assert "completely_random" in shard_weights
@@ -49,6 +54,7 @@ def test_kirbyam_template_surface_options_visibility() -> None:
             assert "ability_randomization_no_ability_weight" in game_block
             assert "ability_randomization_statues" in game_block
             assert "starting_kirby_color" in game_block
+            assert "configured_area_boss" in game_block
             assert "pink" in color_weights
             assert "random_color" in color_weights
 


### PR DESCRIPTION
Implements a new goal mode that defeats a user-selected area boss.

Summary:
- Adds `defeat_configured_area_boss` plus the `configured_area_boss` selector.
- Defaults the configured target to the Master Hand + Crazy Hand pair.
- Wires slot data, client goal reporting, and rules validation for the new mode.
- Updates protocol/docs and adds focused tests.

Validation:
- `python -m pytest worlds/kirbyam/test/test_rules.py worlds/kirbyam/test/test_client.py worlds/kirbyam/test/test_slot_data_contract.py worlds/kirbyam/test/test_template_options.py`

Closes #207 