### PR TITLE
Fix DeathLink-triggered check bursts during dead-state frames

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -18,6 +18,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### Bug Fixes
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
+- Prevented large false LocationChecks bursts after death transitions (including DeathLink deaths) by treating dead-state frames as non-gameplay for polling/writes and de-duping repeated pause popups while deferred (Issue #864).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -18,7 +18,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### Bug Fixes
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
-- Prevent false LocationChecks after death by deferring polling while HP =< 0 (Issue #864).
+- Prevent false LocationChecks after death by deferring polling while HP <= 0 (Issue #864).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -18,7 +18,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### Bug Fixes
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
-- Prevented false LocationChecks after death by deferring polling while HP =< 0 (Issue #864).
+- Prevent false LocationChecks after death by deferring polling while HP =< 0 (Issue #864).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -18,7 +18,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 ### Bug Fixes
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
-- Prevented large false LocationChecks bursts after death transitions (including DeathLink deaths) by treating dead-state frames as non-gameplay for polling/writes and de-duping repeated pause popups while deferred (Issue #864).
+- Prevented false LocationChecks after death by deferring polling while HP =< 0 (Issue #864).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -317,6 +317,11 @@ When runtime gate classifies non-gameplay:
 - Continue mailbox ACK/recovery handling for already-pending deliveries.
 - Continue goal polling (goal signal can occur in post-clear non-gameplay states).
 
+Runtime gate classification details:
+- `ai_kirby_state_native` below normal gameplay thresholds is non-gameplay (tutorial/menu, cutscene, and goal-clear phases).
+- Title-screen demo playback (`demo_playback_flags_native`) is non-gameplay even when AI state reports normal gameplay.
+- `kirby_hp_native <= 0` is treated as non-gameplay to avoid transient dead-state check bursts (including DeathLink-triggered defeats).
+
 Issue #223 status note:
 - In-game unsafe delivery windows (major boss, miniboss, cannon travel, warp-star travel) are not yet part of the enforced protocol contract.
 - Current client behavior is research-first: only observational candidate probing is allowed until stable native signals or hook points are verified.

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -318,7 +318,8 @@ When runtime gate classifies non-gameplay:
 - Continue goal polling (goal signal can occur in post-clear non-gameplay states).
 
 Runtime gate classification details:
-- `ai_kirby_state_native` below normal gameplay thresholds is non-gameplay (tutorial/menu, cutscene, and goal-clear phases).
+- `ai_kirby_state_native` below normal gameplay thresholds is non-gameplay (tutorial/menu and cutscene phases).
+- Goal-clear AI states (`ai_kirby_state_native in {9999, 10000}`) are non-gameplay.
 - Title-screen demo playback (`demo_playback_flags_native`) is non-gameplay even when AI state reports normal gameplay.
 - `kirby_hp_native <= 0` is treated as non-gameplay to avoid transient dead-state check bursts (including DeathLink-triggered defeats).
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1553,6 +1553,7 @@ class KirbyAmClient(BizHawkClient):
                 ai_state=ai_state,
             )
             if not gameplay_active:
+                was_deferred = self._last_runtime_gate_reason is not None
                 if self._last_runtime_gate_reason != defer_reason:
                     self._log_verbose(
                         "info",
@@ -1560,8 +1561,9 @@ class KirbyAmClient(BizHawkClient):
                         defer_reason,
                         ai_state if ai_state is not None else "unavailable",
                     )
-                    await self._display_client_message(ctx, "Item sending paused by game state")
                     self._last_runtime_gate_reason = defer_reason
+                if not was_deferred:
+                    await self._display_client_message(ctx, "Item sending paused by game state")
 
                 # Preserve mailbox ACK handling while deferring new writes.
                 await self._deliver_items(ctx, allow_new_writes=False)
@@ -2205,6 +2207,9 @@ class KirbyAmClient(BizHawkClient):
         reads: list[tuple[int, int, str]] = [(ai_state_addr, _AI_STATE_ADDR_WIDTH, "System Bus")]
         if demo_flags_addr is not None:
             reads.append((demo_flags_addr, _DEMO_PLAYBACK_FLAGS_WIDTH, "System Bus"))
+        kirby_hp_addr = self._native_addr(_KIRBY_HP_ADDR_KEY)
+        if kirby_hp_addr is not None:
+            reads.append((kirby_hp_addr, _KIRBY_HP_READ_WIDTH, "System Bus"))
         heartbeat_addr = self._transport_addr("hook_heartbeat")
         if self._debug_logging_enabled and heartbeat_addr is not None:
             reads.append((heartbeat_addr, 4, "System Bus"))
@@ -2218,6 +2223,11 @@ class KirbyAmClient(BizHawkClient):
             demo_flags = self._u32_le(raw_values[next_read_index])
             next_read_index += 1
 
+        current_hp: int | None = None
+        if kirby_hp_addr is not None and len(raw_values) > next_read_index:
+            current_hp = self._s8(raw_values[next_read_index])
+            next_read_index += 1
+
         heartbeat_counter: int | None = None
         if self._debug_logging_enabled and heartbeat_addr is not None and len(raw_values) > next_read_index:
             heartbeat_counter = self._u32_le(raw_values[next_read_index])
@@ -2225,7 +2235,10 @@ class KirbyAmClient(BizHawkClient):
         reason: str
         gameplay_active: bool
 
-        if ai_state < _AI_STATE_CUTSCENE_THRESHOLD:
+        if current_hp is not None and current_hp <= 0:
+            reason = "non_gameplay_kirby_dead"
+            gameplay_active = False
+        elif ai_state < _AI_STATE_CUTSCENE_THRESHOLD:
             reason = "non_gameplay_tutorial_or_menu"
             gameplay_active = False
         elif ai_state < _AI_STATE_NORMAL:

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -3822,16 +3822,19 @@ async def test_runtime_gameplay_state_logs_ai_and_demo_changes_with_heartbeat(mo
             [
                 (100).to_bytes(4, 'little'),
                 (0).to_bytes(4, 'little'),
+                (10).to_bytes(1, 'little'),
                 (7).to_bytes(4, 'little'),
             ],
             [
                 (300).to_bytes(4, 'little'),
                 (0).to_bytes(4, 'little'),
+                (10).to_bytes(1, 'little'),
                 (8).to_bytes(4, 'little'),
             ],
             [
                 (300).to_bytes(4, 'little'),
                 (0x10).to_bytes(4, 'little'),
+                (10).to_bytes(1, 'little'),
                 (9).to_bytes(4, 'little'),
             ],
         ]

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -4478,6 +4478,29 @@ async def test_runtime_gameplay_state_non_gameplay_on_goal_clear_state(mock_bizh
 
 
 @pytest.mark.asyncio
+async def test_runtime_gameplay_state_non_gameplay_when_kirby_dead(mock_bizhawk_context):
+    """Kirby HP <= 0 should defer gameplay polling even if AI state is normal."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    with patch.dict(data.native_ram_addresses, {
+        "ai_kirby_state_native": 0x0203AD2C,
+        "kirby_hp_native": 0x02020FE0,
+    }, clear=False), patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read:
+        mock_read.return_value = [
+            (300).to_bytes(4, 'little'),
+            (0).to_bytes(4, 'little'),
+            (0).to_bytes(1, 'little'),
+        ]
+
+        active, reason, ai_state = await client._runtime_gameplay_state(mock_bizhawk_context)
+
+    assert active is False
+    assert reason == "non_gameplay_kirby_dead"
+    assert ai_state == 300
+
+
+@pytest.mark.asyncio
 async def test_runtime_gameplay_state_fail_open_on_unknown_post_normal_state(mock_bizhawk_context):
     """Unknown post-300 AI states should fail open so item delivery is not blocked."""
     client = KirbyAmClient()
@@ -4582,6 +4605,35 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
 
     mock_display.assert_any_await(mock_bizhawk_context.bizhawk_ctx, "Item sending paused by game state")
     mock_display.assert_any_await(mock_bizhawk_context.bizhawk_ctx, "Item sending resumed")
+
+
+@pytest.mark.asyncio
+async def test_game_watcher_dedupes_pause_popup_while_non_gameplay_reason_changes(mock_bizhawk_context):
+    """Pause popup should emit once while deferred, even if defer reason changes."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    with ExitStack() as stack:
+        mock_gate = stack.enter_context(
+            patch.object(client, '_runtime_gameplay_state', new_callable=AsyncMock)
+        )
+        stack.enter_context(patch.object(client, '_load_persistent_state', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_log_boss_shard_debug_window', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_deliver_items', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_maybe_report_goal', new_callable=AsyncMock))
+        mock_display = stack.enter_context(
+            patch('worlds.kirbyam.client.bizhawk.display_message', new_callable=AsyncMock)
+        )
+
+        mock_gate.side_effect = [
+            (False, "non_gameplay_cutscene", 200),
+            (False, "non_gameplay_kirby_dead", 300),
+        ]
+
+        await client.game_watcher(mock_bizhawk_context)
+        await client.game_watcher(mock_bizhawk_context)
+
+    mock_display.assert_awaited_once_with(mock_bizhawk_context.bizhawk_ctx, "Item sending paused by game state")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- treat kirby_hp_native <= 0 as a non-gameplay watcher gate to suppress location polling/check sends during death transitions
- dedupe pause popups so reason churn while already deferred does not spam UI updates
- add regression tests for dead-state gate behavior and popup dedupe
- update protocol/changelog notes for the new runtime guard

## Testing
- python -m pytest worlds/kirbyam/test/test_client.py -k "runtime_gameplay_state_non_gameplay_when_kirby_dead or dedupes_pause_popup_while_non_gameplay_reason_changes or defers_polling_and_new_writes_when_non_gameplay or incoming_death_link_suppresses_echo_send or apply_pending_death_link_writes_zero_hp"

Closes #864
Closes #860 
