### PR TITLE
Issue #871: Shrink kirbyam.apworld packaging footprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ EnemizerCLI/
 /options.yaml
 /config.yaml
 /logs/
+worlds/kirbyam/save_states/
+worlds/kirbyam/kirby_ap_payload/patch_rom.log
+worlds/kirbyam/__pycache__/
+worlds/kirbyam/kirby_ap_payload/__pycache__/
+worlds/kirbyam/test/__pycache__/
 _persistent_storage.yaml
 mystery_result_*.yaml
 *-errors.txt

--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -32,6 +32,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Log files now report the `world_version` and all game options (Issue #861).
 - Added file-only telemetry diagnostics for ability statue grants when `ability_randomization_mode` is `shuffled` or `completely_random`, goal target resolution (one-time per session), runtime ability config rewrites (mask/seed snapshot on change), mailbox ACK timeout aggregates, and explicit statue ability-gate suppression reasons (PR #867).
 - Expand the allowed versions of requirements.txt (PR #881).
+- Reduce generated `kirbyam.apworld` size by excluding `worlds/kirbyam/save_states` and `worlds/kirbyam/kirby_ap_payload/patch_rom.log` from world packaging, and add explicit ignore entries for KirbyAM-local cache/log artifacts (Issue #871).
 
 ### Other
 

--- a/worlds/kirbyam/build.py
+++ b/worlds/kirbyam/build.py
@@ -181,6 +181,12 @@ def should_exclude(rel_posix: str) -> bool:
     if name in {".DS_Store", "Thumbs.db"}:
         return True
 
+    # Keep local tooling artifacts out of the shipped apworld.
+    if parts and parts[0] == "save_states":
+        return True
+    if rel_posix == "kirby_ap_payload/patch_rom.log":
+        return True
+
     return False
 
 

--- a/worlds/kirbyam/test/test_build_tooling_negative.py
+++ b/worlds/kirbyam/test/test_build_tooling_negative.py
@@ -335,3 +335,15 @@ def test_prepare_args_file_source_accepts_relative_rom_path_tmp(tmp_path: Path, 
     prepared = build_mod._prepare_args_for_patch(args, tmp_path)
     assert prepared.source_type == "file"
     assert prepared.rom is None
+
+
+def test_should_exclude_save_states_tree() -> None:
+    assert build_mod.should_exclude("save_states/1 - Rainbow Route/sample.State")
+
+
+def test_should_exclude_patch_rom_log() -> None:
+    assert build_mod.should_exclude("kirby_ap_payload/patch_rom.log")
+
+
+def test_should_not_exclude_regular_world_data_file() -> None:
+    assert not build_mod.should_exclude("data/locations.json")


### PR DESCRIPTION
## Summary\n- exclude worlds/kirbyam/save_states from kirbyam.apworld packaging\n- exclude worlds/kirbyam/kirby_ap_payload/patch_rom.log from kirbyam.apworld packaging\n- add explicit ignore rules for KirbyAM local cache/log artifacts and add regression coverage for the new build exclusions\n\n## Testing\n- ./.venv/Scripts/python.exe -m pytest worlds/kirbyam/test/test_build_tooling_negative.py\n\nCloses #871