### PR TITLE
KirbyAM Client: enforce statue gating with legacy slot_data fallback

### DIFF
--- a/worlds/kirbyam/CHANGELOG.md
+++ b/worlds/kirbyam/CHANGELOG.md
@@ -26,6 +26,7 @@ Contract for `## Unreleased` and post-public `## v...` sections going forward:
 
 - Prevent false LocationChecks after death by deferring polling while HP <= 0 (Issue #864).
 - When `ability_randomization_mode` was `completely_random` and `ability_randomization_statues` was enabled, statue abilities were just shuffled, not random (Issue #841).
+- Ability statues now honor ability-gating rules even when slot data falls back to legacy fields without `enemy_copy_ability_policy` (Issue #874).
 - Changed map and shard item grants to be only additive, never overwriting what was already in the save. This was a consequence of how I "replayed" certain item grants when a game was opened again (PR #881).
 - Fixed hub-switch first-poll baseline suppression so reconnect/disconnect windows do not drop legitimate big-switch location checks (Issue #879).
 

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1770,20 +1770,26 @@ class KirbyAmClient(BizHawkClient):
             return
 
         policy = slot_data.get("enemy_copy_ability_policy")
-        if not isinstance(policy, dict):
-            return
-
+        allowed_abilities_raw: object
         try:
-            mode = int(policy.get("mode", 0)) & 0xFFFFFFFF
-            seed = int(policy.get("seed", 0)) & 0xFFFFFFFFFFFFFFFF
-            no_ability_weight = int(policy.get("ability_randomization_no_ability_weight", 0)) & 0xFFFFFFFF
+            if isinstance(policy, dict):
+                mode = int(policy.get("mode", 0)) & 0xFFFFFFFF
+                seed = int(policy.get("seed", 0)) & 0xFFFFFFFFFFFFFFFF
+                no_ability_weight = int(policy.get("ability_randomization_no_ability_weight", 0)) & 0xFFFFFFFF
+                allowed_abilities_raw = policy.get("allowed_abilities", [])
+            else:
+                # Legacy slot_data compatibility: still sync ability gating masks even
+                # when a full enemy_copy_ability_policy payload is unavailable.
+                mode = int(slot_data.get("ability_randomization_mode", 0)) & 0xFFFFFFFF
+                seed = 0
+                no_ability_weight = int(slot_data.get("ability_randomization_no_ability_weight", 0)) & 0xFFFFFFFF
+                allowed_abilities_raw = slot_data.get("enemy_copy_ability_whitelist", [])
         except (TypeError, ValueError):
             return
 
         allowed_mask = 0
-        allowed_abilities = policy.get("allowed_abilities", [])
-        if isinstance(allowed_abilities, list):
-            for ability_name in allowed_abilities:
+        if isinstance(allowed_abilities_raw, (list, tuple, set)):
+            for ability_name in allowed_abilities_raw:
                 if not isinstance(ability_name, str):
                     continue
                 ability_id = ABILITY_NAME_TO_ID.get(ability_name)

--- a/worlds/kirbyam/client.py
+++ b/worlds/kirbyam/client.py
@@ -1778,6 +1778,16 @@ class KirbyAmClient(BizHawkClient):
                 no_ability_weight = int(policy.get("ability_randomization_no_ability_weight", 0)) & 0xFFFFFFFF
                 allowed_abilities_raw = policy.get("allowed_abilities", [])
             else:
+                legacy_config_keys = {
+                    "ability_gating",
+                    "ability_gateable_abilities",
+                    "ability_unlock_items",
+                    "ability_randomization_mode",
+                    "ability_randomization_no_ability_weight",
+                    "enemy_copy_ability_whitelist",
+                }
+                if not any(key in slot_data for key in legacy_config_keys):
+                    return
                 # Legacy slot_data compatibility: still sync ability gating masks even
                 # when a full enemy_copy_ability_policy payload is unavailable.
                 mode = int(slot_data.get("ability_randomization_mode", 0)) & 0xFFFFFFFF

--- a/worlds/kirbyam/test/test_client.py
+++ b/worlds/kirbyam/test/test_client.py
@@ -5696,6 +5696,77 @@ async def test_sync_enemy_copy_ability_runtime_config_rewrites_when_revalidation
     )
 
 
+@pytest.mark.asyncio
+async def test_sync_enemy_copy_ability_runtime_config_legacy_slot_data_still_syncs_gating_masks(mock_bizhawk_context):
+    """Legacy slot_data without enemy_copy_ability_policy must still enforce gating masks."""
+    client = KirbyAmClient()
+    client.initialize_client()
+
+    magic_item_id = next(
+        item_id
+        for item_id, item_data in data.items.items()
+        if item_data.label == "Magic Ability"
+    )
+
+    mode = 0
+    seed_lo = 0
+    seed_hi = 0
+    no_ability_weight = 0
+    allowed_mask = 0
+    ability_gating_enabled = True
+    gated_mask = 0
+    for ability_name in GATEABLE_ENEMY_COPY_ABILITIES:
+        ability_id = ABILITY_NAME_TO_ID.get(ability_name)
+        if ability_id is not None and 0 < ability_id <= 31:
+            gated_mask |= 1 << ability_id
+    magic_ability_id = ABILITY_NAME_TO_ID["Magic"]
+    unlocked_mask = 1 << magic_ability_id
+
+    mock_bizhawk_context.slot_data = {
+        "ability_gating": True,
+        "ability_randomization_mode": mode,
+        "ability_randomization_no_ability_weight": no_ability_weight,
+        "enemy_copy_ability_whitelist": [],
+    }
+    mock_bizhawk_context.items_received = [Mock(item=magic_item_id)]
+
+    with patch('worlds.kirbyam.client.bizhawk.write', new_callable=AsyncMock) as mock_write:
+        await client._sync_enemy_copy_ability_runtime_config(mock_bizhawk_context)
+
+    mode_addr = data.transport_ram_addresses["ability_randomization_mode_runtime"]
+    seed_lo_addr = data.transport_ram_addresses["ability_randomization_seed_lo_runtime"]
+    seed_hi_addr = data.transport_ram_addresses["ability_randomization_seed_hi_runtime"]
+    weight_addr = data.transport_ram_addresses["ability_randomization_no_ability_weight_runtime"]
+    mask_addr = data.transport_ram_addresses["ability_randomization_allowed_mask_runtime"]
+    gate_addr = data.transport_ram_addresses["ability_gate_mask_runtime"]
+    unlock_addr = data.transport_ram_addresses["ability_unlock_mask_runtime"]
+    rng_state_addr = data.transport_ram_addresses["ability_randomization_rng_state_runtime"]
+
+    assert client._last_ability_runtime_config_signature == (
+        mode,
+        seed_lo,
+        seed_hi,
+        no_ability_weight,
+        allowed_mask,
+        ability_gating_enabled,
+        gated_mask,
+        unlocked_mask,
+    )
+    mock_write.assert_awaited_once_with(
+        mock_bizhawk_context.bizhawk_ctx,
+        [
+            (mode_addr, (mode).to_bytes(4, "little"), "System Bus"),
+            (seed_lo_addr, (seed_lo).to_bytes(4, "little"), "System Bus"),
+            (seed_hi_addr, (seed_hi).to_bytes(4, "little"), "System Bus"),
+            (weight_addr, (no_ability_weight).to_bytes(4, "little"), "System Bus"),
+            (mask_addr, (allowed_mask).to_bytes(4, "little"), "System Bus"),
+            (gate_addr, (gated_mask).to_bytes(4, "little"), "System Bus"),
+            (unlock_addr, (unlocked_mask).to_bytes(4, "little"), "System Bus"),
+            (rng_state_addr, (0).to_bytes(4, "little"), "System Bus"),
+        ],
+    )
+
+
 def test_vitality_chest_locations_defined_in_regions():
     """Regression test: all VITALITY_CHEST locations must be registered in their regions.
 


### PR DESCRIPTION
## What is this fixing or adding?

Fixes #874 by ensuring ability-gating masks are still synchronized when slot data does not include nemy_copy_ability_policy.

- KirbyAmClient._sync_enemy_copy_ability_runtime_config now falls back to legacy slot_data keys (bility_randomization_mode, bility_randomization_no_ability_weight, and nemy_copy_ability_whitelist) instead of returning early.
- This guarantees bility_gate_mask_runtime and bility_unlock_mask_runtime are written, so ability statues cannot grant locked gated abilities (for example, Magic) before their AP unlock items are received.
- Added a regression test covering legacy slot_data gating-mask sync and updated changelog notes.

## How was this tested?

- python -m pytest worlds/kirbyam/test/test_client.py -k "sync_enemy_copy_ability_runtime_config"
  - 3 passed, 202 deselected

## If this makes graphical changes, please attach screenshots.

No graphical changes.