### PR TITLE
Add 4 lever location checks (Issue #850)

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -14,6 +14,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Ability gating is now available and under the `Make the game harder` option group. It defaults to be "on". A preset list of abilities is available at the beginning of the game (Beam, Burning, Mini, Stone, and Wheel). This list should be the bare minimum you need to complete the game and get all the currently supported locations. All other abilities are gated by custom AP items (for example, "Sword Ability") (Issues #855, #819).
 - Added a new goal mode: `defeat_configured_area_boss` completes the seed after a specific area-boss is defeated (Issue #207).
   - Which area boss is used is determined by the new `configured_area_boss` option. It defaults to Master Hand and Crazy Hand.
+- Added four new lever location checks sourced from native lever bits: Moonlight Mansion 2-11, Olive Ocean 6-13, Carrot Castle 5-12, and Radish Ruins 8-12 (Issue #850).
 - Added the world map big chest in the tutorial rooms as an AP location check (Issue #845). We plan for the world map as an item can follow later.
   - Because of how we detect the game state, the check will only send AFTER the tutorial is completed and you enter Central Circle for the first time.
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -91,6 +91,7 @@ EWRAM Layout (0x02000000 - 0x02040000):
 | 0x02038970 | 1B | KIRBY_SHARD_FLAGS       | Native mirror shard bitfield (bits 0-7) |
 | 0x0203897C | 4B | big_chest_bitfield_native | gTreasures.bigChestField; bit N = area ID N (enum AreaId): bit 1=Rainbow Route, 2=Moonlight Mansion, 3=Cabbage Cavern, 4=Mustard Mountain, 5=Carrot Castle, 6=Olive Ocean, 7=Peppermint Palace, 8=Radish Ruins, 9=Candy Constellation. This is the native map-ownership field. AP major-chest checks use `major_chest_flags` in the transport block, and the BizHawk client may reassert AP-owned map bits here from `start_with_all_maps` plus confirmed delivered map items to recover from reconnect/save-state drift. |
 | 0x02038960 - 0x02038969 | 10B | other_chest_flags_native | Native small-chest/switch bitfield block. Unique MINOR_CHEST AP checks still use this bitfield as a resend/fallback signal, while report-only ambiguous minor chest locations use `minor_chest_event_ring` for exact disambiguation. |
+| 0x02038962 / 0x02038968 / 0x02038969 | 1B each | lever_*_flag_native | Native lever bits for AP lever location checks (Issue #850): Moonlight lever uses `0x02038962` bit2, Olive uses `0x02038968` bit1, Carrot uses `0x02038969` bit5, and Radish uses `0x02038969` bit2. |
 | 0x02028C14+ |  -  | Boss/Mirror table       | Native location flags (TBD - not yet mapped). The BizHawk client may probe rising edges here for diagnostics, but boss-defeat AP checks are transport-authoritative via `boss_defeat_flags`. |
 | 0x02028CA0 | 576B | gVisitedDoors (`room_visit_flags_native`) | Native room-visit array (`u16[0x120]`); bit 15 marks visited state by `doorsIdx` |
 | 0x02023B28 | 2B | current_room_native | Current native room ID (`gCurLevelInfo[0].currentRoom`) used for room-entry diagnostics |
@@ -197,6 +198,7 @@ All location IDs use **BASE_OFFSET + 100_000** as the auto-assignment start (= 3
 | VITALITY_CHEST_CANDY_CONSTELLATION | 3960303 | Candy Constellation 9-8 vitality big chest (transport vitality bit 3) |
 | SOUND_PLAYER_CHEST | 3960304 | Candy Constellation Sound Player chest (transport sound_player_chest bit 0) |
 | HUB_SWITCH_* | 3960400 - 3960414 | Hub big-switch checks mapped to `hub_switch_flags` bits 0..14 (bit 0 = Peppermint West, bit 11 = Moonlight; others sequential) |
+| LEVER_* | 3960415 - 3960418 | Lever checks sourced from native bits (`0x02038962` bit2 Moonlight 2-11, `0x02038968` bit1 Olive 6-13, `0x02038969` bit5 Carrot 5-12, `0x02038969` bit2 Radish 8-12) |
 | AREA_VISIT_* | 3960451 - 3960459 | First-visit checks for gameplay areas 1..9 (Rainbow Route through Candy Constellation), derived from first visited room per area via native `gVisitedDoors` |
 | MINOR_CHEST_RAINBOW_ROUTE_1_39 | 3960500 | Rainbow Route 1-39 small chest (native other_chest_flags_native bit 1) |
 | MINOR_CHEST_RAINBOW_ROUTE_1_22 | 3960501 | Rainbow Route 1-22 small chest (native other_chest_flags_native bit 23) |

--- a/worlds/kirbyam/__init__.py
+++ b/worlds/kirbyam/__init__.py
@@ -565,6 +565,7 @@ class KirbyAmWorld(World):
             vitality_chest_locations: list[KirbyAmLocation] = []
             sound_player_chest_locations: list[KirbyAmLocation] = []
             hub_switch_locations: list[KirbyAmLocation] = []
+            lever_locations: list[KirbyAmLocation] = []
             minor_chest_locations: list[KirbyAmLocation] = []
             room_sanity_locations: list[KirbyAmLocation] = []
             area_visit_locations: list[KirbyAmLocation] = []
@@ -586,6 +587,8 @@ class KirbyAmWorld(World):
                     sound_player_chest_locations.append(loc)
                 elif loc_meta.category == LocationCategory.HUB_SWITCH:
                     hub_switch_locations.append(loc)
+                elif loc_meta.category == LocationCategory.LEVER:
+                    lever_locations.append(loc)
                 elif loc_meta.category == LocationCategory.MINOR_CHEST:
                     minor_chest_locations.append(loc)
                 elif loc_meta.category == LocationCategory.ROOM_SANITY:
@@ -598,6 +601,7 @@ class KirbyAmWorld(World):
             vitality_chest_locations.sort(key=lambda loc: loc.key or "")
             sound_player_chest_locations.sort(key=lambda loc: loc.key or "")
             hub_switch_locations.sort(key=lambda loc: loc.key or "")
+            lever_locations.sort(key=lambda loc: loc.key or "")
             minor_chest_locations.sort(key=lambda loc: loc.key or "")
             room_sanity_locations.sort(key=lambda loc: loc.key or "")
             area_visit_locations.sort(key=lambda loc: loc.key or "")
@@ -610,6 +614,7 @@ class KirbyAmWorld(World):
                 or vitality_chest_locations
                 or sound_player_chest_locations
                 or hub_switch_locations
+                or lever_locations
                 or minor_chest_locations
                 or room_sanity_locations
                 or area_visit_locations
@@ -674,6 +679,7 @@ class KirbyAmWorld(World):
                         + vitality_chest_locations
                         + sound_player_chest_locations
                         + hub_switch_locations
+                        + lever_locations
                         + minor_chest_locations
                         + room_sanity_locations
                         + area_visit_locations

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -77,6 +77,14 @@ _AREA_REGION_TOKEN_TO_AREA_ID: dict[str, int] = {
     "RADISH_RUINS": 8,
     "CANDY_CONSTELLATION": 9,
 }
+# Lever bit ordinals are interpreted as 1-based from Issue #850 input:
+# - "3rd bit" -> bit index 2, "2nd bit" -> bit index 1, "6th bit" -> bit index 5.
+_LEVER_LOCATION_NATIVE_SPECS: dict[str, tuple[str, int]] = {
+    "LEVER_MOONLIGHT_MANSION_2_11": ("lever_moonlight_flag_native", 2),
+    "LEVER_OLIVE_OCEAN_6_13": ("lever_olive_flag_native", 1),
+    "LEVER_CARROT_CASTLE_5_12": ("lever_carrot_flag_native", 5),
+    "LEVER_RADISH_RUINS_8_12": ("lever_radish_flag_native", 2),
+}
 _STARTING_KIRBY_COLOR_MIN = 0
 _STARTING_KIRBY_COLOR_MAX = 13
 _STARTING_KIRBY_COLOR_REVALIDATE_TICKS = 4
@@ -403,6 +411,26 @@ class KirbyAmClient(BizHawkClient):
             for location_id in location_ids
         }
 
+        # Lever native-byte bitfield checks (Issue #850).
+        self._lever_location_specs: list[tuple[int, str, int, str]] = []
+        for location_key, (addr_key, bit_index) in _LEVER_LOCATION_NATIVE_SPECS.items():
+            location = data.locations.get(location_key)
+            if location is None:
+                self._log_verbose(
+                    "warning",
+                    "KirbyAM: lever mapping references unknown location key '%s'",
+                    location_key,
+                )
+                continue
+            if location.location_id is None:
+                self._log_verbose(
+                    "warning",
+                    "KirbyAM: lever mapping location key '%s' has no location_id",
+                    location_key,
+                )
+                continue
+            self._lever_location_specs.append((location.location_id, addr_key, bit_index, location.label))
+
         # Room-sanity bitfield index (doorsIdx) -> location IDs.
         self._room_sanity_location_ids_by_bit = self._build_location_ids_by_bit(LocationCategory.ROOM_SANITY)
         self._room_sanity_bits_sorted: list[int] = sorted(self._room_sanity_location_ids_by_bit.keys())
@@ -437,6 +465,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_vitality_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_sound_player_chest_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._last_hub_switch_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
+        self._last_lever_poll_log: tuple[str, tuple[int, ...], tuple[int, ...]] | None = None
         self._hub_switch_baseline_mask: int | None = None
         self._hub_switch_session_initialized: bool = False
         self._hub_switch_stream_marker: object = None
@@ -661,6 +690,7 @@ class KirbyAmClient(BizHawkClient):
         self._last_vitality_chest_poll_log = None
         self._last_sound_player_chest_poll_log = None
         self._last_hub_switch_poll_log = None
+        self._last_lever_poll_log = None
         self._last_room_sanity_poll_log = None
         self._last_area_visit_poll_log = None
         self._last_boss_probe_snapshot = None
@@ -1665,6 +1695,9 @@ class KirbyAmClient(BizHawkClient):
 
             # Hub switch location polling via dedicated hub_switch_flags register
             await self._poll_hub_switch_locations(ctx)
+
+            # Lever location polling via native other_chest_flags bytes.
+            await self._poll_lever_locations(ctx)
 
             # Share one gVisitedDoors read for area-first-visit and room-sanity polling.
             self._cached_room_visit_flags_view = None
@@ -3026,6 +3059,80 @@ class KirbyAmClient(BizHawkClient):
                 self._last_hub_switch_poll_log = switch_log_state
         else:
             self._last_hub_switch_poll_log = None
+
+    async def _poll_lever_locations(self, ctx: KirbyAmBizHawkClientContext) -> None:
+        """
+        Read native lever bytes and map set bits to lever LocationChecks.
+
+        Lever checks are sourced from native state, not transport mailbox flags:
+        - 0x02038962 bit2: Moonlight lever
+        - 0x02038968 bit1: Olive lever
+        - 0x02038969 bit5: Carrot lever
+        - 0x02038969 bit2: Radish lever
+        """
+        if not self._lever_location_specs:
+            return
+
+        read_specs: list[tuple[int, int, str]] = []
+        address_keys_in_order: list[str] = []
+        for _location_id, address_key, _bit_index, _label in self._lever_location_specs:
+            if address_key in address_keys_in_order:
+                continue
+            native_addr = self._native_addr(address_key)
+            if native_addr is None:
+                continue
+            read_specs.append((native_addr, 1, "System Bus"))
+            address_keys_in_order.append(address_key)
+
+        if not read_specs:
+            return
+
+        raw_values = await bizhawk.read(ctx.bizhawk_ctx, read_specs)
+        if len(raw_values) != len(address_keys_in_order):
+            return
+
+        current_values_by_address_key: dict[str, int] = {
+            address_key: int.from_bytes(raw[:1], "little")
+            for address_key, raw in zip(address_keys_in_order, raw_values)
+        }
+
+        active_location_ids = self._active_location_id_set(ctx)
+        mapped_checked_locations: set[int] = set()
+        for location_id, address_key, bit_index, _label in self._lever_location_specs:
+            if active_location_ids is not None and location_id not in active_location_ids:
+                continue
+            current_value = current_values_by_address_key.get(address_key)
+            if current_value is None:
+                continue
+            if (current_value >> bit_index) & 1:
+                mapped_checked_locations.add(location_id)
+
+        missing_on_server = sorted(mapped_checked_locations - ctx.checked_locations)
+        already_acknowledged = sorted(mapped_checked_locations & ctx.checked_locations)
+        if missing_on_server:
+
+            lever_log_state = ("resend", tuple(missing_on_server), tuple(already_acknowledged))
+            if lever_log_state != self._last_lever_poll_log:
+                self._log_verbose(
+                    "info",
+                    "KirbyAM: resending lever LocationChecks missing on server (missing=%s, acked=%s)",
+                    missing_on_server,
+                    already_acknowledged,
+                )
+                self._last_lever_poll_log = lever_log_state
+
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": missing_on_server}])
+        elif mapped_checked_locations:
+            lever_log_state = ("dedupe", tuple(), tuple(already_acknowledged))
+            if lever_log_state != self._last_lever_poll_log:
+                self._log_verbose(
+                    "debug",
+                    "KirbyAM: dedupe suppressed lever LocationChecks (all RAM-derived checks already acknowledged: %s)",
+                    already_acknowledged,
+                )
+                self._last_lever_poll_log = lever_log_state
+        else:
+            self._last_lever_poll_log = None
 
     async def _poll_room_entry_logging(self, ctx: KirbyAmBizHawkClientContext) -> None:
         """

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -3074,26 +3074,33 @@ class KirbyAmClient(BizHawkClient):
             return
 
         read_specs: list[tuple[int, int, str]] = []
-        address_keys_in_order: list[str] = []
+        native_addrs_in_order: list[int] = []
+        native_addr_by_address_key: dict[str, int] = {}
         for _location_id, address_key, _bit_index, _label in self._lever_location_specs:
-            if address_key in address_keys_in_order:
-                continue
             native_addr = self._native_addr(address_key)
             if native_addr is None:
                 continue
+            native_addr_by_address_key[address_key] = native_addr
+            if native_addr in native_addrs_in_order:
+                continue
             read_specs.append((native_addr, 1, "System Bus"))
-            address_keys_in_order.append(address_key)
+            native_addrs_in_order.append(native_addr)
 
         if not read_specs:
             return
 
         raw_values = await bizhawk.read(ctx.bizhawk_ctx, read_specs)
-        if len(raw_values) != len(address_keys_in_order):
+        if len(raw_values) != len(native_addrs_in_order):
             return
 
+        current_values_by_native_addr: dict[int, int] = {
+            native_addr: int.from_bytes(raw[:1], "little")
+            for native_addr, raw in zip(native_addrs_in_order, raw_values)
+        }
         current_values_by_address_key: dict[str, int] = {
-            address_key: int.from_bytes(raw[:1], "little")
-            for address_key, raw in zip(address_keys_in_order, raw_values)
+            address_key: current_values_by_native_addr[native_addr]
+            for address_key, native_addr in native_addr_by_address_key.items()
+            if native_addr in current_values_by_native_addr
         }
 
         active_location_ids = self._active_location_id_set(ctx)

--- a/worlds/kirbyam/data.py
+++ b/worlds/kirbyam/data.py
@@ -193,6 +193,7 @@ class LocationCategory(IntEnum):
     HUB_SWITCH = 13
     MINOR_CHEST = 14
     AREA_VISIT = 15
+    LEVER = 16
 
 
 class ItemData(NamedTuple):

--- a/worlds/kirbyam/data/addresses.json
+++ b/worlds/kirbyam/data/addresses.json
@@ -43,6 +43,10 @@
     },
     "native": {
       "other_chest_flags_native": "0x02038960",
+      "lever_moonlight_flag_native": "0x02038962",
+      "lever_olive_flag_native": "0x02038968",
+      "lever_carrot_flag_native": "0x02038969",
+      "lever_radish_flag_native": "0x02038969",
       "shard_bitfield_native": "0x02038970",
       "spray_paint_bitfield_native": "0x02038974",
       "music_player_and_sheets_bitfield_native": "0x02038978",

--- a/worlds/kirbyam/data/locations.json
+++ b/worlds/kirbyam/data/locations.json
@@ -574,6 +574,50 @@
     "category": "HUB_SWITCH",
     "location_id": 3960414
   },
+  "LEVER_MOONLIGHT_MANSION_2_11": {
+    "label": "Moonlight Mansion 2-11 - Lever",
+    "parent_region": "REGION_MOONLIGHT_MANSION/ROOM_2_11",
+    "tags": [
+      "Lever",
+      "MAP_MOONLIGHT_MANSION"
+    ],
+    "bit_index": 0,
+    "category": "LEVER",
+    "location_id": 3960415
+  },
+  "LEVER_OLIVE_OCEAN_6_13": {
+    "label": "Olive Ocean 6-13 - Lever",
+    "parent_region": "REGION_OLIVE_OCEAN/ROOM_6_13",
+    "tags": [
+      "Lever",
+      "MAP_OLIVE_OCEAN"
+    ],
+    "bit_index": 1,
+    "category": "LEVER",
+    "location_id": 3960416
+  },
+  "LEVER_CARROT_CASTLE_5_12": {
+    "label": "Carrot Castle 5-12 - Lever",
+    "parent_region": "REGION_CARROT_CASTLE/ROOM_5_12",
+    "tags": [
+      "Lever",
+      "MAP_CARROT_CASTLE"
+    ],
+    "bit_index": 2,
+    "category": "LEVER",
+    "location_id": 3960417
+  },
+  "LEVER_RADISH_RUINS_8_12": {
+    "label": "Radish Ruins 8-12 - Lever",
+    "parent_region": "REGION_RADISH_RUINS/ROOM_8_12",
+    "tags": [
+      "Lever",
+      "MAP_RADISH_RUINS"
+    ],
+    "bit_index": 3,
+    "category": "LEVER",
+    "location_id": 3960418
+  },
   "MINOR_CHEST_SPRAY_PAINT_01": {
     "label": "Spray Paint #1",
     "parent_region": "REGION_RAINBOW_ROUTE/ROOM_1_CENTRAL_CIRCLE",

--- a/worlds/kirbyam/groups.py
+++ b/worlds/kirbyam/groups.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable, Mapping, Set as AbstractSet
-from typing import Dict, Set
 
 from .data import LocationCategory, data
 
@@ -44,6 +43,7 @@ _LOCATION_GROUP_MAPS: dict[str, set[str]] = {
 _LOCATION_CATEGORY_TO_GROUP_NAME = {
     LocationCategory.MAP_CHEST: "Major Chests",
     LocationCategory.HUB_SWITCH: "Hub Switches",
+    LocationCategory.LEVER: "Levers",
     LocationCategory.MINOR_CHEST: "Minor Chests",
     LocationCategory.AREA_VISIT: "Area First Visits",
 }

--- a/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
+++ b/worlds/kirbyam/test/data/snapshots/slot_data_representative.json
@@ -394,6 +394,42 @@
         "MAP_RAINBOW_ROUTE"
       ]
     },
+    "LEVER_CARROT_CASTLE_5_12": {
+      "category": "LEVER",
+      "label": "Carrot Castle 5-12 - Lever",
+      "location_id": 3960417,
+      "tags": [
+        "Lever",
+        "MAP_CARROT_CASTLE"
+      ]
+    },
+    "LEVER_MOONLIGHT_MANSION_2_11": {
+      "category": "LEVER",
+      "label": "Moonlight Mansion 2-11 - Lever",
+      "location_id": 3960415,
+      "tags": [
+        "Lever",
+        "MAP_MOONLIGHT_MANSION"
+      ]
+    },
+    "LEVER_OLIVE_OCEAN_6_13": {
+      "category": "LEVER",
+      "label": "Olive Ocean 6-13 - Lever",
+      "location_id": 3960416,
+      "tags": [
+        "Lever",
+        "MAP_OLIVE_OCEAN"
+      ]
+    },
+    "LEVER_RADISH_RUINS_8_12": {
+      "category": "LEVER",
+      "label": "Radish Ruins 8-12 - Lever",
+      "location_id": 3960418,
+      "tags": [
+        "Lever",
+        "MAP_RADISH_RUINS"
+      ]
+    },
     "MAJOR_CHEST_CABBAGE_CAVERN": {
       "category": "MAP_CHEST",
       "label": "Cabbage Cavern Map - Big Chest",

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -4835,6 +4835,7 @@ async def test_game_watcher_emits_runtime_gate_logs_file_only(mock_bizhawk_conte
         stack.enter_context(patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_poll_lever_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock))

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1256,6 +1256,10 @@ async def test_poll_lever_locations_sends_location_checks_for_set_bits(mock_bizh
 
         await client._poll_lever_locations(mock_bizhawk_context)
 
+    assert mock_read.await_count == 1
+    read_specs = mock_read.await_args.args[1]
+    assert read_specs.count((0x02038969, 1, "System Bus")) == 1
+
     mock_send.assert_awaited_once_with([
         {"cmd": "LocationChecks", "locations": [moonlight, olive, carrot, radish]}
     ])

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1251,8 +1251,8 @@ async def test_poll_lever_locations_sends_location_checks_for_set_bits(mock_bizh
     }, clear=False), \
          patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
          patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
-        # 1-based ordinal mapping: moonlight bit2, olive bit1, carrot bit5, radish bit2.
-        mock_read.return_value = [bytes([1 << 2]), bytes([1 << 1]), bytes([1 << 5]), bytes([1 << 2])]
+        # 1-based ordinal mapping: moonlight bit2, olive bit1, shared carrot/radish byte has bits5+2.
+        mock_read.return_value = [bytes([1 << 2]), bytes([1 << 1]), bytes([(1 << 5) | (1 << 2)])]
 
         await client._poll_lever_locations(mock_bizhawk_context)
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1232,6 +1232,73 @@ async def test_poll_sound_player_chest_skips_when_address_missing(mock_bizhawk_c
 
 
 @pytest.mark.asyncio
+async def test_poll_lever_locations_sends_location_checks_for_set_bits(mock_bizhawk_context):
+    """Set native lever bits should map to lever LocationChecks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    moonlight = data.locations["LEVER_MOONLIGHT_MANSION_2_11"].location_id
+    olive = data.locations["LEVER_OLIVE_OCEAN_6_13"].location_id
+    carrot = data.locations["LEVER_CARROT_CASTLE_5_12"].location_id
+    radish = data.locations["LEVER_RADISH_RUINS_8_12"].location_id
+    mock_bizhawk_context.checked_locations = set()
+
+    with patch.dict(data.native_ram_addresses, {
+        "lever_moonlight_flag_native": 0x02038962,
+        "lever_olive_flag_native": 0x02038968,
+        "lever_carrot_flag_native": 0x02038969,
+        "lever_radish_flag_native": 0x02038969,
+    }, clear=False), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        # 1-based ordinal mapping: moonlight bit2, olive bit1, carrot bit5, radish bit2.
+        mock_read.return_value = [bytes([1 << 2]), bytes([1 << 1]), bytes([1 << 5]), bytes([1 << 2])]
+
+        await client._poll_lever_locations(mock_bizhawk_context)
+
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [moonlight, olive, carrot, radish]}
+    ])
+
+
+@pytest.mark.asyncio
+async def test_poll_lever_locations_skips_when_addresses_missing(mock_bizhawk_context):
+    """Missing native lever addresses should no-op safely."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    native_without_levers = {
+        k: v
+        for k, v in data.native_ram_addresses.items()
+        if k not in {
+            "lever_moonlight_flag_native",
+            "lever_olive_flag_native",
+            "lever_carrot_flag_native",
+            "lever_radish_flag_native",
+        }
+    }
+    ram_without_levers = {
+        k: v
+        for k, v in data.ram_addresses.items()
+        if k not in {
+            "lever_moonlight_flag_native",
+            "lever_olive_flag_native",
+            "lever_carrot_flag_native",
+            "lever_radish_flag_native",
+        }
+    }
+
+    with patch.dict(data.native_ram_addresses, native_without_levers, clear=True), \
+         patch.dict(data.ram_addresses, ram_without_levers, clear=True), \
+         patch('worlds.kirbyam.client.bizhawk.read', new_callable=AsyncMock) as mock_read, \
+         patch.object(mock_bizhawk_context, 'send_msgs', new_callable=AsyncMock) as mock_send:
+        await client._poll_lever_locations(mock_bizhawk_context)
+
+    mock_read.assert_not_awaited()
+    mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_poll_hub_switch_sends_location_checks_for_set_bits(mock_bizhawk_context):
     """Set transport hub-switch bits after baseline should map to LocationChecks."""
     client = KirbyAmClient()
@@ -4223,6 +4290,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality, \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player, \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switch, \
+         patch.object(client, '_poll_lever_locations', new_callable=AsyncMock) as mock_poll_lever, \
          patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock) as mock_poll_area_visit, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe_boss, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
@@ -4243,6 +4311,7 @@ async def test_game_watcher_reloads_state_after_transport_recovery(mock_bizhawk_
     mock_poll_vitality.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_sound_player.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_hub_switch.assert_awaited_once_with(mock_bizhawk_context)
+    mock_poll_lever.assert_awaited_once_with(mock_bizhawk_context)
     mock_poll_area_visit.assert_awaited_once_with(mock_bizhawk_context)
     mock_probe_boss.assert_awaited_once_with(mock_bizhawk_context)
     mock_probe_unsafe.assert_awaited_once_with(mock_bizhawk_context)
@@ -4358,6 +4427,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
             patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock) as mock_poll_vitality_chests, \
             patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock) as mock_poll_sound_player_chests, \
                 patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock) as mock_poll_hub_switches, \
+                patch.object(client, '_poll_lever_locations', new_callable=AsyncMock) as mock_poll_levers, \
                 patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock) as mock_poll_area_visits, \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock) as mock_probe, \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock) as mock_probe_unsafe, \
@@ -4395,6 +4465,7 @@ async def test_game_watcher_reconnect_entry_resets_transient_state_once(mock_biz
         mock_poll_vitality_chests.assert_awaited_once()
         mock_poll_sound_player_chests.assert_awaited_once()
         mock_poll_hub_switches.assert_awaited_once()
+        mock_poll_levers.assert_awaited_once()
         mock_poll_area_visits.assert_awaited_once()
         mock_probe.assert_awaited_once()
         mock_probe_unsafe.assert_awaited_once()
@@ -4428,6 +4499,7 @@ async def test_game_watcher_reconnect_entry_emits_file_only_session_ready_log(mo
         stack.enter_context(patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_poll_lever_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock))
@@ -4668,6 +4740,7 @@ async def test_game_watcher_emits_pause_then_resume_popups_on_transition(mock_bi
         stack.enter_context(patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_poll_lever_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock))
@@ -4811,6 +4884,7 @@ async def test_game_watcher_syncs_death_link_enabled_from_slot_data(mock_bizhawk
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_lever_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \
@@ -4843,6 +4917,7 @@ async def test_game_watcher_death_link_sync_is_deduped_until_value_changes(mock_
          patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock), \
+         patch.object(client, '_poll_lever_locations', new_callable=AsyncMock), \
          patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock), \
          patch.object(client, '_probe_boss_defeat_candidates', new_callable=AsyncMock), \
          patch.object(client, '_probe_unsafe_delivery_candidates', new_callable=AsyncMock), \

--- a/worlds/kirbyam/test/test_data_normalization.py
+++ b/worlds/kirbyam/test/test_data_normalization.py
@@ -132,6 +132,25 @@ def test_generated_hub_switch_contract_compatibility_aliases_are_disjoint() -> N
             assert bit not in canonical_bits
 
 
+def test_all_lever_locations_have_expected_unique_mapping() -> None:
+    expected_lever_keys = {
+        "LEVER_MOONLIGHT_MANSION_2_11",
+        "LEVER_OLIVE_OCEAN_6_13",
+        "LEVER_CARROT_CASTLE_5_12",
+        "LEVER_RADISH_RUINS_8_12",
+    }
+
+    levers = {
+        key: location
+        for key, location in kirby_data.locations.items()
+        if key.startswith("LEVER_")
+    }
+
+    assert set(levers) == expected_lever_keys
+    assert all(location.category == LocationCategory.LEVER for location in levers.values())
+    assert {location.location_id for location in levers.values()} == set(range(3960415, 3960419))
+
+
 def test_all_goal_locations_are_explicitly_region_claimed() -> None:
     claimed_locations = {
         location_key

--- a/worlds/kirbyam/test/test_item_pool.py
+++ b/worlds/kirbyam/test/test_item_pool.py
@@ -562,6 +562,7 @@ def test_vanilla_shards_are_locked_to_boss_defeats() -> None:
     )
     _minor_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MINOR_CHEST)
     _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
+    _lever_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.LEVER)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
     _area_visit_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.AREA_VISIT)
     _expected_pool_size = (
@@ -570,6 +571,7 @@ def test_vanilla_shards_are_locked_to_boss_defeats() -> None:
         + _sound_player_chest_count
         + _minor_chest_count
         + _hub_switch_count
+        + _lever_count
         + _room_sanity_count
         + _area_visit_count
     )
@@ -595,6 +597,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
     )
     _minor_chest_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.MINOR_CHEST)
     _hub_switch_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.HUB_SWITCH)
+    _lever_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.LEVER)
     _room_sanity_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.ROOM_SANITY)
     _area_visit_count = sum(1 for m in data.locations.values() if m.category == LocationCategory.AREA_VISIT)
     _shard_item_count = len(KirbyAmWorld._SHARD_ITEM_LABEL_ORDER)
@@ -605,6 +608,7 @@ def test_completely_random_pool_contains_all_shards_but_bosses_are_unlocked() ->
         + _sound_player_chest_count
         + _minor_chest_count
         + _hub_switch_count
+        + _lever_count
         + _room_sanity_count
         + _area_visit_count
     )

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -141,6 +141,7 @@ async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_b
         stack.enter_context(patch.object(client, '_poll_vitality_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_sound_player_chest_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_hub_switch_locations', new_callable=AsyncMock))
+        stack.enter_context(patch.object(client, '_poll_lever_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_area_visit_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_room_sanity_locations', new_callable=AsyncMock))
         stack.enter_context(patch.object(client, '_poll_room_entry_logging', new_callable=AsyncMock))

--- a/worlds/kirbyam/test/test_reconnect_chaos.py
+++ b/worlds/kirbyam/test/test_reconnect_chaos.py
@@ -12,7 +12,9 @@ from ..data import data
 
 
 @pytest.mark.asyncio
-async def test_reconnect_chaos_boss_defeat_polling_resends_once_then_dedupes(mock_bizhawk_context):
+async def test_reconnect_chaos_boss_defeat_polling_resends_once_then_dedupes(
+    mock_bizhawk_context: Mock,
+) -> None:
     """Reconnect cycles should not duplicate boss-defeat LocationChecks after server acknowledgement."""
     client = KirbyAmClient()
     client.initialize_client()
@@ -38,7 +40,9 @@ async def test_reconnect_chaos_boss_defeat_polling_resends_once_then_dedupes(moc
 
 
 @pytest.mark.asyncio
-async def test_reconnect_chaos_item_delivery_resumes_without_duplicate_first_item(mock_bizhawk_context):
+async def test_reconnect_chaos_item_delivery_resumes_without_duplicate_first_item(
+    mock_bizhawk_context: Mock,
+) -> None:
     """Delivery should resume after reconnect without replaying already-pending first item."""
     client = KirbyAmClient()
     client.initialize_client()
@@ -113,7 +117,9 @@ async def test_reconnect_chaos_item_delivery_resumes_without_duplicate_first_ite
 
 
 @pytest.mark.asyncio
-async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(mock_bizhawk_context):
+async def test_reconnect_chaos_goal_reporting_is_idempotent_across_cycles(
+    mock_bizhawk_context: Mock,
+) -> None:
     """Addressless goal flow should send CLIENT_GOAL once, with no duplicate status on later reconnects."""
     client = KirbyAmClient()
     client.initialize_client()

--- a/worlds/kirbyam/test/test_rules.py
+++ b/worlds/kirbyam/test/test_rules.py
@@ -816,3 +816,32 @@ def test_hub_switch_locations_have_matching_big_switch_events() -> None:
         found_events.add(expected_event)
 
     assert found_events == set(expected_events_by_hub_switch.values())
+
+
+def test_lever_locations_have_matching_lever_events() -> None:
+    from ..data import load_json_data
+
+    rooms = load_json_data("regions/rooms.json")
+    locations = load_json_data("locations.json")
+
+    expected_events_by_lever_location = {
+        "LEVER_MOONLIGHT_MANSION_2_11": "Activate Lever - Moonlight Mansion 2-11",
+        "LEVER_CARROT_CASTLE_5_12": "Activate Lever - Carrot Castle 5-12",
+        "LEVER_OLIVE_OCEAN_6_13": "Activate Lever - Olive Ocean 6-13",
+        "LEVER_RADISH_RUINS_8_12": "Activate Lever - Radish Ruins 8-12",
+    }
+
+    for lever_key, expected_event in expected_events_by_lever_location.items():
+        location_meta = locations.get(lever_key)
+        assert isinstance(location_meta, dict), f"Missing location metadata for {lever_key}"
+
+        parent_region = str(location_meta.get("parent_region", ""))
+        assert parent_region in rooms, f"Missing room region for {lever_key}: {parent_region}"
+        room_data = rooms[parent_region]
+        assert isinstance(room_data, dict), f"Invalid room payload for {parent_region}"
+
+        events = room_data.get("events", [])
+        assert isinstance(events, list), f"Invalid events list for room {parent_region}"
+        event_set = {event for event in events if isinstance(event, str)}
+
+        assert expected_event in event_set

--- a/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
+++ b/worlds/kirbyam/tools/kirbyam_protocol_cheat_watch.wch
@@ -38,6 +38,10 @@ SystemID GBA
 02038960	d	h	0	System Bus	other_chest_flags_native[0:31] (native chest/switch state block)
 02038964	d	h	0	System Bus	other_chest_flags_native[32:63]
 02038968	w	h	0	System Bus	other_chest_flags_native[64:79]
+02038962	b	h	0	System Bus	lever_moonlight_flag_native (bit2 = Moonlight Mansion 2-11 lever)
+02038968	b	h	0	System Bus	lever_olive_flag_native (bit1 = Olive Ocean 6-13 lever)
+02038969	b	h	0	System Bus	lever_carrot_flag_native (bit5 = Carrot Castle 5-12 lever)
+02038969	b	h	0	System Bus	lever_radish_flag_native (bit2 = Radish Ruins 8-12 lever)
 02038970	b	b	0	System Bus	shard_bitfield_native (KIRBY_SHARD_FLAGS)
 02038974	d	b	0	System Bus	spray_paint_bitfield_native (gTreasures.sprayPaintField)
 02038978	d	b	0	System Bus	music_player_and_sheets_bitfield_native (gTreasures.musicPlayerAndSheetsField)


### PR DESCRIPTION
## Summary
- add a new LEVER location category and four AP locations for native in-world levers
- add native lever address keys and poll them via BizHawk watcher flow
- include lever locations in pool/group/data normalization and rule consistency checks
- document lever addresses and location range in protocol/watch files and changelog

## Testing
- ./.venv/Scripts/python -m pytest worlds/kirbyam/test/test_client.py -k "lever or hub_switch or reconnect_entry"
- ./.venv/Scripts/python -m pytest worlds/kirbyam/test/test_item_pool.py worlds/kirbyam/test/test_data_normalization.py worlds/kirbyam/test/test_rules.py worlds/kirbyam/test/test_slot_data_contract.py

Closes #850
