### PR TITLE
Fix statue completely_random fallback drift by tightening runtime config revalidation

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -15,10 +15,14 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Added a new goal mode: `defeat_configured_area_boss` completes the seed after a specific area-boss is defeated (Issue #207).
   - Which area boss is used is determined by the new `configured_area_boss` option. It defaults to Master Hand and Crazy Hand.
 
-### Bug Fixes
+### Improvements
 
 - Self-send item popups in BizHawk are now collapsed to one line (`You found your <item>.`) instead of separate send and receive popups (Issue #848).
+
+### Bug Fixes
+
 - Prevent false LocationChecks after death by deferring polling while HP <= 0 (Issue #864).
+- When `ability_randomization_mode` was `completely_random` and `ability_randomization_statues` was enabled, statue abilities were just shuffled, not random (Issue #841).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -78,7 +78,9 @@ _AREA_REGION_TOKEN_TO_AREA_ID: dict[str, int] = {
 _STARTING_KIRBY_COLOR_MIN = 0
 _STARTING_KIRBY_COLOR_MAX = 13
 _STARTING_KIRBY_COLOR_REVALIDATE_TICKS = 4
-_ABILITY_RUNTIME_CONFIG_REVALIDATE_TICKS = 4
+# Revalidate every watcher tick so transport resets cannot leave a stale
+# completely-random config window where statue pickups fall back to static table writes.
+_ABILITY_RUNTIME_CONFIG_REVALIDATE_TICKS = 1
 _CHALLENGE_RUNTIME_CONFIG_REVALIDATE_TICKS = 4
 _OPTIONAL_UNSAFE_DELIVERY_COUNTERS = (
     ("shadow_kirby_encounters_native", "shadow_kirby_encounters"),
@@ -1781,6 +1783,10 @@ class KirbyAmClient(BizHawkClient):
                 and self._u32_le(unlock_raw) == (unlocked_mask & 0xFFFFFFFF)
             ):
                 return
+            self._log_verbose(
+                "info",
+                "KirbyAM: runtime ability config drift detected; rewriting mailbox config",
+            )
 
         self._ability_runtime_config_revalidate_counter = 0
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -5292,6 +5292,58 @@ async def test_poll_enemy_ability_reroll_events_resolves_boxy_spawned_object(moc
 
 
 @pytest.mark.asyncio
+async def test_sync_enemy_copy_ability_runtime_config_revalidates_each_tick_for_unchanged_signature(mock_bizhawk_context):
+    """Unchanged signatures should still be read-validated each watcher tick."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    policy = {
+        "mode": 2,
+        "seed": 0x0000000100000002,
+        "ability_randomization_no_ability_weight": 55,
+        "allowed_abilities": [],
+    }
+    mock_bizhawk_context.slot_data = {"enemy_copy_ability_policy": policy, "ability_gating": True}
+
+    mode = 2
+    seed_lo = 2
+    seed_hi = 1
+    no_ability_weight = 55
+    allowed_mask = 0
+    ability_gating_enabled = True
+    gated_mask = 0
+    unlocked_mask = 0
+    client._last_ability_runtime_config_signature = (
+        mode,
+        seed_lo,
+        seed_hi,
+        no_ability_weight,
+        allowed_mask,
+        ability_gating_enabled,
+        gated_mask,
+        unlocked_mask,
+    )
+    client._ability_runtime_config_revalidate_counter = 0
+
+    with patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        mock_read.return_value = [
+            (mode).to_bytes(4, 'little'),
+            (seed_lo).to_bytes(4, 'little'),
+            (seed_hi).to_bytes(4, 'little'),
+            (no_ability_weight).to_bytes(4, 'little'),
+            (allowed_mask).to_bytes(4, 'little'),
+            (gated_mask).to_bytes(4, 'little'),
+            (unlocked_mask).to_bytes(4, 'little'),
+        ]
+
+        await client._sync_enemy_copy_ability_runtime_config(mock_bizhawk_context)
+
+    mock_read.assert_awaited_once()
+    mock_write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_sync_enemy_copy_ability_runtime_config_rewrites_when_revalidation_detects_mailbox_drift(mock_bizhawk_context):
     """When signature is unchanged, periodic read-back should still rewrite drifted mailbox state."""
     client = KirbyAmClient()


### PR DESCRIPTION
## Summary
- tighten runtime ability-config revalidation cadence so mailbox drift/reset is detected on every watcher tick
- rewrite drifted runtime ability mailbox config immediately, with file-only diagnostic logging
- add regression coverage ensuring unchanged signatures are still read-validated each tick

## Why
Issue #841 reports statue behavior in completely_random appearing type-shuffled. A stale runtime config window can temporarily fall back to static table behavior; this change minimizes that window by revalidating every tick and rewriting on drift.

## Testing
- python -m pytest worlds/kirbyam/test/test_client.py -k "sync_enemy_copy_ability_runtime_config"

Closes #841