### PR TITLE
KirbyAM: fix hub-switch resend suppression with existing server checks

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -27,6 +27,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 - Prevent false LocationChecks after death by deferring polling while HP <= 0 (Issue #864).
 - When `ability_randomization_mode` was `completely_random` and `ability_randomization_statues` was enabled, statue abilities were just shuffled, not random (Issue #841).
 - Changed map and shard item grants to be only additive, never overwriting what was already in the save. This was a consequence of how I "replayed" certain item grants when a game was opened again (PR #881).
+- Fixed hub-switch first-poll baseline suppression so reconnect/disconnect windows do not drop legitimate big-switch location checks (Issue #879).
 
 ### Internal Changes
 

--- a/worlds/kirbyam/PROTOCOL.md
+++ b/worlds/kirbyam/PROTOCOL.md
@@ -399,6 +399,7 @@ hub_switch_bits = RAM[0x0203B04C] as u32
 hub_switch_baseline = 0
 if first_hub_switch_poll and server_checked_locations is empty and hub_switch_bits != 0:
     # Treat pre-existing transport bits as baseline to avoid stale cross-session resend.
+    # This baseline applies only before *any* server checks are acknowledged.
     hub_switch_baseline = hub_switch_bits
 effective_hub_switch_bits = hub_switch_bits & ~hub_switch_baseline
 for bit in mapped_hub_switch_bits:
@@ -452,7 +453,7 @@ Boss shard scrub timing contract (Issue #505):
 
 **Behavior notes:**
 - Detection is **level-based** (current bitfield state), not edge-based, to be reconnect-safe.
-- Hub-switch polling suppresses only pre-session baseline bits on first poll when no hub-switch checks are yet acknowledged by the server, preventing stale EWRAM bits from being resent as fresh checks.
+- Hub-switch polling suppresses only pre-session baseline bits on first poll when no checks are yet acknowledged by the server, preventing stale EWRAM bits from being resent as fresh checks while preserving reconnect resends.
 - No checks are sent for bits already in `server_checked_locations`.
 - No checks are sent for reserved/unmapped bits even when set.
 - Boss-defeat, major-chest, vitality-chest, sound-player-chest, hub-switch, and room-sanity polling follow the same resend/dedupe diagnostic contract.

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -3012,17 +3012,17 @@ class KirbyAmClient(BizHawkClient):
             self._hub_switch_baseline_mask = None
 
         # Capture baseline only on first hub-switch poll of a session when the server
-        # has not yet acknowledged any hub-switch locations. This suppresses
-        # pre-session stale transport bits without suppressing legitimate reconnect
-        # resends for hub-switch checks that the server already knows about.
-        has_hub_switch_acknowledgements = bool(self._hub_switch_location_ids_all & ctx.checked_locations)
+        # has not acknowledged any checks yet. This suppresses stale cross-session
+        # transport bits on truly fresh sessions without suppressing legitimate
+        # reconnect resends that are missing on the server.
+        has_any_server_acknowledgements = bool(ctx.checked_locations)
         if not self._hub_switch_session_initialized:
             self._hub_switch_session_initialized = True
-            if self._hub_switch_baseline_mask is None and switch_bits != 0 and not has_hub_switch_acknowledgements:
+            if self._hub_switch_baseline_mask is None and switch_bits != 0 and not has_any_server_acknowledgements:
                 self._hub_switch_baseline_mask = switch_bits
                 self._log_verbose(
                     "info",
-                    "KirbyAM: hub-switch baseline initialized from first-poll transport state before any hub-switch server acknowledgements (baseline=0x%08X)",
+                    "KirbyAM: hub-switch baseline initialized from first-poll transport state before any server acknowledgements (baseline=0x%08X)",
                     switch_bits,
                 )
 

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -1382,8 +1382,8 @@ async def test_poll_hub_switch_suppresses_pre_session_stale_bits(mock_bizhawk_co
 
 
 @pytest.mark.asyncio
-async def test_poll_hub_switch_suppresses_pre_session_stale_bits_with_unrelated_server_checks(mock_bizhawk_context):
-    """First-poll stale hub-switch bits should still be baselined when only non-hub checks are acknowledged."""
+async def test_poll_hub_switch_resends_with_unrelated_server_checks(mock_bizhawk_context):
+    """First-poll hub-switch bits should resend when any server checks are already acknowledged."""
     client = KirbyAmClient()
     client.initialize_client()
 
@@ -1392,6 +1392,7 @@ async def test_poll_hub_switch_suppresses_pre_session_stale_bits_with_unrelated_
         for loc in data.locations.values()
         if loc.location_id is not None and loc.category != LocationCategory.HUB_SWITCH
     )
+    peppermint_west = data.locations["HUB_SWITCH_PEPPERMINT_WEST"].location_id
     mock_bizhawk_context.checked_locations = {unrelated_location}
 
     with patch.dict(data.transport_ram_addresses, {"hub_switch_flags": 0x0203B04C}, clear=False), \
@@ -1400,9 +1401,10 @@ async def test_poll_hub_switch_suppresses_pre_session_stale_bits_with_unrelated_
         mock_read.return_value = [((1 << 0)).to_bytes(4, 'little')]
 
         await client._poll_hub_switch_locations(mock_bizhawk_context)
-        await client._poll_hub_switch_locations(mock_bizhawk_context)
 
-    mock_send.assert_not_awaited()
+    mock_send.assert_awaited_once_with([
+        {"cmd": "LocationChecks", "locations": [peppermint_west]}
+    ])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What is this fixing or adding?
This fixes an edge case where hub-switch checks could be suppressed on the first poll if the player already had other acknowledged checks but no acknowledged hub-switch checks yet.

The previous baseline rule treated first-poll hub-switch bits as stale whenever no hub-switch checks were acknowledged. That could hide a legitimate check that happened during a reconnect/disconnect window.

Now, baseline suppression is only applied when there are no server acknowledgements at all (truly fresh session state). If any checks are already acknowledged, hub-switch bits are treated as reconnect-safe and resent until acknowledged.

Closes #879.

## How was this tested?
- Ran targeted pytest coverage for hub-switch polling behavior:
  - python -m pytest worlds/kirbyam/test/test_client.py -k "hub_switch and (sends_location_checks_for_set_bits or suppresses_pre_session_stale_bits or resends_with_unrelated_server_checks or rebaselines_on_stream_marker_change)"
- Updated and passed test expectation for first-poll resend with unrelated acknowledged checks.
- Updated worlds/kirbyam/PROTOCOL.md behavior notes to match implementation.

## If this makes graphical changes, please attach screenshots.
N/A